### PR TITLE
notification bell + replace alert/status pill with toasts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,7 +131,6 @@
 	                    </div>
 
                     <div class="header-actions">
-                         <div id="status-msg" class="status-badge">Ready</div>
                          <div class="transfer-wrap">
                             <button id="transfer-pill" class="transfer-pill" type="button" aria-haspopup="dialog" aria-expanded="false" style="display: none;"></button>
                             <div id="transfer-sheet" class="transfer-sheet" role="dialog" aria-label="Transfers" style="display: none;">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,16 +131,7 @@
 	                    </div>
 
                     <div class="header-actions">
-                         <div class="transfer-wrap">
-                            <button id="transfer-pill" class="transfer-pill" type="button" aria-haspopup="dialog" aria-expanded="false" style="display: none;"></button>
-                            <div id="transfer-sheet" class="transfer-sheet" role="dialog" aria-label="Transfers" style="display: none;">
-                                <div class="transfer-sheet-header">
-                                    <div class="transfer-sheet-title">Transfers</div>
-                                    <button id="transfer-clear" class="transfer-sheet-clear" type="button" style="display: none;">Clear</button>
-                                </div>
-                                <div id="transfer-upload-list" class="transfer-sheet-list"></div>
-                            </div>
-                        </div>
+                         <button id="notif-bell" class="notif-bell" type="button"></button>
                          
 	                        <button class="icon-btn" onclick="triggerRefresh()" title="Refresh">
 	                            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -149,10 +149,6 @@
                     </div>
                 </header>
 
-                <div id="transfer-progress" class="transfer-progress" role="progressbar" aria-label="Download progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" style="display: none;">
-                    <div id="transfer-progress-fill" class="transfer-progress-fill"></div>
-                </div>
-
                 <div class="drive-breadcrumb">
                     <button id="breadcrumb-back" class="icon-btn back-btn" title="Back" aria-label="Back">
                         <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -29,6 +29,7 @@ import { bindChannelsRenderers, refreshActiveDrive } from './modules/channels.js
 
 // Notifications
 import { setupNotifications } from './modules/notifications.js';
+import { setupNotifBell } from './modules/notif-bell.js';
 
 // Setup window bindings that need to be available globally
 window.refreshFiles = refreshFiles;
@@ -57,7 +58,8 @@ window.onload = async function() {
     console.log("App loaded. Checking Status...");
 
     // Notifications surface — must be set up before any other module that
-    // might emit toasts.
+    // might emit toasts. Bell is the unified history; toasts feed into it.
+    setupNotifBell();
     setupNotifications();
 
     // Setup all modals

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -27,6 +27,9 @@ import { setupLeaveDriveModal } from './modules/modals/leave-drive.js';
 import { setupSidebar, renderSidebar } from './modules/sidebar.js';
 import { bindChannelsRenderers, refreshActiveDrive } from './modules/channels.js';
 
+// Notifications
+import { setupNotifications } from './modules/notifications.js';
+
 // Setup window bindings that need to be available globally
 window.refreshFiles = refreshFiles;
 window.triggerRefresh = function() {
@@ -52,6 +55,10 @@ window.initDelete = function(id, name) {
 // Application initialization
 window.onload = async function() {
     console.log("App loaded. Checking Status...");
+
+    // Notifications surface — must be set up before any other module that
+    // might emit toasts.
+    setupNotifications();
 
     // Setup all modals
     setupDeleteModal();

--- a/frontend/src/modules/auth.js
+++ b/frontend/src/modules/auth.js
@@ -8,6 +8,7 @@ import {
 } from '../../wailsjs/go/main/App';
 import { renderBreadcrumb } from './navigation.js';
 import { loadChannels } from './channels.js';
+import { notify, dismissNotification } from './notifications.js';
 
 export function hideAllScreens() {
     const screens = ["setupcontainer", "phonecontainer", "codecontainer", "passwordcontainer", "success-screen"];
@@ -51,8 +52,13 @@ async function initDriveWithRetry(maxAttempts = 3) {
     let lastError = "Error: Init failed";
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        const status = document.getElementById("status-msg");
-        if (status) status.innerText = `Setting up… (${attempt}/${maxAttempts})`;
+        notify({
+            id: 'init-drive',
+            level: 'info',
+            title: maxAttempts > 1 ? `Setting up your drive… (${attempt}/${maxAttempts})` : 'Setting up your drive…',
+            sticky: true,
+            spinner: true,
+        });
 
         try {
             const initRes = await InitDrive();
@@ -91,15 +97,16 @@ export async function showDashboard() {
     renderBreadcrumb();
 
     const initResult = await initDriveWithRetry(3);
-    const status = document.getElementById("status-msg");
+    dismissNotification('init-drive');
 
     if (!initResult.ok) {
-        if (status) status.innerText = "Init failed";
-        alert(initResult.error || "Failed to initialize your drive. Check logs/console and try again.");
+        notify({
+            level: 'error',
+            title: 'Could not initialize your drive',
+            body: initResult.error || 'Check logs/console and try again.',
+        });
         return;
     }
-
-    if (status) status.innerText = "Ready";
 
     // Load drive list (personal + any joined shared) before the first
     // refresh, so the sidebar populates and folder-control gating runs
@@ -146,7 +153,11 @@ export async function checkStatusAndShowScreen() {
 
     } catch (err) {
         console.error("Startup Crash:", err);
-        alert("Startup Error: " + err + "\n\nDid you restart 'wails dev'?");
+        notify({
+            level: 'error',
+            title: 'Startup error',
+            body: String(err) + " — did you restart `wails dev`?",
+        });
     }
 }
 
@@ -155,17 +166,23 @@ export function setupAuthWindowBindings() {
     window.submitSetup = function() {
         const id = parseInt(document.getElementById("api_id").value);
         const hash = document.getElementById("api_hash").value;
-        if (!id || !hash) return alert("Enter both fields.");
+        if (!id || !hash) {
+            notify({ level: 'warning', title: 'Enter both API ID and hash' });
+            return;
+        }
 
         SaveSetup(id, hash).then(res => {
-            if(res === "Success") location.reload();
-            else alert(res);
+            if (res === "Success") location.reload();
+            else notify({ level: 'error', title: 'Setup failed', body: String(res) });
         });
     };
 
     window.startLogin = function () {
         const phone = (document.getElementById("enterphone").value || "").trim();
-        if(!phone) return alert("Enter phone number");
+        if (!phone) {
+            notify({ level: 'warning', title: 'Enter your phone number' });
+            return;
+        }
 
         state.lastLoginPhoneNumber = phone;
 

--- a/frontend/src/modules/drag-drop.js
+++ b/frontend/src/modules/drag-drop.js
@@ -2,6 +2,7 @@
 
 import { state } from '../state.js';
 import { MoveFile, MoveFolder, MsgToTdriveSystem } from '../../wailsjs/go/main/App';
+import { notify } from './notifications.js';
 
 export function clearDropHighlights() {
     if (state.dragOverEl) {
@@ -80,7 +81,11 @@ export async function performDropMove(newParentId) {
         }
 
         if (typeof res === "string" && res.startsWith("Error")) {
-            alert(res);
+            notify({
+                level: 'error',
+                title: 'Move failed',
+                body: res.replace(/^Error:?\s*/i, ''),
+            });
         } else {
             window.refreshFiles();
         }

--- a/frontend/src/modules/modals/delete.js
+++ b/frontend/src/modules/modals/delete.js
@@ -7,6 +7,33 @@ import { ensureNotInsideDeletedFolder } from '../navigation.js';
 import { deleteFolder } from '../file-list.js';
 import { notify, dismissNotification } from '../notifications.js';
 
+// Build the success-toast title for a bulk delete. Names the item when
+// possible — "Deleted N files" / "Deleted folder X" — instead of the
+// generic "Item deleted" that hides what was acted on.
+function bulkSuccessTitle(items) {
+    if (!Array.isArray(items) || items.length === 0) return 'Items deleted';
+    const folders = items.filter((i) => i?.type === 'folder');
+    const files = items.filter((i) => i?.type === 'file');
+
+    if (items.length === 1) {
+        const single = items[0];
+        const name = String(single?.name || '').trim();
+        if (name) {
+            return single?.type === 'folder'
+                ? `Deleted folder "${name}"`
+                : `Deleted "${name}"`;
+        }
+        return single?.type === 'folder' ? 'Folder deleted' : 'File deleted';
+    }
+    if (folders.length === items.length) {
+        return `Deleted ${folders.length} folders`;
+    }
+    if (files.length === items.length) {
+        return `Deleted ${files.length} files`;
+    }
+    return `Deleted ${items.length} items (${files.length} file${files.length === 1 ? '' : 's'}, ${folders.length} folder${folders.length === 1 ? '' : 's'})`;
+}
+
 export function openDeleteModal(target) {
     const modal = document.getElementById("delete-modal");
     const title = document.getElementById("delete-modal-title");
@@ -134,7 +161,7 @@ export function setupDeleteModal() {
                 if (failures.length === 0) {
                     notify({
                         level: 'success',
-                        title: items.length === 1 ? 'Item deleted' : `Deleted ${items.length} items`,
+                        title: bulkSuccessTitle(items),
                     });
                 } else {
                     notify({
@@ -152,10 +179,13 @@ export function setupDeleteModal() {
                     : await DeleteFile(Number(target.id));
 
                 dismissNotification(progressId);
+                const name = String(target.name || '').trim();
                 if (typeof res === "string" && res.startsWith("Error")) {
                     notify({
                         level: 'error',
-                        title: target.type === 'folder' ? 'Could not delete folder' : 'Could not delete file',
+                        title: name
+                            ? `Could not delete ${target.type === 'folder' ? 'folder ' : ''}"${name}"`
+                            : (target.type === 'folder' ? 'Could not delete folder' : 'Could not delete file'),
                         body: res.replace(/^Error:?\s*/i, ''),
                     });
                     return;
@@ -163,8 +193,9 @@ export function setupDeleteModal() {
                 if (target.type === "folder") ensureNotInsideDeletedFolder(String(target.id));
                 notify({
                     level: 'success',
-                    title: target.type === 'folder' ? 'Folder deleted' : 'File deleted',
-                    body: target.name ? String(target.name) : '',
+                    title: name
+                        ? `Deleted ${target.type === 'folder' ? 'folder ' : ''}"${name}"`
+                        : (target.type === 'folder' ? 'Folder deleted' : 'File deleted'),
                 });
                 window.refreshFiles();
             }

--- a/frontend/src/modules/modals/delete.js
+++ b/frontend/src/modules/modals/delete.js
@@ -5,6 +5,7 @@ import { DeleteFile } from '../../../wailsjs/go/main/App';
 import { clearSelection } from '../selection.js';
 import { ensureNotInsideDeletedFolder } from '../navigation.js';
 import { deleteFolder } from '../file-list.js';
+import { notify, dismissNotification } from '../notifications.js';
 
 export function openDeleteModal(target) {
     const modal = document.getElementById("delete-modal");
@@ -82,14 +83,19 @@ export function setupDeleteModal() {
         close();
         if (!target) return;
 
-        const status = document.getElementById("status-msg");
-        if (status) status.innerText = "Deleting...";
+        const progressId = notify({
+            id: 'deleting',
+            level: 'info',
+            title: 'Deleting…',
+            sticky: true,
+            spinner: true,
+        });
 
         try {
             if (target.type === "bulk") {
                 const items = Array.isArray(target.items) ? target.items : [];
                 if (items.length === 0) {
-                    if (status) status.innerText = "Ready";
+                    dismissNotification(progressId);
                     return;
                 }
                 const folders = items.filter((i) => i?.type === "folder");
@@ -123,11 +129,21 @@ export function setupDeleteModal() {
                 }
 
                 clearSelection();
-                if (failures.length) {
-                    if (status) status.innerText = "Delete failed";
-                    alert(`Some items were not deleted:\n\n${failures.slice(0, 5).join("\n")}${failures.length > 5 ? "\n..." : ""}`);
-                } else if (status) {
-                    status.innerText = "Done";
+                dismissNotification(progressId);
+                const successCount = items.length - failures.length;
+                if (failures.length === 0) {
+                    notify({
+                        level: 'success',
+                        title: items.length === 1 ? 'Item deleted' : `Deleted ${items.length} items`,
+                    });
+                } else {
+                    notify({
+                        level: 'error',
+                        title: successCount > 0
+                            ? `Deleted ${successCount} of ${items.length} items`
+                            : 'Could not delete items',
+                        body: failures.slice(0, 5).join('\n') + (failures.length > 5 ? '\n…' : ''),
+                    });
                 }
                 window.refreshFiles();
             } else {
@@ -135,23 +151,34 @@ export function setupDeleteModal() {
                     ? await deleteFolder(String(target.id))
                     : await DeleteFile(Number(target.id));
 
+                dismissNotification(progressId);
                 if (typeof res === "string" && res.startsWith("Error")) {
-                    if (status) status.innerText = "Delete failed";
-                    alert(res);
+                    notify({
+                        level: 'error',
+                        title: target.type === 'folder' ? 'Could not delete folder' : 'Could not delete file',
+                        body: res.replace(/^Error:?\s*/i, ''),
+                    });
                     return;
                 }
                 if (target.type === "folder") ensureNotInsideDeletedFolder(String(target.id));
-                if (status) status.innerText = res || "Done";
+                notify({
+                    level: 'success',
+                    title: target.type === 'folder' ? 'Folder deleted' : 'File deleted',
+                    body: target.name ? String(target.name) : '',
+                });
                 window.refreshFiles();
             }
         } catch (err) {
             console.error("Delete failed:", err);
-            if (status) status.innerText = "Delete failed";
-            alert("Delete failed. Check console/logs.");
+            dismissNotification(progressId);
+            notify({
+                level: 'error',
+                title: 'Delete failed',
+                body: 'Check the console for details.',
+            });
         } finally {
-            setTimeout(() => {
-                if (status) status.innerText = "Ready";
-            }, 2000);
+            // No-op trailer; the legacy 2-second status reset is gone with
+            // the status pill.
         }
     });
 }

--- a/frontend/src/modules/modals/delete.js
+++ b/frontend/src/modules/modals/delete.js
@@ -7,31 +7,16 @@ import { ensureNotInsideDeletedFolder } from '../navigation.js';
 import { deleteFolder } from '../file-list.js';
 import { notify, dismissNotification } from '../notifications.js';
 
-// Build the success-toast title for a bulk delete. Names the item when
-// possible — "Deleted N files" / "Deleted folder X" — instead of the
-// generic "Item deleted" that hides what was acted on.
-function bulkSuccessTitle(items) {
-    if (!Array.isArray(items) || items.length === 0) return 'Items deleted';
-    const folders = items.filter((i) => i?.type === 'folder');
-    const files = items.filter((i) => i?.type === 'file');
+function successTitle(item) {
+    const name = String(item?.name || '').trim();
+    if (!name) return item?.type === 'folder' ? 'Folder deleted' : 'File deleted';
+    return item?.type === 'folder' ? `Deleted folder "${name}"` : `Deleted "${name}"`;
+}
 
-    if (items.length === 1) {
-        const single = items[0];
-        const name = String(single?.name || '').trim();
-        if (name) {
-            return single?.type === 'folder'
-                ? `Deleted folder "${name}"`
-                : `Deleted "${name}"`;
-        }
-        return single?.type === 'folder' ? 'Folder deleted' : 'File deleted';
-    }
-    if (folders.length === items.length) {
-        return `Deleted ${folders.length} folders`;
-    }
-    if (files.length === items.length) {
-        return `Deleted ${files.length} files`;
-    }
-    return `Deleted ${items.length} items (${files.length} file${files.length === 1 ? '' : 's'}, ${folders.length} folder${folders.length === 1 ? '' : 's'})`;
+function failureTitle(item) {
+    const name = String(item?.name || '').trim();
+    if (!name) return item?.type === 'folder' ? 'Could not delete folder' : 'Could not delete file';
+    return item?.type === 'folder' ? `Could not delete folder "${name}"` : `Could not delete "${name}"`;
 }
 
 export function openDeleteModal(target) {
@@ -127,19 +112,21 @@ export function setupDeleteModal() {
                 }
                 const folders = items.filter((i) => i?.type === "folder");
                 const files = items.filter((i) => i?.type === "file");
+                const succeeded = [];
                 const failures = [];
 
                 for (const folder of folders) {
                     try {
                         const res = await deleteFolder(String(folder.id));
                         if (typeof res === "string" && res.startsWith("Error")) {
-                            failures.push(`${folder.name || folder.id}: ${res}`);
+                            failures.push({ item: folder, error: res.replace(/^Error:?\s*/i, '') });
                             continue;
                         }
                         ensureNotInsideDeletedFolder(String(folder.id));
+                        succeeded.push(folder);
                     } catch (err) {
                         console.error("Delete folder failed:", folder, err);
-                        failures.push(`${folder.name || folder.id}: ${err?.message || String(err)}`);
+                        failures.push({ item: folder, error: err?.message || String(err) });
                     }
                 }
 
@@ -147,29 +134,29 @@ export function setupDeleteModal() {
                     try {
                         const res = await DeleteFile(Number(file.id));
                         if (typeof res === "string" && res.startsWith("Error")) {
-                            failures.push(`${file.name || file.id}: ${res}`);
+                            failures.push({ item: file, error: res.replace(/^Error:?\s*/i, '') });
+                            continue;
                         }
+                        succeeded.push(file);
                     } catch (err) {
                         console.error("Delete file failed:", file, err);
-                        failures.push(`${file.name || file.id}: ${err?.message || String(err)}`);
+                        failures.push({ item: file, error: err?.message || String(err) });
                     }
                 }
 
                 clearSelection();
                 dismissNotification(progressId);
-                const successCount = items.length - failures.length;
-                if (failures.length === 0) {
+                for (const item of succeeded) {
                     notify({
                         level: 'success',
-                        title: bulkSuccessTitle(items),
+                        title: successTitle(item),
                     });
-                } else {
+                }
+                for (const { item, error } of failures) {
                     notify({
                         level: 'error',
-                        title: successCount > 0
-                            ? `Deleted ${successCount} of ${items.length} items`
-                            : 'Could not delete items',
-                        body: failures.slice(0, 5).join('\n') + (failures.length > 5 ? '\n…' : ''),
+                        title: failureTitle(item),
+                        body: error,
                     });
                 }
                 window.refreshFiles();
@@ -179,13 +166,10 @@ export function setupDeleteModal() {
                     : await DeleteFile(Number(target.id));
 
                 dismissNotification(progressId);
-                const name = String(target.name || '').trim();
                 if (typeof res === "string" && res.startsWith("Error")) {
                     notify({
                         level: 'error',
-                        title: name
-                            ? `Could not delete ${target.type === 'folder' ? 'folder ' : ''}"${name}"`
-                            : (target.type === 'folder' ? 'Could not delete folder' : 'Could not delete file'),
+                        title: failureTitle(target),
                         body: res.replace(/^Error:?\s*/i, ''),
                     });
                     return;
@@ -193,9 +177,7 @@ export function setupDeleteModal() {
                 if (target.type === "folder") ensureNotInsideDeletedFolder(String(target.id));
                 notify({
                     level: 'success',
-                    title: name
-                        ? `Deleted ${target.type === 'folder' ? 'folder ' : ''}"${name}"`
-                        : (target.type === 'folder' ? 'Folder deleted' : 'File deleted'),
+                    title: successTitle(target),
                 });
                 window.refreshFiles();
             }

--- a/frontend/src/modules/modals/folder.js
+++ b/frontend/src/modules/modals/folder.js
@@ -2,6 +2,7 @@
 
 import { state } from '../../state.js';
 import { createFolder } from '../file-list.js';
+import { notify, dismissNotification } from '../notifications.js';
 
 export function setupFolderModal() {
     const modal = document.getElementById("folder-modal");
@@ -31,7 +32,6 @@ export function setupFolderModal() {
         const name = (nameInput.value || "").trim();
         if (!name) return;
 
-        const status = document.getElementById("status-msg");
         const parentId = state.currentFolderId;
         const tempId = `pending:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
 
@@ -40,17 +40,22 @@ export function setupFolderModal() {
         inFlight = true;
         createBtn.disabled = true;
         cancelBtn.disabled = true;
-        if (status) status.innerText = "Creating folder...";
 
         // Render immediately so the new row appears under the cursor
         // before the Telegram round-trip completes.
         window.refreshFiles();
 
+        let failed = false;
         try {
             await createFolder(name, parentId);
             close();
         } catch (err) {
-            alert("Failed to create folder: " + err);
+            failed = true;
+            notify({
+                level: 'error',
+                title: 'Could not create folder',
+                body: String(err),
+            });
         } finally {
             // Drop the pending overlay regardless of outcome. The follow-up
             // refreshFiles either shows the new real row (success) or
@@ -59,8 +64,10 @@ export function setupFolderModal() {
             inFlight = false;
             createBtn.disabled = false;
             cancelBtn.disabled = false;
-            if (status) status.innerText = "Ready";
             window.refreshFiles();
+            if (!failed) {
+                notify({ level: 'success', title: `Folder "${name}" created` });
+            }
         }
     };
 

--- a/frontend/src/modules/modals/join-drive.js
+++ b/frontend/src/modules/modals/join-drive.js
@@ -1,6 +1,7 @@
 // "Join shared drive" modal.
 
 import { joinSharedDrive } from '../channels.js';
+import { notify, dismissNotification } from '../notifications.js';
 
 export function setupJoinDriveModal() {
     const modal = document.getElementById('join-drive-modal');
@@ -20,17 +21,33 @@ export function setupJoinDriveModal() {
     const submit = async () => {
         const link = String(input.value || '').trim();
         if (!link) return;
-        const status = document.getElementById('status-msg');
-        if (status) status.innerText = 'Joining drive...';
+        const progressId = notify({
+            id: 'joining-drive',
+            level: 'info',
+            title: 'Joining drive…',
+            body: 'If the drive has lots of history, this can take a few seconds.',
+            sticky: true,
+            spinner: true,
+        });
         go.disabled = true;
         try {
-            await joinSharedDrive(link);
+            const info = await joinSharedDrive(link);
             close();
+            dismissNotification(progressId);
+            notify({
+                level: 'success',
+                title: 'Joined drive',
+                body: info?.title ? String(info.title) : '',
+            });
         } catch (err) {
-            alert('Failed to join drive: ' + err);
+            dismissNotification(progressId);
+            notify({
+                level: 'error',
+                title: 'Could not join drive',
+                body: String(err),
+            });
         } finally {
             go.disabled = false;
-            if (status) status.innerText = 'Ready';
         }
     };
 

--- a/frontend/src/modules/modals/leave-drive.js
+++ b/frontend/src/modules/modals/leave-drive.js
@@ -1,6 +1,7 @@
 // "Leave drive" confirm modal.
 
 import { leaveSharedDrive } from '../channels.js';
+import { notify, dismissNotification } from '../notifications.js';
 
 let pendingTarget = null;
 
@@ -21,17 +22,33 @@ export function setupLeaveDriveModal() {
 
     confirm.addEventListener('click', async () => {
         if (!pendingTarget) { close(); return; }
-        const status = document.getElementById('status-msg');
-        if (status) status.innerText = 'Leaving drive...';
+        const progressId = notify({
+            id: 'leaving-drive',
+            level: 'info',
+            title: 'Leaving drive…',
+            sticky: true,
+            spinner: true,
+        });
         confirm.disabled = true;
         try {
-            await leaveSharedDrive(pendingTarget.id);
+            const target = pendingTarget;
+            await leaveSharedDrive(target.id);
             close();
+            dismissNotification(progressId);
+            notify({
+                level: 'success',
+                title: 'Left drive',
+                body: target.title ? String(target.title) : '',
+            });
         } catch (err) {
-            alert('Failed to leave drive: ' + err);
+            dismissNotification(progressId);
+            notify({
+                level: 'error',
+                title: 'Could not leave drive',
+                body: String(err),
+            });
         } finally {
             confirm.disabled = false;
-            if (status) status.innerText = 'Ready';
         }
     });
 

--- a/frontend/src/modules/modals/new-drive.js
+++ b/frontend/src/modules/modals/new-drive.js
@@ -2,6 +2,7 @@
 
 import { createSharedDrive } from '../channels.js';
 import { openShareDriveModal } from './share-drive.js';
+import { notify, dismissNotification } from '../notifications.js';
 
 export function setupNewDriveModal() {
     const modal = document.getElementById('new-drive-modal');
@@ -21,20 +22,31 @@ export function setupNewDriveModal() {
     const submit = async () => {
         const title = String(input.value || '').trim();
         if (!title) return;
-        const status = document.getElementById('status-msg');
-        if (status) status.innerText = 'Creating drive...';
+        const progressId = notify({
+            id: 'creating-drive',
+            level: 'info',
+            title: 'Creating drive…',
+            sticky: true,
+            spinner: true,
+        });
         create.disabled = true;
         try {
             const info = await createSharedDrive(title);
             close();
+            dismissNotification(progressId);
+            notify({ level: 'success', title: `Drive "${title}" created` });
             if (info?.invite_link) {
                 openShareDriveModal(String(info.invite_link));
             }
         } catch (err) {
-            alert('Failed to create drive: ' + err);
+            dismissNotification(progressId);
+            notify({
+                level: 'error',
+                title: 'Could not create drive',
+                body: String(err),
+            });
         } finally {
             create.disabled = false;
-            if (status) status.innerText = 'Ready';
         }
     };
 

--- a/frontend/src/modules/modals/preview.js
+++ b/frontend/src/modules/modals/preview.js
@@ -1,5 +1,6 @@
 import { PreviewFile, PreviewThumbnail } from '../../../wailsjs/go/main/App';
 import { state } from '../../state.js';
+import { notify } from '../notifications.js';
 
 const SUPPORTED_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg"]);
 const PREVIEW_CHROME_HIDE_DELAY_MS = 1600;
@@ -28,7 +29,6 @@ let previewReady = false;
 let previewRequestToken = 0;
 let activePreviewKey = "";
 let activePreviewMsgID = 0;
-let statusResetTimer = null;
 let chromeHideTimer = null;
 
 function isSpaceKey(event) {
@@ -51,19 +51,9 @@ function isBlockingOverlayOpen() {
     return Boolean(contextMenu && contextMenu.style.display !== "none");
 }
 
-function flashStatus(message, delay = 2200) {
-    const statusEl = document.getElementById("status-msg");
-    if (!statusEl || !message) return;
-
-    const previous = statusEl.textContent || "Ready";
-    statusEl.textContent = message;
-
-    if (statusResetTimer) clearTimeout(statusResetTimer);
-    statusResetTimer = setTimeout(() => {
-        if (statusEl.textContent === message) {
-            statusEl.textContent = previous === message ? "Ready" : previous;
-        }
-    }, delay);
+function flashStatus(message) {
+    if (!message) return;
+    notify({ level: 'info', title: message, durationMs: 2400 });
 }
 
 function getPreviewKey(item) {

--- a/frontend/src/modules/notif-bell.js
+++ b/frontend/src/modules/notif-bell.js
@@ -106,9 +106,10 @@ export function pushHistoryEvent({ level = 'info', title = '', body = '', ts } =
 }
 
 // pushTransferStart begins tracking an upload or download. id should be
-// unique per transfer (msg_id, upload id, etc.).
+// unique per transfer (msg_id, upload id, etc.). id=0 is valid — upload
+// IDs are zero-based, so don't reject falsy.
 export function pushTransferStart({ id, direction, name, total = 0 }) {
-    if (!id || !direction) return;
+    if (id == null || !direction) return;
     const key = `xfer:${direction}:${id}`;
     // De-dup: if an entry with this key already exists, replace it.
     removeFromHistory(key);
@@ -142,6 +143,9 @@ export function markTransferDone({ id, direction, status = 'done' }) {
     const key = `xfer:${direction}:${id}`;
     const entry = state.historyEvents.find((e) => e.id === key);
     if (!entry) return;
+    // Idempotent: don't downgrade or rewrite an already-terminal entry
+    // (e.g. a safety sweep firing 'done' on an entry that already failed).
+    if (entry.status !== 'active') return;
     entry.status = status;
     entry.progress = status === 'done' ? 100 : entry.progress;
     entry.finishedAt = Date.now();

--- a/frontend/src/modules/notif-bell.js
+++ b/frontend/src/modules/notif-bell.js
@@ -1,0 +1,439 @@
+// Notification bell — the single unified feedback surface in the top-right
+// header. Three layers of detail:
+//
+//   • Idle bell — quiet, dim. Nothing happening.
+//   • Hover popover — only when transfers are active. Mini progress list.
+//   • Click panel — full history. Active transfers + Recent (notifications
+//     and completed transfers, merged chronologically).
+//
+// History lives in state.historyEvents (capped at 100, ephemeral). Modules
+// elsewhere call `pushHistoryEvent(...)` and `pushTransferStart()` /
+// `updateTransferProgress()` / `markTransferDone()` to feed the bell.
+
+import { state } from '../state.js';
+
+const HISTORY_CAP = 100;
+const HOVER_GRACE_MS = 280;
+
+let bellEl = null;
+let popoverEl = null;
+let panelEl = null;
+let hoverGraceTimer = null;
+let pulseTickerHandle = null;
+
+// ─── ICON LIBRARY ────────────────────────────────────────────────────────────
+
+const ICONS = {
+    bell: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 1112 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 003.4 0"/></svg>',
+    upload: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg>',
+    download: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12l7 7 7-7"/></svg>',
+    success: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>',
+    error:   '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
+    info:    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
+    warning: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
+    cancel:  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="8" y1="12" x2="16" y2="12"/></svg>',
+};
+
+// ─── PUBLIC API ──────────────────────────────────────────────────────────────
+
+export function setupNotifBell() {
+    bellEl = document.getElementById('notif-bell');
+    if (!bellEl) return;
+
+    bellEl.innerHTML = `<span class="notif-bell-icon" aria-hidden="true">${ICONS.bell}</span><span class="notif-bell-dot" data-mode="idle" aria-hidden="true"></span>`;
+    bellEl.setAttribute('aria-haspopup', 'dialog');
+    bellEl.setAttribute('aria-expanded', 'false');
+    bellEl.setAttribute('aria-label', 'Notifications');
+
+    bellEl.addEventListener('click', (e) => {
+        e.stopPropagation();
+        togglePanel();
+    });
+    bellEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            togglePanel();
+        }
+    });
+
+    bellEl.addEventListener('mouseenter', () => {
+        if (state.notifPanelOpen) return;
+        clearTimeout(hoverGraceTimer);
+        if (hasActiveTransfers()) openHoverPopover();
+    });
+    bellEl.addEventListener('mouseleave', () => {
+        clearTimeout(hoverGraceTimer);
+        hoverGraceTimer = setTimeout(() => {
+            if (popoverEl && !popoverEl.matches(':hover')) closeHoverPopover();
+        }, HOVER_GRACE_MS);
+    });
+
+    // Outside-click and Esc close the panel.
+    document.addEventListener('mousedown', (e) => {
+        if (!state.notifPanelOpen) return;
+        if (panelEl && (panelEl.contains(e.target) || bellEl.contains(e.target))) return;
+        closePanel();
+    });
+    window.addEventListener('keydown', (e) => {
+        if (e.key !== 'Escape') return;
+        if (state.notifPanelOpen) closePanel();
+        else if (state.notifHoverOpen) closeHoverPopover();
+    });
+
+    renderBell();
+    startPulseTicker();
+}
+
+// pushHistoryEvent enqueues a non-transfer event (folder created, drive
+// joined, error, etc.). Returns the event id so callers can dedupe by
+// reusing the same id, though that's rarely needed.
+export function pushHistoryEvent({ level = 'info', title = '', body = '', ts } = {}) {
+    const id = `evt:${Date.now()}:${Math.random().toString(36).slice(2, 7)}`;
+    state.historyEvents.unshift({
+        kind: 'event',
+        id,
+        level,
+        title: String(title || ''),
+        body: String(body || ''),
+        ts: ts || Date.now(),
+    });
+    if (level === 'error' && !state.notifPanelOpen) {
+        state.notifUnreadErrors += 1;
+    }
+    capHistory();
+    renderAll();
+    return id;
+}
+
+// pushTransferStart begins tracking an upload or download. id should be
+// unique per transfer (msg_id, upload id, etc.).
+export function pushTransferStart({ id, direction, name, total = 0 }) {
+    if (!id || !direction) return;
+    const key = `xfer:${direction}:${id}`;
+    // De-dup: if an entry with this key already exists, replace it.
+    removeFromHistory(key);
+    state.historyEvents.unshift({
+        kind: 'transfer',
+        id: key,
+        direction,
+        name: String(name || ''),
+        progress: 0,
+        total: Number(total) || 0,
+        status: 'active',
+        startedAt: Date.now(),
+        finishedAt: 0,
+    });
+    capHistory();
+    renderAll();
+    return key;
+}
+
+export function updateTransferProgress({ id, direction, progress }) {
+    const key = `xfer:${direction}:${id}`;
+    const entry = state.historyEvents.find((e) => e.id === key);
+    if (!entry || entry.status !== 'active') return;
+    const value = Math.max(0, Math.min(100, Number(progress) || 0));
+    if (Math.round(entry.progress) === Math.round(value)) return; // skip noise
+    entry.progress = value;
+    renderAll();
+}
+
+export function markTransferDone({ id, direction, status = 'done' }) {
+    const key = `xfer:${direction}:${id}`;
+    const entry = state.historyEvents.find((e) => e.id === key);
+    if (!entry) return;
+    entry.status = status;
+    entry.progress = status === 'done' ? 100 : entry.progress;
+    entry.finishedAt = Date.now();
+    if (status === 'failed' && !state.notifPanelOpen) {
+        state.notifUnreadErrors += 1;
+    }
+    renderAll();
+}
+
+export function clearHistory() {
+    // Keep active transfers. Drop everything else.
+    state.historyEvents = state.historyEvents.filter(
+        (e) => e.kind === 'transfer' && e.status === 'active'
+    );
+    state.notifUnreadErrors = 0;
+    renderAll();
+}
+
+// ─── INTERNAL: STATE ─────────────────────────────────────────────────────────
+
+function capHistory() {
+    if (state.historyEvents.length <= HISTORY_CAP) return;
+    state.historyEvents = state.historyEvents.slice(0, HISTORY_CAP);
+}
+
+function removeFromHistory(id) {
+    const idx = state.historyEvents.findIndex((e) => e.id === id);
+    if (idx >= 0) state.historyEvents.splice(idx, 1);
+}
+
+function hasActiveTransfers() {
+    return state.historyEvents.some((e) => e.kind === 'transfer' && e.status === 'active');
+}
+
+// ─── INTERNAL: RENDER ────────────────────────────────────────────────────────
+
+function renderAll() {
+    renderBell();
+    if (state.notifHoverOpen) renderHoverPopover();
+    if (state.notifPanelOpen) renderPanel();
+}
+
+function renderBell() {
+    if (!bellEl) return;
+    const dot = bellEl.querySelector('.notif-bell-dot');
+    if (!dot) return;
+    let mode = 'idle';
+    if (state.notifUnreadErrors > 0) mode = 'error';
+    else if (hasActiveTransfers()) mode = 'active';
+    dot.dataset.mode = mode;
+    bellEl.dataset.mode = mode;
+}
+
+function startPulseTicker() {
+    // Keep the bell rerendered while transfers are active so the
+    // pulsing dot's CSS animation begins/ends as state changes.
+    if (pulseTickerHandle) return;
+    const tick = () => {
+        renderBell();
+        pulseTickerHandle = requestAnimationFrame(tick);
+    };
+    pulseTickerHandle = requestAnimationFrame(tick);
+}
+
+// ─── HOVER POPOVER ───────────────────────────────────────────────────────────
+
+function openHoverPopover() {
+    if (state.notifPanelOpen) return;
+    if (!hasActiveTransfers()) return;
+    state.notifHoverOpen = true;
+    if (!popoverEl) {
+        popoverEl = document.createElement('div');
+        popoverEl.className = 'notif-popover';
+        popoverEl.setAttribute('role', 'dialog');
+        popoverEl.setAttribute('aria-label', 'Active transfers');
+        popoverEl.addEventListener('mouseenter', () => clearTimeout(hoverGraceTimer));
+        popoverEl.addEventListener('mouseleave', () => {
+            clearTimeout(hoverGraceTimer);
+            hoverGraceTimer = setTimeout(closeHoverPopover, HOVER_GRACE_MS);
+        });
+        popoverEl.addEventListener('click', (e) => {
+            // Click into the popover → upgrade to full panel.
+            e.stopPropagation();
+            closeHoverPopover();
+            openPanel();
+        });
+        document.body.appendChild(popoverEl);
+    }
+    positionAnchored(popoverEl);
+    renderHoverPopover();
+}
+
+function closeHoverPopover() {
+    state.notifHoverOpen = false;
+    if (!popoverEl) return;
+    popoverEl.classList.add('notif-leaving');
+    const node = popoverEl;
+    popoverEl = null;
+    setTimeout(() => node.remove(), 160);
+}
+
+function renderHoverPopover() {
+    if (!popoverEl) return;
+    const active = state.historyEvents.filter(
+        (e) => e.kind === 'transfer' && e.status === 'active'
+    );
+    if (active.length === 0) {
+        closeHoverPopover();
+        return;
+    }
+    popoverEl.innerHTML = `
+        <div class="notif-popover-list">
+            ${active.slice(0, 4).map(transferRowHTML).join('')}
+        </div>
+        ${active.length > 4 ? `<div class="notif-popover-more">+ ${active.length - 4} more</div>` : ''}
+    `;
+}
+
+// ─── FULL PANEL ──────────────────────────────────────────────────────────────
+
+function togglePanel() {
+    if (state.notifPanelOpen) closePanel();
+    else openPanel();
+}
+
+function openPanel() {
+    closeHoverPopover();
+    state.notifPanelOpen = true;
+    state.notifUnreadErrors = 0; // opening clears the unread badge
+    if (!panelEl) {
+        panelEl = document.createElement('div');
+        panelEl.className = 'notif-panel';
+        panelEl.setAttribute('role', 'dialog');
+        panelEl.setAttribute('aria-modal', 'false');
+        panelEl.setAttribute('aria-label', 'Notifications');
+        panelEl.addEventListener('click', (e) => e.stopPropagation());
+        document.body.appendChild(panelEl);
+    }
+    positionAnchored(panelEl);
+    renderPanel();
+    bellEl?.setAttribute('aria-expanded', 'true');
+    renderBell();
+}
+
+function closePanel() {
+    state.notifPanelOpen = false;
+    bellEl?.setAttribute('aria-expanded', 'false');
+    if (!panelEl) return;
+    panelEl.classList.add('notif-leaving');
+    const node = panelEl;
+    panelEl = null;
+    setTimeout(() => node.remove(), 160);
+    renderBell();
+}
+
+function renderPanel() {
+    if (!panelEl) return;
+    const active = state.historyEvents.filter(
+        (e) => e.kind === 'transfer' && e.status === 'active'
+    );
+    const recent = state.historyEvents.filter(
+        (e) => !(e.kind === 'transfer' && e.status === 'active')
+    );
+
+    panelEl.innerHTML = `
+        <div class="notif-panel-header">
+            <div class="notif-panel-title">Notifications</div>
+            <button class="notif-panel-clear" type="button" ${recent.length === 0 ? 'disabled' : ''}>Clear</button>
+        </div>
+        <div class="notif-panel-body">
+            ${active.length > 0 ? `
+                <div class="notif-section-label">Active</div>
+                <div class="notif-section">
+                    ${active.map(transferRowHTML).join('')}
+                </div>
+            ` : ''}
+            ${recent.length > 0 ? `
+                <div class="notif-section-label" style="margin-top:${active.length > 0 ? '14px' : '0'}">Recent</div>
+                <div class="notif-section">
+                    ${recent.slice(0, 50).map(eventRowHTML).join('')}
+                </div>
+            ` : (active.length === 0 ? `
+                <div class="notif-empty">
+                    <div class="notif-empty-glyph">${ICONS.bell}</div>
+                    <div class="notif-empty-title">All caught up</div>
+                    <div class="notif-empty-body">Folder activity, uploads, and shared-drive events will show up here.</div>
+                </div>
+            ` : '')}
+        </div>
+    `;
+    const clearBtn = panelEl.querySelector('.notif-panel-clear');
+    if (clearBtn) clearBtn.addEventListener('click', clearHistory);
+
+    // Click an error row to copy its body to clipboard.
+    panelEl.querySelectorAll('.notif-row[data-clipable="1"]').forEach((row) => {
+        row.addEventListener('click', async () => {
+            const text = row.dataset.copyText || '';
+            if (!text) return;
+            try { await navigator.clipboard.writeText(text); } catch {}
+            row.classList.add('notif-copied');
+            setTimeout(() => row.classList.remove('notif-copied'), 800);
+        });
+    });
+}
+
+// ─── ROW TEMPLATES ───────────────────────────────────────────────────────────
+
+function transferRowHTML(t) {
+    const direction = t.direction === 'up' ? 'upload' : 'download';
+    const dirLabel = t.direction === 'up' ? 'Uploading' : 'Downloading';
+    const statusClass =
+        t.status === 'done' ? 'is-done' :
+        t.status === 'failed' ? 'is-failed' :
+        t.status === 'canceled' ? 'is-canceled' :
+        'is-active';
+    const meta =
+        t.status === 'done' ? 'Done' :
+        t.status === 'failed' ? 'Failed' :
+        t.status === 'canceled' ? 'Canceled' :
+        `${Math.round(t.progress || 0)}%`;
+    return `
+        <div class="notif-row notif-row-transfer ${statusClass}">
+            <span class="notif-row-icon" data-kind="${direction}" aria-hidden="true">${ICONS[direction]}</span>
+            <div class="notif-row-body">
+                <div class="notif-row-title" title="${escapeHTML(t.name)}">${escapeHTML(t.name || dirLabel)}</div>
+                <div class="notif-row-progress">
+                    <div class="notif-row-progress-fill" style="width:${Math.max(0, Math.min(100, t.progress || 0))}%"></div>
+                </div>
+            </div>
+            <div class="notif-row-meta">${escapeHTML(meta)}</div>
+        </div>
+    `;
+}
+
+function eventRowHTML(e) {
+    if (e.kind === 'transfer') {
+        // Completed/failed transfer in Recent — render compactly.
+        return transferRowHTML(e);
+    }
+    const level = e.level || 'info';
+    const icon = ICONS[level] || ICONS.info;
+    const clipable = level === 'error' && e.body ? '1' : '0';
+    const copyText = clipable === '1' ? `${e.title}\n${e.body}` : '';
+    return `
+        <div class="notif-row notif-row-event level-${level}"
+             data-clipable="${clipable}" data-copy-text="${escapeHTML(copyText)}">
+            <span class="notif-row-icon" data-kind="${level}" aria-hidden="true">${icon}</span>
+            <div class="notif-row-body">
+                <div class="notif-row-title">${escapeHTML(e.title)}</div>
+                ${e.body ? `<div class="notif-row-sub">${escapeHTML(e.body)}</div>` : ''}
+            </div>
+            <div class="notif-row-meta">${escapeHTML(formatRelative(e.ts))}</div>
+        </div>
+    `;
+}
+
+// ─── POSITIONING ─────────────────────────────────────────────────────────────
+
+function positionAnchored(node) {
+    if (!bellEl || !node) return;
+    const rect = bellEl.getBoundingClientRect();
+    const right = Math.max(12, window.innerWidth - rect.right);
+    const top = rect.bottom + 10;
+    node.style.right = `${right}px`;
+    node.style.top = `${top}px`;
+}
+
+// ─── UTILS ───────────────────────────────────────────────────────────────────
+
+function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    })[c]);
+}
+
+function formatRelative(ts) {
+    const t = Number(ts);
+    if (!t) return '';
+    const diffSec = Math.floor((Date.now() - t) / 1000);
+    if (diffSec < 30) return 'just now';
+    if (diffSec < 60) return `${diffSec}s ago`;
+    const m = Math.floor(diffSec / 60);
+    if (m < 60) return `${m} min ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h} hr ago`;
+    const d = Math.floor(h / 24);
+    if (d < 7) return `${d}d ago`;
+    return new Date(t).toLocaleDateString();
+}
+
+// Reposition open surfaces on viewport resize.
+window.addEventListener('resize', () => {
+    if (popoverEl) positionAnchored(popoverEl);
+    if (panelEl) positionAnchored(panelEl);
+});

--- a/frontend/src/modules/notifications.js
+++ b/frontend/src/modules/notifications.js
@@ -18,6 +18,7 @@
 //   notify({ level: 'error', title: 'Could not join drive', body: String(err) });
 
 import { state } from '../state.js';
+import { pushHistoryEvent } from './notif-bell.js';
 
 const MAX_VISIBLE = 5;
 const DEFAULT_DURATION = 4000;
@@ -77,6 +78,19 @@ export function notify(opts = {}) {
         paused: false,
         spinner: opts.spinner === true,
     };
+
+    // Mirror non-spinner / non-progress toasts into the bell history. We
+    // skip in-progress sticky toasts (spinners) because their final
+    // success/failure version replaces them; the panel doesn't need both.
+    const isProgress = entry.spinner === true;
+    if (!isProgress && entry.title) {
+        pushHistoryEvent({
+            level: entry.level,
+            title: entry.title,
+            body: entry.body,
+            ts: now,
+        });
+    }
 
     const idx = state.toasts.findIndex((t) => t.id === id);
     if (idx >= 0) {

--- a/frontend/src/modules/notifications.js
+++ b/frontend/src/modules/notifications.js
@@ -1,0 +1,239 @@
+// Toast notification system. Single global stack rendered in the
+// bottom-right corner. Replaces every alert() and the #status-msg pill.
+//
+// Usage:
+//   import { notify, dismissNotification } from './notifications.js';
+//
+//   // Transient info / success (auto-dismiss after ~4s):
+//   notify({ level: 'success', title: 'Folder created' });
+//
+//   // Sticky in-progress with id, then replace on resolve:
+//   notify({ id: 'creating', level: 'info', title: 'Creating folder…',
+//            sticky: true });
+//   await thing();
+//   dismissNotification('creating');
+//   notify({ level: 'success', title: 'Folder created' });
+//
+//   // Errors are sticky by default; user dismisses or clicks to copy.
+//   notify({ level: 'error', title: 'Could not join drive', body: String(err) });
+
+import { state } from '../state.js';
+
+const MAX_VISIBLE = 5;
+const DEFAULT_DURATION = 4000;
+const ICONS = {
+    info: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
+    success: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>',
+    warning: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
+    error: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
+    spinner: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" class="toast-spinner"><circle cx="12" cy="12" r="9" stroke-opacity="0.25"/><path d="M12 3 a9 9 0 0 1 9 9"/></svg>',
+};
+
+let stackEl = null;
+let timer = null;
+
+export function setupNotifications() {
+    if (stackEl) return;
+    stackEl = document.createElement('div');
+    stackEl.id = 'toast-stack';
+    stackEl.className = 'toast-stack';
+    stackEl.setAttribute('role', 'status');
+    stackEl.setAttribute('aria-live', 'polite');
+    document.body.appendChild(stackEl);
+
+    // Pause auto-dismiss while the stack is hovered (per-toast pausing
+    // happens via the data attribute too; this is the broad gesture).
+    stackEl.addEventListener('mouseenter', () => setAllPaused(true));
+    stackEl.addEventListener('mouseleave', () => setAllPaused(false));
+
+    // Esc clears the most recent error toast (sticky errors otherwise
+    // require a manual click).
+    window.addEventListener('keydown', (e) => {
+        if (e.key !== 'Escape') return;
+        const lastError = [...state.toasts].reverse().find((t) => t.level === 'error');
+        if (lastError) dismissNotification(lastError.id);
+    });
+
+    requestAnimationFrame(tick);
+}
+
+// notify enqueues a toast. Returns its id; pass the same id back via
+// `notify({ id })` to replace an existing entry in place (used for
+// long-running operations).
+export function notify(opts = {}) {
+    const level = ['info', 'success', 'warning', 'error'].includes(opts.level) ? opts.level : 'info';
+    const id = opts.id || `t${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+    const sticky = opts.sticky === true || level === 'error' || opts.durationMs === 0;
+    const duration = sticky ? 0 : (Number.isFinite(opts.durationMs) ? opts.durationMs : DEFAULT_DURATION);
+    const now = Date.now();
+    const entry = {
+        id,
+        level,
+        title: String(opts.title || ''),
+        body: opts.body ? String(opts.body) : '',
+        sticky,
+        durationMs: duration,
+        expiresAt: duration > 0 ? now + duration : 0,
+        paused: false,
+        spinner: opts.spinner === true,
+    };
+
+    const idx = state.toasts.findIndex((t) => t.id === id);
+    if (idx >= 0) {
+        // Preserve element identity if the level is unchanged, so the
+        // replacement morphs in place instead of slide-in/slide-out.
+        const existing = state.toasts[idx];
+        const morph = existing.level === level;
+        state.toasts[idx] = entry;
+        renderStack({ keepNode: morph ? id : null });
+    } else {
+        // Cap the visible queue; if exceeded, the oldest non-sticky entry
+        // is dismissed early so urgent ones aren't drowned.
+        if (state.toasts.length >= MAX_VISIBLE) {
+            const stalest = state.toasts.findIndex((t) => !t.sticky);
+            if (stalest >= 0) state.toasts.splice(stalest, 1);
+            else state.toasts.shift();
+        }
+        state.toasts.push(entry);
+        renderStack();
+    }
+    return id;
+}
+
+export function dismissNotification(id) {
+    const idx = state.toasts.findIndex((t) => t.id === id);
+    if (idx < 0) return;
+    state.toasts.splice(idx, 1);
+    renderStack();
+}
+
+export function clearAllNotifications() {
+    state.toasts = [];
+    renderStack();
+}
+
+function setAllPaused(paused) {
+    if (!state.toasts.length) return;
+    const now = Date.now();
+    for (const t of state.toasts) {
+        if (t.sticky) continue;
+        if (paused && !t.paused) {
+            t.paused = true;
+            t.remainingMs = Math.max(0, (t.expiresAt || now) - now);
+        } else if (!paused && t.paused) {
+            t.paused = false;
+            t.expiresAt = now + (t.remainingMs || 0);
+        }
+    }
+}
+
+function tick() {
+    const now = Date.now();
+    let changed = false;
+    for (let i = state.toasts.length - 1; i >= 0; i--) {
+        const t = state.toasts[i];
+        if (t.sticky || t.paused) continue;
+        if (t.expiresAt && now >= t.expiresAt) {
+            state.toasts.splice(i, 1);
+            changed = true;
+        }
+    }
+    if (changed) renderStack();
+    timer = requestAnimationFrame(tick);
+}
+
+function renderStack({ keepNode = null } = {}) {
+    if (!stackEl) return;
+
+    // Build a quick map of existing nodes by id so we can preserve
+    // identity for entries that didn't change (avoids reflow / animation
+    // restart on every render).
+    const existing = new Map();
+    for (const node of stackEl.querySelectorAll('.toast')) {
+        existing.set(node.dataset.id, node);
+    }
+
+    const fragment = document.createDocumentFragment();
+    for (const t of state.toasts) {
+        let node = existing.get(t.id);
+        if (node && (t.id !== keepNode)) {
+            // Re-attach existing node if the underlying entry hasn't
+            // structurally changed. We always rebuild content for safety
+            // (cheap and keeps title/body in sync if a notify() call
+            // updated them).
+        }
+        if (!node) {
+            node = buildToastNode(t);
+        } else {
+            updateToastNode(node, t);
+        }
+        existing.delete(t.id);
+        fragment.appendChild(node);
+    }
+
+    // Animate-out any nodes whose entries were removed.
+    for (const stale of existing.values()) {
+        stale.classList.add('toast-leaving');
+        // After the CSS transition (~180ms) drop it from the DOM.
+        stale.addEventListener('transitionend', () => stale.remove(), { once: true });
+        // Safety net in case transitionend doesn't fire.
+        setTimeout(() => { if (stale.isConnected) stale.remove(); }, 240);
+    }
+
+    stackEl.appendChild(fragment);
+}
+
+function buildToastNode(t) {
+    const node = document.createElement('div');
+    node.className = `toast toast-${t.level}`;
+    node.dataset.id = t.id;
+    node.setAttribute('role', t.level === 'error' ? 'alert' : 'status');
+    node.setAttribute('tabindex', '0');
+
+    node.addEventListener('mouseenter', () => { t.paused = true; });
+    node.addEventListener('mouseleave', () => {
+        if (!t.sticky && t.paused) {
+            t.paused = false;
+            // resume from where we paused — use the remaining time stored
+            // on entry; fall back to a fresh timeout if absent.
+            const remaining = t.remainingMs || t.durationMs || DEFAULT_DURATION;
+            t.expiresAt = Date.now() + remaining;
+        }
+    });
+
+    updateToastNode(node, t);
+    return node;
+}
+
+function updateToastNode(node, t) {
+    const iconKey = t.spinner ? 'spinner' : t.level;
+    node.innerHTML = `
+        <span class="toast-icon" aria-hidden="true">${ICONS[iconKey] || ICONS.info}</span>
+        <div class="toast-content">
+            <div class="toast-title">${escapeHTML(t.title)}</div>
+            ${t.body ? `<div class="toast-body">${escapeHTML(t.body)}</div>` : ''}
+        </div>
+        <button class="toast-close" type="button" aria-label="Dismiss">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+    `;
+    const closeBtn = node.querySelector('.toast-close');
+    if (closeBtn) {
+        closeBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            dismissNotification(t.id);
+        });
+    }
+    // Click body to dismiss errors (lets users clear them quickly without
+    // hunting for the X).
+    node.addEventListener('click', (e) => {
+        if (e.target.closest('.toast-close')) return;
+        if (t.level === 'error') dismissNotification(t.id);
+    });
+}
+
+function escapeHTML(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+    })[c]);
+}

--- a/frontend/src/modules/sidebar.js
+++ b/frontend/src/modules/sidebar.js
@@ -7,6 +7,7 @@ import { openShareDriveModal } from './modals/share-drive.js';
 import { openLeaveDriveModal } from './modals/leave-drive.js';
 import { openNewDriveModal } from './modals/new-drive.js';
 import { openJoinDriveModal } from './modals/join-drive.js';
+import { notify } from './notifications.js';
 
 let personalEl = null;
 let sharedEl = null;
@@ -111,7 +112,11 @@ function showSharedContextMenu(event, c) {
             const link = await getInviteLink(Number(c.id));
             openShareDriveModal(link);
         } catch (err) {
-            alert('Failed to get invite link: ' + err);
+            notify({
+                level: 'error',
+                title: 'Could not get invite link',
+                body: String(err),
+            });
         }
     });
     addItem('Leave drive', () => {

--- a/frontend/src/modules/transfers.js
+++ b/frontend/src/modules/transfers.js
@@ -302,5 +302,14 @@ export async function uploadWithParentID(parentID) {
         console.error("Upload failed:", err);
     } finally {
         if (state.activeTransfer === "upload") state.activeTransfer = null;
+        // Safety sweep: by the time UploadToDriveFS resolves, every upload
+        // in the batch has terminated on the backend. If a Wails event was
+        // dropped, an entry may still be stuck in 'active' at 100% in the
+        // bell. markTransferDone is idempotent against terminal entries,
+        // so this only flips orphaned 'active' rows.
+        for (const [uploadId] of state.uploadTransfers) {
+            markTransferDone({ id: uploadId, direction: 'up', status: 'done' });
+        }
+        state.uploadBatch = null;
     }
 }

--- a/frontend/src/modules/transfers.js
+++ b/frontend/src/modules/transfers.js
@@ -1,9 +1,18 @@
-// Upload/Download progress handling for TDrive frontend
+// Upload/Download progress handling for TDrive frontend.
+//
+// All transfer state surfaces through the notification bell — there is no
+// separate transfer pill or sheet anymore. Active transfers feed the bell's
+// hover popover via pushTransferStart/updateTransferProgress/markTransferDone.
+// Completed transfers stay in the bell's "Recent" panel until cleared.
 
 import { state } from '../state.js';
-import { escapeHtml } from '../utils.js';
 import { SelectFiles, DownloadFile } from '../../wailsjs/go/main/App';
 import { notify } from './notifications.js';
+import {
+    pushTransferStart,
+    updateTransferProgress,
+    markTransferDone,
+} from './notif-bell.js';
 
 const DOWNLOAD_TERMINAL_STATES = new Set(["done", "failed", "canceled"]);
 
@@ -24,19 +33,6 @@ function normalizeDownloadResult(result) {
     };
 }
 
-function getDownloadSummaryLabel(counts) {
-    if (counts.failed > 0 && counts.canceled > 0) {
-        return `Downloads finished (${counts.failed} failed, ${counts.canceled} canceled)`;
-    }
-    if (counts.failed > 0) {
-        return `Downloads finished (${counts.failed} failed)`;
-    }
-    if (counts.canceled > 0) {
-        return `Downloads finished (${counts.canceled} canceled)`;
-    }
-    return "Downloads finished";
-}
-
 export function showDownloadProgress(percent) {
     const value = Number(percent);
     if (!Number.isFinite(value)) return;
@@ -51,8 +47,7 @@ export function showDownloadProgress(percent) {
     if (!isDownloadTerminalState(item.state)) {
         item.state = "downloading";
     }
-    renderDownloadItem(item);
-    updateTransferPill();
+    updateTransferProgress({ id: item.id, direction: 'down', progress: clamped });
 
     if (state.downloadProgressHideTimeout) {
         clearTimeout(state.downloadProgressHideTimeout);
@@ -60,7 +55,10 @@ export function showDownloadProgress(percent) {
     }
 
     if (state.downloadProgressEl && state.downloadProgressFillEl) {
-        state.downloadProgressEl.style.display = "none";
+        // The thin overlay bar at the top of the file list stays as a
+        // secondary signal during active downloads. Bell handles the
+        // primary surface.
+        state.downloadProgressEl.style.display = "block";
         state.downloadProgressEl.setAttribute("aria-valuenow", String(Math.round(clamped)));
         state.downloadProgressFillEl.style.width = `${clamped}%`;
     }
@@ -94,195 +92,6 @@ export function setupDownloadProgress() {
     });
 }
 
-function getDownloadCounts() {
-    const items = Array.isArray(state.downloadQueue) ? state.downloadQueue : [];
-    let total = items.length;
-    let done = 0;
-    let failed = 0;
-    let canceled = 0;
-    let queued = 0;
-    let downloading = 0;
-
-    items.forEach((item) => {
-        const status = String(item?.state || "queued");
-        if (status === "done") done += 1;
-        else if (status === "failed") failed += 1;
-        else if (status === "canceled") canceled += 1;
-        else if (status === "downloading") downloading += 1;
-        else queued += 1;
-    });
-
-    return { total, done, failed, canceled, queued, downloading };
-}
-
-function getUploadCounts() {
-    const items = state.uploadTransfers instanceof Map ? Array.from(state.uploadTransfers.values()) : [];
-    let total = items.length;
-    let done = 0;
-    let failed = 0;
-    let queued = 0;
-    let uploading = 0;
-
-    items.forEach((item) => {
-        const status = String(item?.state || "queued");
-        if (status === "done") done += 1;
-        else if (status === "failed") failed += 1;
-        else if (status === "uploading") uploading += 1;
-        else queued += 1;
-    });
-
-    return { total, done, failed, queued, uploading };
-}
-
-function reconcileUploadBatch() {
-    const counts = getUploadCounts();
-    const settled = counts.done + counts.failed;
-    const hasInFlightUploads = counts.uploading > 0 || counts.queued > 0;
-
-    if (state.uploadBatch && !hasInFlightUploads && counts.total > 0 && settled >= counts.total) {
-        state.uploadBatch = null;
-    }
-
-    return counts;
-}
-
-export function updateTransferPill() {
-    if (!state.transferPillEl) return;
-    const uploadCounts = reconcileUploadBatch();
-    const hasUploads = uploadCounts.total > 0;
-    const hasBatch = Boolean(state.uploadBatch);
-    const hasActiveUploads = uploadCounts.uploading > 0 || uploadCounts.queued > 0;
-    const downloadCounts = getDownloadCounts();
-    const hasDownloads = downloadCounts.total > 0;
-
-    const hasAnyTransfers = hasUploads || hasBatch || hasDownloads;
-
-    if (!hasAnyTransfers) {
-        state.transferPillEl.style.display = "none";
-        return;
-    }
-
-    state.transferPillEl.style.display = "inline-flex";
-    state.transferPillEl.classList.toggle("is-active", hasActiveUploads || downloadCounts.downloading > 0);
-
-    const uploadFailed = uploadCounts.failed;
-    const downloadFailed = downloadCounts.failed;
-    const hasFailures = uploadFailed > 0 || downloadFailed > 0;
-    state.transferPillEl.classList.toggle("is-error", hasFailures);
-
-    let label = "";
-    const uploadLabel = hasUploads
-        ? (hasActiveUploads ? `Uploading ${uploadCounts.done}/${uploadCounts.total}` : uploadFailed > 0 ? `Uploads finished (${uploadFailed} failed)` : "Uploads finished")
-        : "";
-
-    let downloadLabel = "";
-    if (hasDownloads) {
-        if (downloadCounts.downloading > 0) {
-            const current = Math.min(downloadCounts.done + downloadCounts.failed + downloadCounts.canceled + 1, downloadCounts.total);
-            downloadLabel = `Downloading ${current}/${downloadCounts.total}`;
-        } else if (downloadCounts.queued > 0) {
-            downloadLabel = `Downloads queued (${downloadCounts.queued})`;
-        } else {
-            downloadLabel = getDownloadSummaryLabel(downloadCounts);
-        }
-    }
-
-    if (uploadLabel && downloadLabel) label = `${uploadLabel} · ${downloadLabel}`;
-    else label = uploadLabel || downloadLabel || "";
-
-    const uploadsDone = !hasUploads || !hasActiveUploads;
-    const downloadsDone = !hasDownloads || downloadCounts.downloading === 0 && downloadCounts.queued === 0;
-    const allDone = uploadsDone && downloadsDone;
-    state.transferPillEl.classList.toggle("is-idle", allDone && !hasFailures);
-    state.transferPillEl.title = label;
-    state.transferPillEl.innerHTML = `<span class="transfer-pill-dot" aria-hidden="true"></span><span class="transfer-pill-label">${escapeHtml(label)}</span>`;
-
-    if (state.transferClearEl) state.transferClearEl.style.display = allDone ? "inline-flex" : "none";
-}
-
-export function renderTransferItem(uploadId) {
-    if (!state.transferUploadListEl) return;
-    const item = state.uploadTransfers.get(uploadId);
-    if (!item) return;
-
-    let el = state.transferUploadListEl.querySelector(`.transfer-item[data-type="upload"][data-id="${uploadId}"]`);
-    if (!el) {
-        el = document.createElement("div");
-        el.className = "transfer-item";
-        el.dataset.type = "upload";
-        el.dataset.id = String(uploadId);
-        el.innerHTML = `
-            <div class="transfer-item-fill"></div>
-            <div class="transfer-item-content">
-                <div class="transfer-item-name"></div>
-                <div class="transfer-item-meta"></div>
-            </div>
-        `;
-        state.transferUploadListEl.appendChild(el);
-    }
-
-    const fill = el.querySelector(".transfer-item-fill");
-    const nameEl = el.querySelector(".transfer-item-name");
-    const metaEl = el.querySelector(".transfer-item-meta");
-
-    const progress = Math.max(0, Math.min(100, Number(item.progress) || 0));
-    if (fill) fill.style.width = `${progress}%`;
-    if (nameEl) nameEl.textContent = item.name || "Untitled";
-
-    let meta = `${Math.round(progress)}%`;
-    if (item.state === "queued") meta = "Queued";
-    if (item.state === "done") meta = "Done";
-    if (item.state === "failed") meta = "Failed";
-    if (metaEl) metaEl.textContent = meta;
-
-    el.classList.toggle("is-done", item.state === "done");
-    el.classList.toggle("is-failed", item.state === "failed");
-    el.classList.toggle("is-queued", item.state === "queued");
-}
-
-export function renderDownloadItem(item) {
-    if (!state.transferUploadListEl || !item) return;
-    const list = state.transferUploadListEl;
-    const id = Number(item.id);
-    const selector = `.transfer-item[data-type="download"][data-id="${id}"]`;
-
-    let el = list.querySelector(selector);
-    if (!el) {
-        el = document.createElement("div");
-        el.className = "transfer-item";
-        el.dataset.type = "download";
-        el.dataset.id = String(id);
-        el.innerHTML = `
-            <div class="transfer-item-fill"></div>
-            <div class="transfer-item-content">
-                <div class="transfer-item-name"></div>
-                <div class="transfer-item-meta"></div>
-            </div>
-        `;
-        list.prepend(el);
-    }
-
-    const fill = el.querySelector(".transfer-item-fill");
-    const nameEl = el.querySelector(".transfer-item-name");
-    const metaEl = el.querySelector(".transfer-item-meta");
-
-    const progress = Math.max(0, Math.min(100, Number(item.progress) || 0));
-    if (fill) fill.style.width = `${progress}%`;
-    if (nameEl) nameEl.textContent = item.name || "Download";
-
-    let meta = `${Math.round(progress)}%`;
-    if (item.state === "queued") meta = "Queued";
-    if (item.state === "done") meta = "Done";
-    if (item.state === "failed") meta = "Failed";
-    if (item.state === "canceled") meta = "Canceled";
-    if ((item.state === "failed" || item.state === "canceled") && item.message) meta = item.message;
-    if (metaEl) metaEl.textContent = meta;
-
-    el.classList.toggle("is-done", item.state === "done");
-    el.classList.toggle("is-failed", item.state === "failed");
-    el.classList.toggle("is-queued", item.state === "queued");
-}
-
 async function startNextDownload() {
     if (state.activeDownloadId !== null && state.activeDownloadId !== undefined) return;
     const queue = Array.isArray(state.downloadQueue) ? state.downloadQueue : [];
@@ -292,8 +101,7 @@ async function startNextDownload() {
     state.activeDownloadId = next.id;
     next.state = "downloading";
     next.progress = Math.max(0, Math.min(100, Number(next.progress) || 0));
-    renderDownloadItem(next);
-    updateTransferPill();
+    pushTransferStart({ id: next.id, direction: 'down', name: next.name, total: next.size });
 
     try {
         const result = normalizeDownloadResult(await DownloadFile(Number(next.id), Number(next.id)));
@@ -302,22 +110,21 @@ async function startNextDownload() {
         if (result.status === "success") {
             next.state = "done";
             next.progress = 100;
-            notify({ level: 'success', title: 'Download finished', body: String(next.name || '') });
+            markTransferDone({ id: next.id, direction: 'down', status: 'done' });
         } else if (result.status === "canceled") {
             next.state = "canceled";
+            markTransferDone({ id: next.id, direction: 'down', status: 'canceled' });
         } else {
             next.state = "failed";
-            notify({ level: 'error', title: 'Download failed', body: result.message || String(next.name || '') });
+            markTransferDone({ id: next.id, direction: 'down', status: 'failed' });
         }
     } catch (err) {
         console.error("Download failed:", err);
         next.message = "Download failed";
         next.state = "failed";
-        notify({ level: 'error', title: 'Download failed', body: String(next.name || '') });
+        markTransferDone({ id: next.id, direction: 'down', status: 'failed' });
     } finally {
         state.activeDownloadId = null;
-        renderDownloadItem(next);
-        updateTransferPill();
         hideDownloadProgress();
         startNextDownload();
     }
@@ -336,8 +143,6 @@ export function enqueueDownload(id, name, size) {
         existing.progress = 0;
         existing.state = "queued";
         existing.message = "";
-        renderDownloadItem(existing);
-        updateTransferPill();
         if (state.activeDownloadId === null || state.activeDownloadId === undefined) startNextDownload();
         return;
     }
@@ -352,59 +157,11 @@ export function enqueueDownload(id, name, size) {
     };
 
     state.downloadQueue.push(item);
-    renderDownloadItem(item);
-    updateTransferPill();
     if (state.activeDownloadId === null || state.activeDownloadId === undefined) startNextDownload();
 }
 
 export function setupUploadProgress() {
     if (!window.runtime?.EventsOn) return;
-
-    state.transferPillEl = document.getElementById("transfer-pill");
-    state.transferSheetEl = document.getElementById("transfer-sheet");
-    state.transferUploadListEl = document.getElementById("transfer-upload-list");
-    state.transferClearEl = document.getElementById("transfer-clear");
-
-    if (state.transferPillEl) {
-        state.transferPillEl.addEventListener("click", () => {
-            if (!state.transferSheetEl) return;
-            const hasUploads = state.uploadTransfers && state.uploadTransfers.size > 0;
-            const hasBatch = Boolean(state.uploadBatch);
-            const hasDownloads = Array.isArray(state.downloadQueue) && state.downloadQueue.length > 0;
-            if (!hasUploads && !hasBatch && !hasDownloads) return;
-            const isOpen = state.transferSheetEl.style.display !== "none";
-            state.transferSheetEl.style.display = isOpen ? "none" : "block";
-            state.transferPillEl.setAttribute("aria-expanded", isOpen ? "false" : "true");
-        });
-    }
-
-    document.addEventListener("click", (e) => {
-        if (!state.transferSheetEl || state.transferSheetEl.style.display === "none") return;
-        if (state.transferPillEl && state.transferPillEl.contains(e.target)) return;
-        if (state.transferSheetEl.contains(e.target)) return;
-        state.transferSheetEl.style.display = "none";
-        if (state.transferPillEl) state.transferPillEl.setAttribute("aria-expanded", "false");
-    });
-
-    document.addEventListener("keydown", (e) => {
-        if (e.key !== "Escape") return;
-        if (!state.transferSheetEl || state.transferSheetEl.style.display === "none") return;
-        state.transferSheetEl.style.display = "none";
-        if (state.transferPillEl) state.transferPillEl.setAttribute("aria-expanded", "false");
-    });
-
-    if (state.transferClearEl) {
-        state.transferClearEl.addEventListener("click", () => {
-            state.uploadTransfers = new Map();
-            state.uploadBatch = null;
-            state.downloadQueue = [];
-            state.activeDownloadId = null;
-            if (state.transferUploadListEl) state.transferUploadListEl.innerHTML = "";
-            updateTransferPill();
-            if (state.transferSheetEl) state.transferSheetEl.style.display = "none";
-            if (state.transferPillEl) state.transferPillEl.setAttribute("aria-expanded", "false");
-        });
-    }
 
     window.runtime.EventsOn("upload_start", (id, name, size, parentId) => {
         const uploadId = Number(id);
@@ -429,8 +186,7 @@ export function setupUploadProgress() {
             });
         }
 
-        renderTransferItem(uploadId);
-        updateTransferPill();
+        pushTransferStart({ id: uploadId, direction: 'up', name: filename, total: Number(size) || 0 });
     });
 
     window.runtime.EventsOn("upload_progress", (id, percent) => {
@@ -443,7 +199,7 @@ export function setupUploadProgress() {
         const item = state.uploadTransfers.get(uploadId);
         if (!item) return;
         item.progress = clamped;
-        renderTransferItem(uploadId);
+        updateTransferProgress({ id: uploadId, direction: 'up', progress: clamped });
     });
 
     window.runtime.EventsOn("upload_complete", (id, name) => {
@@ -466,27 +222,11 @@ export function setupUploadProgress() {
 
         if (state.uploadBatch) state.uploadBatch.done += 1;
         const batchFinished = Boolean(state.uploadBatch && state.uploadBatch.done + state.uploadBatch.failed >= state.uploadBatch.total);
-        const batchSummary = batchFinished ? state.uploadBatch : null;
         if (batchFinished) state.uploadBatch = null;
-        renderTransferItem(uploadId);
-        updateTransferPill();
+
+        markTransferDone({ id: uploadId, direction: 'up', status: 'done' });
 
         if (batchFinished) {
-            // Single success toast for the whole batch.
-            if (batchSummary && batchSummary.total > 0) {
-                if (batchSummary.failed === 0) {
-                    notify({
-                        level: 'success',
-                        title: batchSummary.total === 1 ? 'Upload complete' : `Uploaded ${batchSummary.total} files`,
-                    });
-                } else if (batchSummary.done > 0) {
-                    notify({
-                        level: 'warning',
-                        title: `Uploaded ${batchSummary.done} of ${batchSummary.total} files`,
-                        body: `${batchSummary.failed} failed.`,
-                    });
-                }
-            }
             window.refreshFiles();
         }
     });
@@ -510,32 +250,14 @@ export function setupUploadProgress() {
 
         if (state.uploadBatch) state.uploadBatch.failed += 1;
         const batchFinished = Boolean(state.uploadBatch && state.uploadBatch.done + state.uploadBatch.failed >= state.uploadBatch.total);
-        const batchSummary = batchFinished ? state.uploadBatch : null;
         if (batchFinished) state.uploadBatch = null;
-        renderTransferItem(uploadId);
-        updateTransferPill();
+
+        markTransferDone({ id: uploadId, direction: 'up', status: 'failed' });
 
         if (batchFinished) {
-            if (batchSummary && batchSummary.failed > 0) {
-                if (batchSummary.done === 0) {
-                    notify({
-                        level: 'error',
-                        title: batchSummary.total === 1 ? 'Upload failed' : `Failed to upload ${batchSummary.failed} files`,
-                        body: filename || undefined,
-                    });
-                } else {
-                    notify({
-                        level: 'warning',
-                        title: `Uploaded ${batchSummary.done} of ${batchSummary.total} files`,
-                        body: `${batchSummary.failed} failed.`,
-                    });
-                }
-            }
             window.refreshFiles();
         }
     });
-
-    updateTransferPill();
 }
 
 export async function uploadWithParentID(parentID) {
@@ -559,21 +281,12 @@ export async function uploadWithParentID(parentID) {
         });
     }
     state.uploadTransfers = nextTransfers;
-    if (state.transferUploadListEl) {
-        state.transferUploadListEl.querySelectorAll('.transfer-item[data-type="upload"]').forEach((el) => el.remove());
-    }
-    for (let i = 0; i < paths.length; i++) renderTransferItem(i);
-    updateTransferPill();
 
     const upload = window?.go?.main?.App?.UploadToDriveFS;
     if (typeof upload !== "function") {
         state.activeTransfer = null;
         state.uploadBatch = null;
         state.uploadTransfers = new Map();
-        if (state.transferUploadListEl) {
-            state.transferUploadListEl.querySelectorAll('.transfer-item[data-type="upload"]').forEach((el) => el.remove());
-        }
-        updateTransferPill();
         notify({
             level: 'error',
             title: 'Upload bindings missing',
@@ -589,7 +302,5 @@ export async function uploadWithParentID(parentID) {
         console.error("Upload failed:", err);
     } finally {
         if (state.activeTransfer === "upload") state.activeTransfer = null;
-        reconcileUploadBatch();
-        updateTransferPill();
     }
 }

--- a/frontend/src/modules/transfers.js
+++ b/frontend/src/modules/transfers.js
@@ -3,6 +3,7 @@
 import { state } from '../state.js';
 import { escapeHtml } from '../utils.js';
 import { SelectFiles, DownloadFile } from '../../wailsjs/go/main/App';
+import { notify } from './notifications.js';
 
 const DOWNLOAD_TERMINAL_STATES = new Set(["done", "failed", "canceled"]);
 
@@ -90,9 +91,6 @@ export function setupDownloadProgress() {
 
         const clamped = Math.max(0, Math.min(100, value));
         showDownloadProgress(clamped);
-
-        const status = document.getElementById("status-msg");
-        if (status) status.innerText = `Downloading… ${Math.round(clamped)}%`;
     });
 }
 
@@ -297,9 +295,6 @@ async function startNextDownload() {
     renderDownloadItem(next);
     updateTransferPill();
 
-    const status = document.getElementById("status-msg");
-    if (status) status.innerText = "Downloading…";
-
     try {
         const result = normalizeDownloadResult(await DownloadFile(Number(next.id), Number(next.id)));
         next.message = result.message;
@@ -307,21 +302,23 @@ async function startNextDownload() {
         if (result.status === "success") {
             next.state = "done";
             next.progress = 100;
+            notify({ level: 'success', title: 'Download finished', body: String(next.name || '') });
         } else if (result.status === "canceled") {
             next.state = "canceled";
         } else {
             next.state = "failed";
+            notify({ level: 'error', title: 'Download failed', body: result.message || String(next.name || '') });
         }
     } catch (err) {
         console.error("Download failed:", err);
         next.message = "Download failed";
         next.state = "failed";
+        notify({ level: 'error', title: 'Download failed', body: String(next.name || '') });
     } finally {
         state.activeDownloadId = null;
         renderDownloadItem(next);
         updateTransferPill();
         hideDownloadProgress();
-        if (status) status.innerText = "Ready";
         startNextDownload();
     }
 }
@@ -469,11 +466,27 @@ export function setupUploadProgress() {
 
         if (state.uploadBatch) state.uploadBatch.done += 1;
         const batchFinished = Boolean(state.uploadBatch && state.uploadBatch.done + state.uploadBatch.failed >= state.uploadBatch.total);
+        const batchSummary = batchFinished ? state.uploadBatch : null;
         if (batchFinished) state.uploadBatch = null;
         renderTransferItem(uploadId);
         updateTransferPill();
 
         if (batchFinished) {
+            // Single success toast for the whole batch.
+            if (batchSummary && batchSummary.total > 0) {
+                if (batchSummary.failed === 0) {
+                    notify({
+                        level: 'success',
+                        title: batchSummary.total === 1 ? 'Upload complete' : `Uploaded ${batchSummary.total} files`,
+                    });
+                } else if (batchSummary.done > 0) {
+                    notify({
+                        level: 'warning',
+                        title: `Uploaded ${batchSummary.done} of ${batchSummary.total} files`,
+                        body: `${batchSummary.failed} failed.`,
+                    });
+                }
+            }
             window.refreshFiles();
         }
     });
@@ -497,11 +510,27 @@ export function setupUploadProgress() {
 
         if (state.uploadBatch) state.uploadBatch.failed += 1;
         const batchFinished = Boolean(state.uploadBatch && state.uploadBatch.done + state.uploadBatch.failed >= state.uploadBatch.total);
+        const batchSummary = batchFinished ? state.uploadBatch : null;
         if (batchFinished) state.uploadBatch = null;
         renderTransferItem(uploadId);
         updateTransferPill();
 
         if (batchFinished) {
+            if (batchSummary && batchSummary.failed > 0) {
+                if (batchSummary.done === 0) {
+                    notify({
+                        level: 'error',
+                        title: batchSummary.total === 1 ? 'Upload failed' : `Failed to upload ${batchSummary.failed} files`,
+                        body: filename || undefined,
+                    });
+                } else {
+                    notify({
+                        level: 'warning',
+                        title: `Uploaded ${batchSummary.done} of ${batchSummary.total} files`,
+                        body: `${batchSummary.failed} failed.`,
+                    });
+                }
+            }
             window.refreshFiles();
         }
     });
@@ -545,7 +574,11 @@ export async function uploadWithParentID(parentID) {
             state.transferUploadListEl.querySelectorAll('.transfer-item[data-type="upload"]').forEach((el) => el.remove());
         }
         updateTransferPill();
-        alert("UploadToDriveFS is missing in backend. Rebuild the app (wails dev/build) and try again.");
+        notify({
+            level: 'error',
+            title: 'Upload bindings missing',
+            body: 'UploadToDriveFS is missing in the backend. Rebuild the app (wails dev/build) and try again.',
+        });
         return;
     }
 

--- a/frontend/src/modules/transfers.js
+++ b/frontend/src/modules/transfers.js
@@ -33,62 +33,24 @@ function normalizeDownloadResult(result) {
     };
 }
 
-export function showDownloadProgress(percent) {
-    const value = Number(percent);
-    if (!Number.isFinite(value)) return;
-    const activeId = state.activeDownloadId;
-    if (activeId === null || activeId === undefined) return;
-
-    const item = (state.downloadQueue || []).find((entry) => entry.id === activeId);
-    if (!item) return;
-
-    const clamped = Math.max(0, Math.min(100, value));
-    item.progress = clamped;
-    if (!isDownloadTerminalState(item.state)) {
-        item.state = "downloading";
-    }
-    updateTransferProgress({ id: item.id, direction: 'down', progress: clamped });
-
-    if (state.downloadProgressHideTimeout) {
-        clearTimeout(state.downloadProgressHideTimeout);
-        state.downloadProgressHideTimeout = null;
-    }
-
-    if (state.downloadProgressEl && state.downloadProgressFillEl) {
-        // The thin overlay bar at the top of the file list stays as a
-        // secondary signal during active downloads. Bell handles the
-        // primary surface.
-        state.downloadProgressEl.style.display = "block";
-        state.downloadProgressEl.setAttribute("aria-valuenow", String(Math.round(clamped)));
-        state.downloadProgressFillEl.style.width = `${clamped}%`;
-    }
-}
-
-export function hideDownloadProgress() {
-    if (state.downloadProgressHideTimeout) {
-        clearTimeout(state.downloadProgressHideTimeout);
-        state.downloadProgressHideTimeout = null;
-    }
-
-    if (state.downloadProgressEl && state.downloadProgressFillEl) {
-        state.downloadProgressEl.style.display = "none";
-        state.downloadProgressEl.setAttribute("aria-valuenow", "0");
-        state.downloadProgressFillEl.style.width = "0%";
-    }
-}
-
 export function setupDownloadProgress() {
-    state.downloadProgressEl = document.getElementById("transfer-progress");
-    state.downloadProgressFillEl = document.getElementById("transfer-progress-fill");
     if (!window.runtime?.EventsOn) return;
 
     window.runtime.EventsOn("download_progress", (percent) => {
-        if (!state.downloadQueue || state.activeDownloadId === null || state.activeDownloadId === undefined) return;
+        const activeId = state.activeDownloadId;
+        if (activeId === null || activeId === undefined) return;
         const value = Number(percent);
         if (!Number.isFinite(value)) return;
 
         const clamped = Math.max(0, Math.min(100, value));
-        showDownloadProgress(clamped);
+        const item = (state.downloadQueue || []).find((entry) => entry.id === activeId);
+        if (!item) return;
+
+        item.progress = clamped;
+        if (!isDownloadTerminalState(item.state)) {
+            item.state = "downloading";
+        }
+        updateTransferProgress({ id: item.id, direction: 'down', progress: clamped });
     });
 }
 
@@ -125,7 +87,6 @@ async function startNextDownload() {
         markTransferDone({ id: next.id, direction: 'down', status: 'failed' });
     } finally {
         state.activeDownloadId = null;
-        hideDownloadProgress();
         startNextDownload();
     }
 }

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -77,6 +77,10 @@ export const state = {
     userNames: new Map(),
     userNameFailures: new Set(),
     userNameRequests: new Map(),
+
+    // Toast notifications (the global feedback surface). Each entry:
+    // { id, level, title, body, sticky, expiresAt, paused }
+    toasts: [],
 };
 
 // Helper to reset folder caches (called on refresh)

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -81,6 +81,20 @@ export const state = {
     // Toast notifications (the global feedback surface). Each entry:
     // { id, level, title, body, sticky, expiresAt, paused }
     toasts: [],
+
+    // Notification bell — single unified surface in the top-right header.
+    // historyEvents is a chronological log of everything worth showing in
+    // the panel. Two flavors:
+    //   { kind: 'transfer', id, direction: 'up'|'down', name, progress,
+    //     status: 'active'|'done'|'failed'|'canceled', startedAt, finishedAt }
+    //   { kind: 'event',    id, level, title, body, ts }
+    // Capped at 100, ephemeral (cleared on app close).
+    historyEvents: [],
+
+    // Bell visibility / state machine.
+    notifPanelOpen: false,
+    notifHoverOpen: false,
+    notifUnreadErrors: 0,
 };
 
 // Helper to reset folder caches (called on refresh)

--- a/frontend/src/state.js
+++ b/frontend/src/state.js
@@ -12,9 +12,6 @@ export const state = {
 
     // Transfer state
     activeTransfer: null, // "download" | "upload" | null
-    downloadProgressEl: null,
-    downloadProgressFillEl: null,
-    downloadProgressHideTimeout: null,
     downloadQueue: [],
     activeDownloadId: null,
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -514,9 +514,12 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     border-radius: 999px;
     transition: width 200ms ease;
 }
-.notif-row-transfer.is-done .notif-row-progress-fill { background: #6ee7a3; }
-.notif-row-transfer.is-failed .notif-row-progress-fill { background: var(--danger); }
-.notif-row-transfer.is-canceled .notif-row-progress-fill { background: var(--text-muted); opacity: 0.5; }
+/* Once a transfer terminates, the bar is just noise — the meta label
+   ("Done" / "Failed" / "Canceled") already says it. Hide it so finished
+   rows match the look of completed event rows above. */
+.notif-row-transfer.is-done .notif-row-progress,
+.notif-row-transfer.is-failed .notif-row-progress,
+.notif-row-transfer.is-canceled .notif-row-progress { display: none; }
 
 .notif-row.level-error .notif-row-title { color: #f7a8b9; }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -294,6 +294,265 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 }
 .uploader-chip:empty { display: none; }
 
+/* === NOTIFICATION BELL === */
+.notif-bell {
+    position: relative;
+    width: 36px;
+    height: 36px;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--text-muted);
+    border-radius: 10px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+    padding: 0;
+}
+.notif-bell:hover { background: var(--bg-panel); color: var(--text-main); border-color: var(--border); }
+.notif-bell:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.notif-bell:active { transform: translateY(1px); }
+.notif-bell-icon { width: 18px; height: 18px; display: inline-flex; }
+.notif-bell-icon svg { width: 100%; height: 100%; }
+
+.notif-bell[data-mode="active"] .notif-bell-icon { color: var(--accent); }
+.notif-bell[data-mode="error"]  .notif-bell-icon { color: var(--danger); }
+
+.notif-bell-dot {
+    position: absolute;
+    top: 7px;
+    right: 7px;
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: transparent;
+    box-shadow: 0 0 0 2px var(--bg-dark);
+    transition: background 200ms ease, transform 200ms ease;
+    transform: scale(0);
+}
+.notif-bell-dot[data-mode="active"] {
+    background: var(--accent);
+    transform: scale(1);
+    animation: notif-bell-pulse 1.6s ease-in-out infinite;
+}
+.notif-bell-dot[data-mode="error"] {
+    background: var(--danger);
+    transform: scale(1);
+}
+@keyframes notif-bell-pulse {
+    0%, 100% { box-shadow: 0 0 0 2px var(--bg-dark), 0 0 0 0 rgba(122, 162, 247, 0.45); }
+    50%      { box-shadow: 0 0 0 2px var(--bg-dark), 0 0 0 6px rgba(122, 162, 247, 0); }
+}
+
+/* Hover popover — minimal active-transfer peek */
+.notif-popover {
+    position: fixed;
+    z-index: 9998;
+    width: 280px;
+    max-width: calc(100vw - 24px);
+    padding: 10px;
+    border-radius: 12px;
+    background: rgba(36, 40, 59, 0.78);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow:
+        0 16px 48px rgba(0, 0, 0, 0.45),
+        0 1px 0 rgba(255, 255, 255, 0.04) inset;
+    backdrop-filter: blur(24px) saturate(180%);
+    -webkit-backdrop-filter: blur(24px) saturate(180%);
+    color: var(--text-main);
+    transform-origin: top right;
+    animation: notif-pop-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+    transition: opacity 140ms ease, transform 140ms ease;
+}
+.notif-popover.notif-leaving { opacity: 0; transform: translateY(-4px) scale(0.97); pointer-events: none; }
+.notif-popover-list { display: flex; flex-direction: column; gap: 8px; }
+.notif-popover-more {
+    margin-top: 8px;
+    text-align: center;
+    font-size: 0.74rem;
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+
+/* Full panel */
+.notif-panel {
+    position: fixed;
+    z-index: 9999;
+    width: 380px;
+    max-width: calc(100vw - 24px);
+    max-height: min(560px, calc(100vh - 80px));
+    border-radius: 14px;
+    background: rgba(36, 40, 59, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow:
+        0 22px 60px rgba(0, 0, 0, 0.50),
+        0 1px 0 rgba(255, 255, 255, 0.04) inset;
+    backdrop-filter: blur(28px) saturate(180%);
+    -webkit-backdrop-filter: blur(28px) saturate(180%);
+    color: var(--text-main);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    transform-origin: top right;
+    animation: notif-pop-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
+    transition: opacity 140ms ease, transform 140ms ease;
+}
+.notif-panel.notif-leaving { opacity: 0; transform: translateY(-6px) scale(0.97); pointer-events: none; }
+.notif-panel-header {
+    flex-shrink: 0;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 14px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.notif-panel-title {
+    font-size: 0.92rem;
+    font-weight: 600;
+    color: var(--text-main);
+}
+.notif-panel-clear {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    padding: 4px 10px;
+    border-radius: 7px;
+    cursor: pointer;
+    transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
+}
+.notif-panel-clear:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-main);
+    border-color: rgba(255, 255, 255, 0.14);
+}
+.notif-panel-clear:disabled { opacity: 0.4; cursor: default; }
+.notif-panel-body {
+    overflow-y: auto;
+    padding: 10px 14px 14px;
+}
+.notif-section-label {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    opacity: 0.65;
+    padding: 4px 0 6px;
+}
+.notif-section {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+/* Rows */
+.notif-row {
+    display: grid;
+    grid-template-columns: 22px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    border-radius: 10px;
+    font-size: 0.85rem;
+    transition: background 140ms ease, transform 140ms ease;
+}
+.notif-row:hover { background: rgba(255, 255, 255, 0.05); }
+.notif-row[data-clipable="1"] { cursor: pointer; }
+.notif-row[data-clipable="1"]:active { transform: scale(0.99); }
+.notif-row.notif-copied { background: rgba(52, 199, 89, 0.10); border-color: rgba(52, 199, 89, 0.25); }
+
+.notif-row-icon {
+    width: 22px; height: 22px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border-radius: 999px;
+    flex-shrink: 0;
+}
+.notif-row-icon svg { width: 14px; height: 14px; }
+.notif-row-icon[data-kind="upload"]   { background: rgba(122, 162, 247, 0.16); color: var(--accent); }
+.notif-row-icon[data-kind="download"] { background: rgba(122, 162, 247, 0.12); color: #9eb9f9; }
+.notif-row-icon[data-kind="success"]  { background: rgba(52, 199, 89, 0.18); color: #6ee7a3; }
+.notif-row-icon[data-kind="info"]     { background: rgba(122, 162, 247, 0.14); color: var(--accent); }
+.notif-row-icon[data-kind="warning"]  { background: rgba(247, 178, 76, 0.18); color: #f7b24c; }
+.notif-row-icon[data-kind="error"]    { background: rgba(247, 118, 142, 0.20); color: var(--danger); }
+
+.notif-row-body { min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.notif-row-title {
+    font-weight: 500;
+    color: var(--text-main);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+.notif-row-sub {
+    color: var(--text-muted);
+    font-size: 0.76rem;
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.notif-row-meta {
+    color: var(--text-muted);
+    font-size: 0.74rem;
+    flex-shrink: 0;
+    margin-left: 8px;
+}
+.notif-row-progress {
+    width: 100%;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 999px;
+    overflow: hidden;
+}
+.notif-row-progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent), #9eb9f9);
+    border-radius: 999px;
+    transition: width 200ms ease;
+}
+.notif-row-transfer.is-done .notif-row-progress-fill { background: #6ee7a3; }
+.notif-row-transfer.is-failed .notif-row-progress-fill { background: var(--danger); }
+.notif-row-transfer.is-canceled .notif-row-progress-fill { background: var(--text-muted); opacity: 0.5; }
+
+.notif-row.level-error .notif-row-title { color: #f7a8b9; }
+
+/* Empty state */
+.notif-empty {
+    padding: 28px 16px 16px;
+    text-align: center;
+    color: var(--text-muted);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+.notif-empty-glyph {
+    width: 44px; height: 44px;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 999px;
+    color: var(--text-muted);
+    opacity: 0.7;
+}
+.notif-empty-glyph svg { width: 22px; height: 22px; }
+.notif-empty-title { font-weight: 600; color: var(--text-main); font-size: 0.92rem; }
+.notif-empty-body { font-size: 0.8rem; line-height: 1.4; max-width: 240px; }
+
+@keyframes notif-pop-in {
+    from { opacity: 0; transform: translateY(-8px) scale(0.96); }
+    to   { opacity: 1; transform: translateY(0)    scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .notif-bell-dot { animation: none !important; }
+    .notif-popover, .notif-panel { animation: none; transition: opacity 0.001ms; }
+    .notif-popover.notif-leaving, .notif-panel.notif-leaving { transform: none; }
+    .notif-row-progress-fill { transition: none; }
+}
+
 /* === TOAST NOTIFICATIONS === */
 .toast-stack {
     position: fixed;
@@ -470,192 +729,6 @@ header {
 .upload-btn { width: auto; padding: 8px 20px; font-size: 0.9rem; }
 .btn-icon { width: 16px; height: 16px; }
 .folder-btn { padding: 8px 14px; font-size: 0.9rem; }
-
-.transfer-wrap {
-    position: relative;
-    display: flex;
-    align-items: center;
-}
-
-.transfer-pill {
-    height: 34px;
-    padding: 0 12px;
-    border-radius: 999px;
-    border: 1px solid var(--border);
-    background: rgba(255, 255, 255, 0.04);
-    color: rgba(192, 202, 245, 0.9);
-    font-weight: 600;
-    font-size: 0.85rem;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
-    white-space: nowrap;
-}
-.transfer-pill.is-idle {
-    width: 18px;
-    height: 18px;
-    padding: 0;
-    border: 1px solid rgba(41, 46, 66, 0.85);
-    background: rgba(255, 255, 255, 0.02);
-    cursor: default;
-    justify-content: center;
-}
-.transfer-pill.is-idle:hover {
-    background: rgba(255, 255, 255, 0.02);
-    border-color: rgba(41, 46, 66, 0.85);
-}
-.transfer-pill.is-idle:active { transform: none; }
-.transfer-pill-label { line-height: 1; }
-.transfer-pill.is-idle .transfer-pill-label { display: none; }
-.transfer-pill:hover { background: rgba(255, 255, 255, 0.06); border-color: rgba(122, 162, 247, 0.35); }
-.transfer-pill:active { transform: translateY(1px); }
-.transfer-pill.is-error { border-color: rgba(247, 118, 142, 0.45); color: rgba(247, 118, 142, 0.95); }
-.transfer-pill.is-active { border-color: rgba(122, 162, 247, 0.45); }
-.transfer-pill-dot {
-    display: none;
-    width: 8px;
-    height: 8px;
-    border-radius: 999px;
-    flex: 0 0 auto;
-    background: rgba(122, 162, 247, 0.9);
-    box-shadow: 0 0 0 4px rgba(122, 162, 247, 0.12);
-}
-.transfer-pill.is-idle .transfer-pill-dot {
-    display: block;
-    width: 8px;
-    height: 8px;
-    background: var(--success);
-    box-shadow: 0 0 0 4px rgba(52, 199, 89, 0.18);
-}
-.transfer-pill.is-error .transfer-pill-dot {
-    background: rgba(247, 118, 142, 0.9);
-    box-shadow: 0 0 0 4px rgba(247, 118, 142, 0.12);
-}
-
-.transfer-sheet {
-    position: absolute;
-    top: calc(100% + 10px);
-    right: 0;
-    width: 360px;
-    border-radius: 14px;
-    background: rgba(22, 22, 30, 0.92);
-    border: 1px solid var(--border);
-    box-shadow: 0 18px 60px rgba(0,0,0,0.6);
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
-    overflow: hidden;
-    z-index: 10001;
-}
-
-.transfer-sheet-header {
-    padding: 12px 14px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-bottom: 1px solid rgba(41, 46, 66, 0.75);
-}
-.transfer-sheet-title {
-    font-weight: 800;
-    color: rgba(255, 255, 255, 0.92);
-    letter-spacing: -0.02em;
-}
-.transfer-sheet-clear {
-    border: 1px solid var(--border);
-    background: rgba(255, 255, 255, 0.03);
-    color: rgba(192, 202, 245, 0.85);
-    padding: 6px 10px;
-    border-radius: 10px;
-    font-weight: 700;
-    font-size: 0.8rem;
-    cursor: pointer;
-    transition: background 0.15s ease, border-color 0.15s ease;
-}
-.transfer-sheet-clear:hover { background: rgba(255, 255, 255, 0.06); border-color: rgba(122, 162, 247, 0.35); }
-
-.transfer-sheet-list {
-    max-height: 320px;
-    overflow: auto;
-    padding: 10px;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(192, 202, 245, 0.22) rgba(255, 255, 255, 0);
-}
-.transfer-sheet-list::-webkit-scrollbar { width: 10px; }
-.transfer-sheet-list::-webkit-scrollbar-track {
-    background: transparent;
-    margin: 10px 0;
-}
-.transfer-sheet-list::-webkit-scrollbar-thumb {
-    background: rgba(192, 202, 245, 0.18);
-    border-radius: 999px;
-    border: 3px solid rgba(0, 0, 0, 0);
-    background-clip: padding-box;
-}
-.transfer-sheet-list::-webkit-scrollbar-thumb:hover { background: rgba(192, 202, 245, 0.26); background-clip: padding-box; }
-
-.transfer-item {
-    position: relative;
-    border-radius: 12px;
-    border: 1px solid rgba(41, 46, 66, 0.85);
-    background: rgba(255, 255, 255, 0.02);
-    overflow: hidden;
-    margin-bottom: 10px;
-}
-.transfer-item:last-child { margin-bottom: 0; }
-
-.transfer-item-fill {
-    position: absolute;
-    inset: 0;
-    width: 0%;
-    background: linear-gradient(90deg, rgba(122, 162, 247, 0.12), rgba(122, 162, 247, 0.32));
-    transition: width 120ms ease;
-}
-.transfer-item.is-done .transfer-item-fill {
-    background: linear-gradient(90deg, rgba(158, 206, 106, 0.10), rgba(158, 206, 106, 0.22));
-}
-.transfer-item.is-failed .transfer-item-fill {
-    background: linear-gradient(90deg, rgba(247, 118, 142, 0.10), rgba(247, 118, 142, 0.20));
-}
-
-.transfer-item-content {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 12px;
-}
-.transfer-item-name {
-    font-weight: 700;
-    font-size: 0.9rem;
-    color: rgba(255, 255, 255, 0.92);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 250px;
-}
-.transfer-item-meta {
-    font-weight: 800;
-    font-size: 0.82rem;
-    color: rgba(192, 202, 245, 0.78);
-    white-space: nowrap;
-}
-.transfer-item.is-failed .transfer-item-meta { color: rgba(247, 118, 142, 0.95); }
-.transfer-item.is-done .transfer-item-meta { color: rgba(158, 206, 106, 0.95); }
-.transfer-item.is-queued .transfer-item-meta { color: rgba(192, 202, 245, 0.55); }
-.transfer-item.is-queued .transfer-item-fill { width: 0% !important; }
-
-.transfer-empty {
-    padding: 14px 12px;
-    border-radius: 12px;
-    border: 1px dashed rgba(41, 46, 66, 0.75);
-    color: rgba(192, 202, 245, 0.55);
-    font-weight: 600;
-    font-size: 0.85rem;
-    text-align: center;
-}
 
 /* BREADCRUMB */
 .drive-breadcrumb {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -698,20 +698,6 @@ header {
     padding: 0 30px; border-bottom: 1px solid var(--border);
 }
 
-.transfer-progress {
-    height: 3px;
-    width: 100%;
-    background: rgba(255, 255, 255, 0.05);
-    overflow: hidden;
-}
-.transfer-progress-fill {
-    height: 100%;
-    width: 0%;
-    background: linear-gradient(90deg, rgba(122, 162, 247, 0.25), var(--accent), rgba(122, 162, 247, 0.75));
-    border-radius: 999px;
-    transition: width 120ms ease;
-}
-
 .search-bar { position: relative; width: 300px; }
 .search-bar input { margin: 0; padding-left: 36px; background: var(--bg-sidebar); border: none; }
 .search-icon { position: absolute; left: 10px; top: 12px; width: 16px; height: 16px; color: var(--text-muted); }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -294,6 +294,123 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 }
 .uploader-chip:empty { display: none; }
 
+/* === TOAST NOTIFICATIONS === */
+.toast-stack {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    z-index: 9999;
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 10px;
+    pointer-events: none;
+    max-width: min(420px, calc(100vw - 40px));
+    width: 100%;
+}
+.toast {
+    pointer-events: auto;
+    display: grid;
+    grid-template-columns: 22px 1fr 22px;
+    gap: 12px;
+    align-items: start;
+    padding: 12px 14px;
+    border-radius: 12px;
+    background: rgba(36, 40, 59, 0.96);
+    border: 1px solid var(--border);
+    box-shadow:
+        0 10px 30px rgba(0, 0, 0, 0.35),
+        0 1px 0 rgba(255, 255, 255, 0.04) inset;
+    backdrop-filter: blur(12px);
+    color: var(--text-main);
+    font-size: 0.88rem;
+    line-height: 1.4;
+    transform-origin: bottom right;
+    animation: toast-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+    transition: opacity 180ms ease, transform 180ms ease;
+    cursor: default;
+}
+.toast:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.toast.toast-leaving {
+    opacity: 0;
+    transform: translateX(40px) scale(0.96);
+    pointer-events: none;
+}
+
+.toast-icon {
+    width: 22px; height: 22px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border-radius: 999px;
+    flex-shrink: 0;
+}
+.toast-icon svg { width: 16px; height: 16px; }
+
+.toast-info    .toast-icon { background: rgba(122, 162, 247, 0.16); color: var(--accent); }
+.toast-success .toast-icon { background: rgba(52, 199, 89, 0.18); color: #6ee7a3; }
+.toast-warning .toast-icon { background: rgba(247, 178, 76, 0.18); color: #f7b24c; }
+.toast-error   .toast-icon { background: rgba(247, 118, 142, 0.20); color: #f7768e; }
+
+.toast-info    { border-color: rgba(122, 162, 247, 0.30); }
+.toast-success { border-color: rgba(52, 199, 89, 0.30); }
+.toast-warning { border-color: rgba(247, 178, 76, 0.32); }
+.toast-error   { border-color: rgba(247, 118, 142, 0.34); }
+
+.toast-content {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding-top: 1px;
+}
+.toast-title {
+    font-weight: 600;
+    color: var(--text-main);
+    word-break: break-word;
+}
+.toast-body {
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    word-break: break-word;
+    /* Cap to ~3 lines to keep the stack tidy. */
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.toast-close {
+    width: 22px; height: 22px;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: 6px;
+    padding: 0;
+    transition: background 120ms ease, color 120ms ease;
+}
+.toast-close svg { width: 14px; height: 14px; }
+.toast-close:hover { background: rgba(255, 255, 255, 0.06); color: var(--text-main); }
+.toast-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+.toast-spinner {
+    animation: toast-spin 0.9s linear infinite;
+    transform-origin: 50% 50%;
+}
+
+@keyframes toast-in {
+    from { opacity: 0; transform: translateX(28px) scale(0.96); }
+    to   { opacity: 1; transform: translateX(0)    scale(1); }
+}
+@keyframes toast-spin {
+    to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .toast { animation: none; transition: opacity 0.001ms; }
+    .toast.toast-leaving { transform: none; }
+    .toast-spinner { animation: none; }
+}
+
 .pending-folder {
     opacity: 0.55;
     pointer-events: none;          /* dim + non-interactive */


### PR DESCRIPTION
Replaces the in-header transfer pill and `alert()`s with a single notification bell + toast stack.

- Bell idles quiet, pulses on active transfer, danger dot for unread errors. Hover peeks at active transfers, click opens a panel with Active + Recent.
- Toasts (bottom-right) for transient feedback; same events also append to the bell history.
- Drops `#transfer-pill`, `#transfer-sheet`, `#status-msg` and the related CSS.
- Frontend only. Reduced-motion + outside-click + Esc handled.

Limits (deferred): no persistence across restarts, no cancel button on active rows, no native OS notifications.