### PR TITLE
Run Wails builds on all platforms in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - feature/shared-drives
 
 permissions:
   contents: read
@@ -55,9 +54,19 @@ jobs:
       - name: Run Go vet
         run: go vet ./...
 
-  wails-linux-build:
-    name: Wails Linux build
-    runs-on: ubuntu-22.04
+  wails-build:
+    name: Wails build (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            platform: linux/amd64
+          - os: windows-latest
+            platform: windows/amd64
+          - os: macos-latest
+            platform: darwin/universal
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,6 +85,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
@@ -86,4 +96,5 @@ jobs:
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Build Wails app
-        run: wails build -clean -platform linux/amd64
+        shell: bash
+        run: wails build -clean -platform "${{ matrix.platform }}"


### PR DESCRIPTION
Updates PR CI to validate Wails builds on Linux, Windows, and macOS.\n\nRelease packaging stays in the existing release workflow; this only checks that each platform can build before changes are merged.