### PR TITLE
fix: auth, sync, and download safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Shared drives are usable now, but still new. You can:
 
 Treat invite links like passwords. Anyone with a normal invite link can join unless you revoke it. If you need tighter control, create an approval-required link.
 
+Folder structure inside a shared drive is collaborative: any member can create, rename, move, or delete folders. Deleting a folder does not delete the files inside it; those files show up in the Orphaned view.
+
 ## Encryption
 
 Personal-drive encryption is per upload. When you choose encrypted upload, TDrive encrypts the file contents before sending them to Telegram, and decrypts automatically on preview/download after you enter the correct password.

--- a/app.go
+++ b/app.go
@@ -381,8 +381,8 @@ func (a *App) authService() *authsvc.Service {
 	return a.auth
 }
 
-func (a *App) LoginPhoneNumber(phoneNumber string) {
-	a.authService().StartLogin(a.ctx, phoneNumber)
+func (a *App) LoginPhoneNumber(phoneNumber string) error {
+	return a.authService().StartLogin(a.ctx, phoneNumber)
 }
 
 func (a *App) InitDrive() string {

--- a/app.go
+++ b/app.go
@@ -663,7 +663,7 @@ func (a *App) RenameFolder(folderID string, newName string) string {
 }
 
 func (a *App) MoveFile(msgID int, newParentID string) string {
-	if err := a.fileService().Move(a.ActiveChannelID(), msgID, newParentID); err != nil {
+	if err := a.fileService().Move(a.ctx, a.ActiveChannelID(), msgID, newParentID); err != nil {
 		return "Error: " + err.Error()
 	}
 	return "Success"

--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -24,8 +24,8 @@ const (
 )
 
 type getchanel interface {
-	GetCodech() chan string
-	GetPassch() chan string
+	WaitCode(ctx context.Context) (string, error)
+	WaitPassword(ctx context.Context, hint string) (string, error)
 	SendHint(hint string)
 }
 
@@ -151,9 +151,7 @@ func (a AuthT) Phone(ctx context.Context) (string, error) {
 }
 
 func (a AuthT) Code(ctx context.Context, sendcode *tg.AuthSentCode) (string, error) {
-	code := <-a.app.GetCodech()
-
-	return code, nil
+	return a.app.WaitCode(ctx)
 }
 
 func (a AuthT) Password(ctx context.Context) (string, error) {
@@ -162,15 +160,14 @@ func (a AuthT) Password(ctx context.Context) (string, error) {
 		return "", err
 	}
 
+	hint := ""
 	if passObj.Hint != "" {
-		a.app.SendHint("Hint : " + passObj.Hint)
+		hint = "Hint : " + passObj.Hint
 	} else {
-		a.app.SendHint("NO HINT found")
+		hint = "NO HINT found"
 	}
 
-	Password := <-a.app.GetPassch()
-
-	return Password, nil
+	return a.app.WaitPassword(ctx, hint)
 }
 
 func (a AuthT) AcceptTermsOfService(ctx context.Context, tos tg.HelpTermsOfService) error {

--- a/backend/auth/channel.go
+++ b/backend/auth/channel.go
@@ -10,8 +10,11 @@ import (
 
 func GetTDriveChannel(ctx context.Context, Client *telegram.Client) (int64, error) {
 	savedId, err := LoadConfig()
+	if err != nil {
+		return 0, fmt.Errorf("load TDrive channel config: %w", err)
+	}
 
-	if err == nil && savedId != 0 {
+	if savedId != 0 {
 		return savedId, nil
 	}
 

--- a/backend/auth/channel_test.go
+++ b/backend/auth/channel_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetTDriveChannelReturnsCorruptConfigError(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	t.Setenv("HOME", root)
+	t.Setenv("AppData", root)
+
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir: %v", err)
+	}
+	tdriveDir := filepath.Join(cfgDir, "TDrive")
+	if err := os.MkdirAll(tdriveDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tdriveDir, "config.json"), []byte(`{bad json`), 0o600); err != nil {
+		t.Fatalf("write corrupt config: %v", err)
+	}
+
+	_, err = GetTDriveChannel(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected corrupt config error")
+	}
+	if !strings.Contains(err.Error(), "load TDrive channel config") {
+		t.Fatalf("err = %v, want load config context", err)
+	}
+}

--- a/backend/auth/config.go
+++ b/backend/auth/config.go
@@ -33,9 +33,30 @@ func SaveConfig(id int64) error {
 	}
 	_ = os.Chmod(dir, privateDirMode)
 
-	err = os.WriteFile(path, jsonData, privateFileMode)
+	tmp, err := os.CreateTemp(dir, ".config-*.tmp")
 	if err != nil {
-		return err
+		return fmt.Errorf("create temp config: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmp.Write(jsonData); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp config: %w", err)
+	}
+	if err := tmp.Chmod(privateFileMode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp config: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp config: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace config: %w", err)
 	}
 	_ = os.Chmod(path, privateFileMode)
 
@@ -57,14 +78,14 @@ func LoadConfig() (int64, error) {
 	}
 
 	if err != nil {
-		return 0, nil
+		return 0, fmt.Errorf("read config: %w", err)
 	}
 
 	channels := ChannelS{}
 
 	err = json.Unmarshal(file, &channels)
 	if err != nil {
-		return 0, nil
+		return 0, fmt.Errorf("parse config: %w", err)
 	}
 
 	cid := channels.ChannelID

--- a/backend/projection/apply.go
+++ b/backend/projection/apply.go
@@ -28,6 +28,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -273,12 +274,17 @@ func parseFileMsgID(obj string) (int64, error) {
 		return 0, fmt.Errorf("%w: not a file id %q", ErrBadOp, obj)
 	}
 	raw := obj[len(FileIDPrefix):]
-	var n int64
+	if raw == "" {
+		return 0, fmt.Errorf("%w: file id must be positive", ErrBadOp)
+	}
 	for _, ch := range raw {
 		if ch < '0' || ch > '9' {
 			return 0, fmt.Errorf("%w: file id has non-digit %q", ErrBadOp, obj)
 		}
-		n = n*10 + int64(ch-'0')
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: file id out of range %q", ErrBadOp, obj)
 	}
 	if n <= 0 {
 		return 0, fmt.Errorf("%w: file id must be positive", ErrBadOp)

--- a/backend/projection/apply_test.go
+++ b/backend/projection/apply_test.go
@@ -420,6 +420,16 @@ func TestApplyRejectsUnknownType(t *testing.T) {
 	}
 }
 
+func TestApplyRejectsOverflowFileID(t *testing.T) {
+	db := newTestDB(t)
+	tx, _ := db.Begin()
+	defer tx.Rollback()
+	err := ApplyOp(tx, testChan, 1, Op{Type: OpTomb, Obj: "f:999999999999999999999999999999"}, 0)
+	if !errors.Is(err, ErrBadOp) {
+		t.Fatalf("err = %v want ErrBadOp", err)
+	}
+}
+
 func mustOp(t *testing.T, db *sql.DB, msgID int64, op Op) {
 	t.Helper()
 	if err := runOp(t, db, testChan, msgID, op); err != nil {

--- a/backend/projection/log.go
+++ b/backend/projection/log.go
@@ -97,9 +97,19 @@ func ProjectFromOpTx(tx *sql.Tx, channelID int64, msgID int64, op Op, actorID in
 	}
 
 	if err := ApplyOp(tx, channelID, msgID, op, actorID); err != nil {
+		if isSkippableApplyError(err) {
+			if recErr := recordReject(tx, channelID, msgID, err); recErr != nil {
+				return false, recErr
+			}
+			return false, nil
+		}
 		return false, fmt.Errorf("projection: apply op msg=%d: %w", msgID, err)
 	}
 	return false, nil
+}
+
+func isSkippableApplyError(err error) bool {
+	return errors.Is(err, ErrCycleRejected) || errors.Is(err, ErrBadOp)
 }
 
 func existingHash(tx *sql.Tx, channelID, msgID int64) (string, bool, error) {
@@ -127,6 +137,20 @@ func recordTamper(tx *sql.Tx, channelID, msgID int64, oldHash, newHash string) e
 	`, channelID, msgID, oldHash, newHash, time.Now().Unix())
 	if err != nil {
 		return fmt.Errorf("projection: record tamper: %w", err)
+	}
+	return nil
+}
+
+func recordReject(tx *sql.Tx, channelID, msgID int64, applyErr error) error {
+	_, err := tx.Exec(`
+		INSERT INTO replay_log_rejects (channel_id, msg_id, error, detected_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(channel_id, msg_id) DO UPDATE SET
+			error = excluded.error,
+			detected_at = excluded.detected_at
+	`, channelID, msgID, applyErr.Error(), time.Now().Unix())
+	if err != nil {
+		return fmt.Errorf("projection: record rejected op: %w", err)
 	}
 	return nil
 }

--- a/backend/projection/log_test.go
+++ b/backend/projection/log_test.go
@@ -100,22 +100,33 @@ func TestProjectFromOpDetectsTamper(t *testing.T) {
 	}
 }
 
-func TestProjectFromOpRollsBackOnApplyError(t *testing.T) {
+func TestProjectFromOpRecordsAndSkipsRejectedApplyError(t *testing.T) {
 	db := newTestDB(t)
 	op := Op{Type: OpRename, Obj: "raw", Name: "x"}
 	header := Format(op)
 
-	_, err := ProjectFromOp(db, testChan, 1, op, 0, header)
-	if err == nil {
-		t.Fatal("expected error from applying a malformed op")
+	already, err := ProjectFromOp(db, testChan, 1, op, 0, header)
+	if err != nil {
+		t.Fatalf("project rejected op: %v", err)
+	}
+	if already {
+		t.Fatal("fresh rejected op should not be alreadySeen")
 	}
 
 	var rows int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM replay_log WHERE channel_id=? AND msg_id=?`, testChan, 1).Scan(&rows); err != nil {
 		t.Fatalf("count: %v", err)
 	}
-	if rows != 0 {
-		t.Fatalf("replay_log row count = %d, want 0 (tx should have rolled back)", rows)
+	if rows != 1 {
+		t.Fatalf("replay_log row count = %d, want 1", rows)
+	}
+
+	var rejectRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM replay_log_rejects WHERE channel_id=? AND msg_id=?`, testChan, 1).Scan(&rejectRows); err != nil {
+		t.Fatalf("count rejects: %v", err)
+	}
+	if rejectRows != 1 {
+		t.Fatalf("reject row count = %d, want 1", rejectRows)
 	}
 }
 

--- a/backend/projection/migration_test.go
+++ b/backend/projection/migration_test.go
@@ -49,7 +49,7 @@ func TestMigrateAddsSchemaTables(t *testing.T) {
 		t.Fatalf("migrate: %v", err)
 	}
 
-	for _, name := range []string{"channels", "replay_log", "replay_log_tamper", "backfill_progress", "pending_joins", "schema_version"} {
+	for _, name := range []string{"channels", "replay_log", "replay_log_tamper", "replay_log_rejects", "backfill_progress", "pending_joins", "schema_version"} {
 		var got string
 		err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, name).Scan(&got)
 		if err != nil {

--- a/backend/projection/rebuild.go
+++ b/backend/projection/rebuild.go
@@ -64,6 +64,12 @@ func RebuildProjection(db *sql.DB, channelID int64) error {
 			op.Type = OpType(r.opType)
 		}
 		if err := ApplyOp(tx, channelID, r.msgID, op, r.actorUserID); err != nil {
+			if isSkippableApplyError(err) {
+				if recErr := recordReject(tx, channelID, r.msgID, err); recErr != nil {
+					return recErr
+				}
+				continue
+			}
 			return fmt.Errorf("projection: rebuild apply msg=%d: %w", r.msgID, err)
 		}
 	}

--- a/backend/projection/schema.go
+++ b/backend/projection/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const currentSchemaVersion = 5
+const currentSchemaVersion = 6
 
 func EnsureSchema(db *sql.DB) error {
 	if db == nil {
@@ -47,6 +47,13 @@ func EnsureSchema(db *sql.DB) error {
 			msg_id      INTEGER NOT NULL,
 			old_hash    TEXT NOT NULL,
 			new_hash    TEXT NOT NULL,
+			detected_at INTEGER NOT NULL,
+			PRIMARY KEY (channel_id, msg_id)
+		);`,
+		`CREATE TABLE IF NOT EXISTS replay_log_rejects (
+			channel_id  INTEGER NOT NULL,
+			msg_id      INTEGER NOT NULL,
+			error       TEXT NOT NULL,
 			detected_at INTEGER NOT NULL,
 			PRIMARY KEY (channel_id, msg_id)
 		);`,
@@ -155,6 +162,9 @@ func MigratePersonalChannel(db *sql.DB, personalChannelID int64) error {
 		if err := addEncryptionHintColumn(tx); err != nil {
 			return err
 		}
+	}
+	if v < 6 {
+		// replay_log_rejects is created by EnsureSchema above. Nothing to backfill.
 	}
 
 	if _, err := tx.Exec(`DELETE FROM schema_version`); err != nil {

--- a/backend/projection/wire.go
+++ b/backend/projection/wire.go
@@ -139,14 +139,14 @@ func Parse(raw string) (Op, error) {
 
 	if s, ok := kv["sz"]; ok {
 		n, err := strconv.ParseInt(s, 10, 64)
-		if err != nil {
+		if err != nil || n < 0 {
 			return Op{}, ErrWireMalformed
 		}
 		op.FileSize = n
 	}
 	if s, ok := kv["ts"]; ok {
 		n, err := strconv.ParseInt(s, 10, 64)
-		if err != nil {
+		if err != nil || n < 0 {
 			return Op{}, ErrWireMalformed
 		}
 		op.FileUploadTime = n
@@ -166,7 +166,7 @@ func Parse(raw string) (Op, error) {
 	}
 	if s, ok := kv["psz"]; ok {
 		n, err := strconv.ParseInt(s, 10, 64)
-		if err != nil {
+		if err != nil || n < 0 {
 			return Op{}, ErrWireMalformed
 		}
 		op.PlaintextSize = n

--- a/backend/projection/wire_test.go
+++ b/backend/projection/wire_test.go
@@ -169,6 +169,19 @@ func TestParseRejectsNonFolderParent(t *testing.T) {
 	}
 }
 
+func TestParseRejectsNegativeFileSizes(t *testing.T) {
+	for _, header := range []string{
+		"TDX1|t=f|p=|n=x|sz=-1",
+		"TDX1|t=f|p=|n=x|ts=-1",
+		"TDX1|t=f|p=|n=x|enc=1|psz=-1",
+	} {
+		_, err := Parse(header)
+		if !errors.Is(err, ErrWireMalformed) {
+			t.Fatalf("Parse(%q) err = %v, want ErrWireMalformed", header, err)
+		}
+	}
+}
+
 func TestParseEmptyHeader(t *testing.T) {
 	_, err := Parse("")
 	if !errors.Is(err, ErrWireMissingHeader) {

--- a/backend/services/auth/service.go
+++ b/backend/services/auth/service.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	coreauth "TDrive/backend/auth"
 )
@@ -16,33 +17,57 @@ type Service struct {
 
 	codech chan string
 	passch chan string
+	mu     sync.Mutex
+	stage  loginStage
 }
+
+type loginStage int
+
+const (
+	stageIdle loginStage = iota
+	stageStarted
+	stageWaitingCode
+	stageWaitingPassword
+)
 
 func NewService(events EventSink) *Service {
 	return &Service{
 		Events: events,
-		codech: make(chan string),
-		passch: make(chan string),
+		codech: make(chan string, 1),
+		passch: make(chan string, 1),
 	}
 }
 
-func (s *Service) StartLogin(ctx context.Context, phoneNumber string) {
+func (s *Service) StartLogin(ctx context.Context, phoneNumber string) error {
+	s.resetAttempt(stageStarted)
 	client, err := coreauth.Connect()
 	if err != nil {
 		fmt.Println("Could not connect to Telegram:", err)
-		return
+		s.finishAttempt()
+		s.emit("login-error", err.Error())
+		return err
 	}
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.finishAttempt()
+				s.emit("login-error", fmt.Sprintf("login panic: %v", r))
+			}
+		}()
 		err := coreauth.StartLogin(ctx, client, s, phoneNumber)
 		if err != nil {
 			fmt.Println("Login failed:", err)
+			s.finishAttempt()
+			s.emit("login-error", err.Error())
 			return
 		}
 
 		fmt.Println("Login Flow Complete. Emitting Success Event.")
+		s.finishAttempt()
 		s.emit("login-success", true)
 	}()
+	return nil
 }
 
 func (s *Service) IsLoggedIn(ctx context.Context) bool {
@@ -73,15 +98,45 @@ func (s *Service) SaveSetup(apiID int, apiHash string) string {
 }
 
 func (s *Service) SubmitCode(code string) {
-	s.codech <- code
+	if !s.accepts(stageStarted, stageWaitingCode) {
+		s.emit("login-error", "Not waiting for a login code. Start login again.")
+		return
+	}
+	sendLatest(s.codech, code)
 }
 
 func (s *Service) SubmitPassword(password string) {
-	s.passch <- password
+	if !s.accepts(stageWaitingPassword) {
+		s.emit("login-error", "Not waiting for a password.")
+		return
+	}
+	sendLatest(s.passch, password)
 }
 
 func (s *Service) SendHint(hint string) {
 	s.emit("gothint", hint)
+}
+
+func (s *Service) WaitCode(ctx context.Context) (string, error) {
+	s.setStage(stageWaitingCode)
+	select {
+	case code := <-s.codech:
+		return code, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func (s *Service) WaitPassword(ctx context.Context, hint string) (string, error) {
+	s.setStage(stageWaitingPassword)
+	s.emit("login-password-required", true)
+	s.SendHint(hint)
+	select {
+	case password := <-s.passch:
+		return password, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
 }
 
 func (s *Service) Codech() chan string {
@@ -103,5 +158,64 @@ func (s *Service) GetPassch() chan string {
 func (s *Service) emit(name string, args ...any) {
 	if s.Events != nil {
 		s.Events.Emit(name, args...)
+	}
+}
+
+func (s *Service) resetAttempt(stage loginStage) {
+	s.mu.Lock()
+	s.stage = stage
+	drain(s.codech)
+	drain(s.passch)
+	s.mu.Unlock()
+}
+
+func (s *Service) finishAttempt() {
+	s.mu.Lock()
+	s.stage = stageIdle
+	drain(s.codech)
+	drain(s.passch)
+	s.mu.Unlock()
+}
+
+func (s *Service) setStage(stage loginStage) {
+	s.mu.Lock()
+	s.stage = stage
+	s.mu.Unlock()
+}
+
+func (s *Service) accepts(stages ...loginStage) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, stage := range stages {
+		if s.stage == stage {
+			return true
+		}
+	}
+	return false
+}
+
+func sendLatest(ch chan string, value string) {
+	select {
+	case ch <- value:
+		return
+	default:
+	}
+	select {
+	case <-ch:
+	default:
+	}
+	select {
+	case ch <- value:
+	default:
+	}
+}
+
+func drain(ch chan string) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
 	}
 }

--- a/backend/services/auth/service_test.go
+++ b/backend/services/auth/service_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,11 +44,13 @@ func TestSystemStatusReadyWhenCredsExist(t *testing.T) {
 	}
 }
 
-func TestSubmitCodeUnblocksGetCodech(t *testing.T) {
+func TestSubmitCodeUnblocksWaitCode(t *testing.T) {
 	svc := NewService(nil)
+	svc.resetAttempt(stageStarted)
 	done := make(chan string, 1)
 	go func() {
-		done <- <-svc.Codech()
+		code, _ := svc.WaitCode(context.Background())
+		done <- code
 	}()
 
 	svc.SubmitCode("12345")
@@ -58,6 +61,25 @@ func TestSubmitCodeUnblocksGetCodech(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for code channel")
+	}
+}
+
+func TestSubmitPasswordWithoutPasswordRequestDoesNotBlock(t *testing.T) {
+	events := &fakeEvents{}
+	svc := NewService(events)
+	done := make(chan struct{}, 1)
+	go func() {
+		svc.SubmitPassword("secret")
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("SubmitPassword blocked without password request")
+	}
+	if len(events.events) != 1 || events.events[0].name != "login-error" {
+		t.Fatalf("events = %+v, want login-error", events.events)
 	}
 }
 

--- a/backend/services/file/service.go
+++ b/backend/services/file/service.go
@@ -142,6 +142,14 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 		go func(uploadID int, path string, pid string) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			defer func() {
+				if r := recover(); r != nil {
+					mu.Lock()
+					failed++
+					mu.Unlock()
+					s.emitEvent("upload_error", uploadID, filepath.Base(path), fmt.Sprintf("upload panic: %v", r))
+				}
+			}()
 
 			meta, op, header, err := s.uploadSingle(ctx, uploadID, path, pid, channelID, encrypt)
 			if err != nil {
@@ -360,14 +368,21 @@ func (s *Service) Download(ctx context.Context, channelID int64, msgID int, look
 		return DownloadResult{Status: "canceled", Message: "Download canceled"}
 	}
 
-	f, err := os.Create(savePath)
+	finalTmp, err := os.CreateTemp(filepath.Dir(savePath), ".tdrive-download-*")
 	if err != nil {
 		return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
 	}
-	defer f.Close()
+	finalTmpPath := finalTmp.Name()
+	committed := false
+	defer func() {
+		_ = finalTmp.Close()
+		if !committed {
+			_ = os.Remove(finalTmpPath)
+		}
+	}()
 
 	if !encrypted {
-		if err := s.TG.DownloadFile(ctx, peer, int64(msgID), f, s.downloadProgress(doc.Size)); err != nil {
+		if err := s.TG.DownloadFile(ctx, peer, int64(msgID), finalTmp, s.downloadProgress(doc.Size)); err != nil {
 			return DownloadResult{Status: "error", Message: "Network Error: " + err.Error()}
 		}
 	} else {
@@ -385,11 +400,17 @@ func (s *Service) Download(ctx context.Context, channelID int64, msgID int, look
 		if _, err := cipher.Seek(0, io.SeekStart); err != nil {
 			return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
 		}
-		if _, err := tdcrypto.DecryptStream(cipher, f, masterKey); err != nil {
-			_ = os.Remove(savePath)
+		if _, err := tdcrypto.DecryptStream(cipher, finalTmp, masterKey); err != nil {
 			return DownloadResult{Status: "error", Message: "Decrypt failed: " + err.Error()}
 		}
 	}
+	if err := finalTmp.Close(); err != nil {
+		return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
+	}
+	if err := replaceDownloadedFile(finalTmpPath, savePath); err != nil {
+		return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
+	}
+	committed = true
 
 	s.emitEvent("download_progress", 100.0)
 	return DownloadResult{
@@ -397,6 +418,16 @@ func (s *Service) Download(ctx context.Context, channelID int64, msgID int, look
 		Message:   "Download complete",
 		SavedPath: savePath,
 	}
+}
+
+func replaceDownloadedFile(tmpPath string, savePath string) error {
+	if err := os.Rename(tmpPath, savePath); err == nil {
+		return nil
+	}
+	if err := os.Remove(savePath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Rename(tmpPath, savePath)
 }
 
 func (s *Service) PreviewThumbnail(ctx context.Context, channelID int64, msgID int) (PreviewPayload, error) {
@@ -558,7 +589,7 @@ func (s *Service) Rename(ctx context.Context, channelID int64, msgID int, newNam
 	return err
 }
 
-func (s *Service) Move(channelID int64, msgID int, newParentID string) error {
+func (s *Service) Move(ctx context.Context, channelID int64, msgID int, newParentID string) error {
 	if err := s.ready(); err != nil {
 		return err
 	}
@@ -575,6 +606,9 @@ func (s *Service) Move(channelID int64, msgID int, newParentID string) error {
 	}
 	if cur == parent {
 		return fmt.Errorf("File is already in this folder")
+	}
+	if err := s.requireOwnerForShared(ctx, channelID, msgID, "move"); err != nil {
+		return err
 	}
 	op := projection.Op{
 		Type:   projection.OpMove,

--- a/backend/services/file/service_test.go
+++ b/backend/services/file/service_test.go
@@ -470,6 +470,65 @@ func TestDownloadEncryptedFileDecrypts(t *testing.T) {
 	}
 }
 
+func TestDownloadEncryptedDecryptFailurePreservesExistingFile(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	masterKey := bytes.Repeat([]byte{7}, 32)
+	wrongKey := bytes.Repeat([]byte{8}, 32)
+	svc.MasterKeyForUpload = func(channelID int64, wantEncrypted bool) ([]byte, error) {
+		if !wantEncrypted {
+			return nil, nil
+		}
+		return masterKey, nil
+	}
+	svc.WriteCiphertextTemp = func(plain io.Reader, plaintextSize int64, masterKey []byte) (*os.File, error) {
+		tmp, err := os.CreateTemp("", "tdrive-test-cipher-*")
+		if err != nil {
+			return nil, err
+		}
+		if err := tdcrypto.EncryptStream(plain, tmp, masterKey, plaintextSize); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return nil, err
+		}
+		if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return nil, err
+		}
+		return tmp, nil
+	}
+	svc.RequireEncryptionKey = func(encrypted bool) ([]byte, error) {
+		if encrypted {
+			return wrongKey, nil
+		}
+		return nil, nil
+	}
+
+	path := writeTempFile(t, "secret")
+	files, err := svc.Upload(context.Background(), personalChannelID, []string{path}, []string{""}, true)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	savePath := filepath.Join(t.TempDir(), "existing.txt")
+	if err := os.WriteFile(savePath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("write existing: %v", err)
+	}
+	result := svc.Download(context.Background(), personalChannelID, files[0].MsgID, files[0].MsgID, func(defaultName string) (string, error) {
+		return savePath, nil
+	})
+	if result.Status != "error" || !strings.Contains(result.Message, "Decrypt failed") {
+		t.Fatalf("download = %+v, want decrypt error", result)
+	}
+	got, err := os.ReadFile(savePath)
+	if err != nil {
+		t.Fatalf("read existing: %v", err)
+	}
+	if string(got) != "keep me" {
+		t.Fatalf("existing file = %q, want preserved contents", string(got))
+	}
+}
+
 func TestDownloadEncryptedRequiresPassword(t *testing.T) {
 	svc, db, fakeTG, _ := newTestService(t)
 	project(t, db, personalChannelID, 80, 7, projection.Op{
@@ -551,7 +610,7 @@ func TestRenameAndMoveFile(t *testing.T) {
 	if err := svc.Rename(context.Background(), personalChannelID, 50, "new.txt"); err != nil {
 		t.Fatalf("rename: %v", err)
 	}
-	if err := svc.Move(personalChannelID, 50, "d:docs"); err != nil {
+	if err := svc.Move(context.Background(), personalChannelID, 50, "d:docs"); err != nil {
 		t.Fatalf("move: %v", err)
 	}
 	parent, err := projection.FileParent(db, personalChannelID, 50)
@@ -563,8 +622,14 @@ func TestRenameAndMoveFile(t *testing.T) {
 	}
 }
 
-func TestSharedRenameAndDeleteRequireUploader(t *testing.T) {
+func TestSharedRenameMoveAndDeleteRequireUploader(t *testing.T) {
 	svc, db, fakeTG, actor := newTestService(t)
+	project(t, db, sharedChannelID, 11, 9, projection.Op{
+		Type:   projection.OpMkdir,
+		Obj:    "d:shared-docs",
+		Parent: "",
+		Name:   "Docs",
+	})
 	project(t, db, sharedChannelID, 60, 9, projection.Op{
 		Type:           projection.OpFileUpload,
 		Parent:         "",
@@ -577,6 +642,9 @@ func TestSharedRenameAndDeleteRequireUploader(t *testing.T) {
 	if err := svc.Rename(context.Background(), sharedChannelID, 60, "bad.txt"); err == nil {
 		t.Fatalf("rename by non-uploader unexpectedly succeeded")
 	}
+	if err := svc.Move(context.Background(), sharedChannelID, 60, "d:shared-docs"); err == nil {
+		t.Fatalf("move by non-uploader unexpectedly succeeded")
+	}
 	if err := svc.Delete(context.Background(), sharedChannelID, 60); err == nil {
 		t.Fatalf("delete by non-uploader unexpectedly succeeded")
 	}
@@ -584,6 +652,9 @@ func TestSharedRenameAndDeleteRequireUploader(t *testing.T) {
 	*actor = 9
 	if err := svc.Rename(context.Background(), sharedChannelID, 60, "good.txt"); err != nil {
 		t.Fatalf("rename by uploader: %v", err)
+	}
+	if err := svc.Move(context.Background(), sharedChannelID, 60, "d:shared-docs"); err != nil {
+		t.Fatalf("move by uploader: %v", err)
 	}
 	if err := svc.Delete(context.Background(), sharedChannelID, 60); err != nil {
 		t.Fatalf("delete by uploader: %v", err)

--- a/backend/services/lifecycle/service.go
+++ b/backend/services/lifecycle/service.go
@@ -168,6 +168,10 @@ func (s *Service) kickoffPersonalBackfill(ctx context.Context, channelID int64) 
 
 	go func() {
 		defer func() {
+			if r := recover(); r != nil {
+				s.warnf("backfill panic: %v\n", r)
+				s.emit("backfill_error", channelID, fmt.Sprintf("backfill panic: %v", r))
+			}
 			s.backfillMu.Lock()
 			delete(s.backfilling, channelID)
 			s.backfillMu.Unlock()

--- a/frontend/src/modules/auth.js
+++ b/frontend/src/modules/auth.js
@@ -216,37 +216,49 @@ export function setupAuthWindowBindings() {
             const target = document.getElementById("code-target");
             if (target) target.innerText = state.lastLoginPhoneNumber;
             if (row) row.style.display = state.lastLoginPhoneNumber ? "flex" : "none";
+        }).catch((err) => {
+            notify({ level: 'error', title: 'Could not start login', body: String(err) });
         });
     };
 
     window.sendCode = function () {
         const code = document.getElementById("entercode").value;
-        SumbitCode(code).then(() => {
-            showAuthWrapper();
-            hideAllScreens();
-            document.getElementById("passwordcontainer").style.display = "block";
-
-            const hintBox = document.getElementById("hint-box");
-            const hintEl = document.getElementById("hinttext");
-            if (hintEl) hintEl.innerText = "";
-            if (hintBox) hintBox.style.display = "none";
-
-            const pw = document.getElementById("enterpassword");
-            const toggle = document.getElementById("toggle-password");
-            if (pw) pw.type = "password";
-            if (toggle) {
-                toggle.dataset.state = "hidden";
-                toggle.setAttribute("aria-label", "Show password");
-                toggle.setAttribute("title", "Show password");
-            }
+        SumbitCode(code).catch((err) => {
+            notify({ level: 'error', title: 'Could not submit code', body: String(err) });
         });
     };
 
     window.sendPassword = function () {
-        SumbitPassword(document.getElementById("enterpassword").value);
+        SumbitPassword(document.getElementById("enterpassword").value).catch((err) => {
+            notify({ level: 'error', title: 'Could not submit password', body: String(err) });
+        });
     };
 
     window.runtime.EventsOn("login-success", () => showDashboard());
+
+    window.runtime.EventsOn("login-password-required", () => {
+        showAuthWrapper();
+        hideAllScreens();
+        document.getElementById("passwordcontainer").style.display = "block";
+
+        const hintBox = document.getElementById("hint-box");
+        const hintEl = document.getElementById("hinttext");
+        if (hintEl) hintEl.innerText = "";
+        if (hintBox) hintBox.style.display = "none";
+
+        const pw = document.getElementById("enterpassword");
+        const toggle = document.getElementById("toggle-password");
+        if (pw) pw.type = "password";
+        if (toggle) {
+            toggle.dataset.state = "hidden";
+            toggle.setAttribute("aria-label", "Show password");
+            toggle.setAttribute("title", "Show password");
+        }
+    });
+
+    window.runtime.EventsOn("login-error", (msg) => {
+        notify({ level: 'error', title: 'Login failed', body: String(msg || 'Try again.') });
+    });
 
     window.runtime.EventsOn("gothint", (hint) => {
         const hintEl = document.getElementById("hinttext");

--- a/frontend/src/modules/drag-drop.js
+++ b/frontend/src/modules/drag-drop.js
@@ -3,6 +3,7 @@
 import { state } from '../state.js';
 import { MoveFile, MoveFolder, MsgToTdriveSystem } from '../../wailsjs/go/main/App';
 import { notify } from './notifications.js';
+import { humanizeBackendError } from './errors.js';
 
 export function clearDropHighlights() {
     if (state.dragOverEl) {
@@ -53,7 +54,7 @@ async function ensureFileInTdriveSystem(target) {
     );
 
     if (typeof res === "string" && res.startsWith("Error")) {
-        throw new Error(res);
+        throw new Error(humanizeBackendError(res));
     }
 }
 
@@ -84,11 +85,17 @@ export async function performDropMove(newParentId) {
             notify({
                 level: 'error',
                 title: 'Move failed',
-                body: res.replace(/^Error:?\s*/i, ''),
+                body: humanizeBackendError(res),
             });
         } else {
             window.refreshFiles();
         }
+    } catch (err) {
+        notify({
+            level: 'error',
+            title: 'Move failed',
+            body: humanizeBackendError(err),
+        });
     } finally {
         clearDropHighlights();
     }

--- a/frontend/src/modules/errors.js
+++ b/frontend/src/modules/errors.js
@@ -1,0 +1,28 @@
+export function humanizeBackendError(err) {
+    const raw = String(err?.message || err || '').replace(/^Error:?\s*/i, '').trim();
+    const lower = raw.toLowerCase();
+
+    if (!raw) return 'Something went wrong.';
+    if (lower.includes('move would create cycle') || lower.includes('own subfolder')) {
+        return "Can't move a folder into itself or one of its subfolders.";
+    }
+    if (lower.includes('only the uploader can')) {
+        return raw;
+    }
+    if (lower.includes('file is already in this folder') || lower.includes('folder is already here')) {
+        return 'This item is already there.';
+    }
+    if (lower.includes('not found')) {
+        return 'That item no longer exists. Refresh and try again.';
+    }
+    if (lower.includes('invalid target') || lower.includes('target folder not found')) {
+        return 'Choose a valid destination folder.';
+    }
+    if (lower.includes('tg client') || lower.includes('telegram') || lower.includes('network')) {
+        return 'Telegram is not reachable right now. Try again.';
+    }
+    if (lower.includes('encryption password required')) {
+        return 'Enter your encryption password first.';
+    }
+    return raw;
+}

--- a/frontend/src/modules/modals/encryption-password.js
+++ b/frontend/src/modules/modals/encryption-password.js
@@ -67,6 +67,8 @@ export function setupEncryptionPasswordModal() {
 export function openEncryptionPasswordModal() {
     const modal = document.getElementById('encryption-password-modal');
     if (!modal) return Promise.resolve(false);
+    const hintRow = modal.querySelector('#encryption-password-hint');
+    const hintText = modal.querySelector('#encryption-password-hint-text');
     return new Promise((resolve) => {
         if (pending) {
             const prev = pending;

--- a/frontend/src/modules/modals/move.js
+++ b/frontend/src/modules/modals/move.js
@@ -5,6 +5,7 @@ import { icons } from '../../constants.js';
 import { MoveFile, MoveFolder, MsgToTdriveSystem } from '../../../wailsjs/go/main/App';
 import { clearSelection } from '../selection.js';
 import { buildFolderIndex, collectDescendants, getFolderContents } from '../file-list.js';
+import { humanizeBackendError } from '../errors.js';
 
 let movePath = [];
 let moveBlocked = new Set();
@@ -23,7 +24,7 @@ async function ensureFileInTdriveSystem(target) {
     );
 
     if (typeof res === "string" && res.startsWith("Error")) {
-        throw new Error(res);
+        throw new Error(humanizeBackendError(res));
     }
 }
 
@@ -285,7 +286,7 @@ export function setupMoveModal() {
                 for (const folder of folders) {
                     const res = await MoveFolder(String(folder.id), String(destId));
                     if (typeof res === "string" && res.startsWith("Error")) {
-                        throw new Error(res);
+                        throw new Error(humanizeBackendError(res));
                     }
                 }
 
@@ -293,19 +294,19 @@ export function setupMoveModal() {
                     await ensureFileInTdriveSystem(file);
                     const res = await MoveFile(Number(file.id), String(destId));
                     if (typeof res === "string" && res.startsWith("Error")) {
-                        throw new Error(res);
+                        throw new Error(humanizeBackendError(res));
                     }
                 }
             } else if (target.type === "folder") {
                 const res = await MoveFolder(String(target.id), String(destId));
                 if (typeof res === "string" && res.startsWith("Error")) {
-                    throw new Error(res);
+                    throw new Error(humanizeBackendError(res));
                 }
             } else {
                 await ensureFileInTdriveSystem(target);
                 const res = await MoveFile(Number(target.id), String(destId));
                 if (typeof res === "string" && res.startsWith("Error")) {
-                    throw new Error(res);
+                    throw new Error(humanizeBackendError(res));
                 }
             }
 
@@ -313,7 +314,7 @@ export function setupMoveModal() {
             clearSelection();
             window.refreshFiles();
         } catch (err) {
-            setMoveError(err?.message || String(err));
+            setMoveError(humanizeBackendError(err));
         } finally {
             updateMoveConfirm();
         }

--- a/frontend/src/modules/modals/rename.js
+++ b/frontend/src/modules/modals/rename.js
@@ -2,6 +2,7 @@
 
 import { state } from '../../state.js';
 import { RenameFile, RenameFolder, MsgToTdriveSystem } from '../../../wailsjs/go/main/App';
+import { humanizeBackendError } from '../errors.js';
 
 async function ensureFileInTdriveSystem(target) {
     if (!target || target.type !== "file") return;
@@ -15,7 +16,7 @@ async function ensureFileInTdriveSystem(target) {
     );
 
     if (typeof res === "string" && res.startsWith("Error")) {
-        throw new Error(res);
+        throw new Error(humanizeBackendError(res));
     }
 }
 
@@ -114,13 +115,13 @@ export function setupRenameModal() {
             }
 
             if (typeof res === "string" && res.startsWith("Error")) {
-                showError(res);
+                showError(humanizeBackendError(res));
                 return;
             }
             close();
             window.refreshFiles();
         } catch (err) {
-            showError(err?.message || String(err));
+            showError(humanizeBackendError(err));
         }
     });
 }

--- a/frontend/src/modules/notif-bell.js
+++ b/frontend/src/modules/notif-bell.js
@@ -200,14 +200,11 @@ function renderBell() {
 }
 
 function startPulseTicker() {
-    // Keep the bell rerendered while transfers are active so the
-    // pulsing dot's CSS animation begins/ends as state changes.
-    if (pulseTickerHandle) return;
-    const tick = () => {
+    if (pulseTickerHandle) cancelAnimationFrame(pulseTickerHandle);
+    pulseTickerHandle = requestAnimationFrame(() => {
+        pulseTickerHandle = null;
         renderBell();
-        pulseTickerHandle = requestAnimationFrame(tick);
-    };
-    pulseTickerHandle = requestAnimationFrame(tick);
+    });
 }
 
 // ─── HOVER POPOVER ───────────────────────────────────────────────────────────

--- a/frontend/src/modules/notifications.js
+++ b/frontend/src/modules/notifications.js
@@ -55,7 +55,7 @@ export function setupNotifications() {
         if (lastError) dismissNotification(lastError.id);
     });
 
-    requestAnimationFrame(tick);
+    ensureTimer();
 }
 
 // notify enqueues a toast. Returns its id; pass the same id back via
@@ -111,6 +111,7 @@ export function notify(opts = {}) {
         state.toasts.push(entry);
         renderStack();
     }
+    ensureTimer();
     return id;
 }
 
@@ -119,11 +120,16 @@ export function dismissNotification(id) {
     if (idx < 0) return;
     state.toasts.splice(idx, 1);
     renderStack();
+    ensureTimer();
 }
 
 export function clearAllNotifications() {
     state.toasts = [];
     renderStack();
+    if (timer) {
+        cancelAnimationFrame(timer);
+        timer = null;
+    }
 }
 
 function setAllPaused(paused) {
@@ -139,9 +145,20 @@ function setAllPaused(paused) {
             t.expiresAt = now + (t.remainingMs || 0);
         }
     }
+    ensureTimer();
+}
+
+function hasExpiringToasts() {
+    return state.toasts.some((t) => !t.sticky && !t.paused && t.expiresAt);
+}
+
+function ensureTimer() {
+    if (timer || !hasExpiringToasts()) return;
+    timer = requestAnimationFrame(tick);
 }
 
 function tick() {
+    timer = null;
     const now = Date.now();
     let changed = false;
     for (let i = state.toasts.length - 1; i >= 0; i--) {
@@ -153,7 +170,7 @@ function tick() {
         }
     }
     if (changed) renderStack();
-    timer = requestAnimationFrame(tick);
+    ensureTimer();
 }
 
 function renderStack({ keepNode = null } = {}) {


### PR DESCRIPTION
Safety pass across auth, sync/projection, and file handling. Split into focused, individually-buildable commits.

- config: fail closed on a bad `config.json` instead of creating a new drive; atomic writes
- login: stage guards + buffered channels so code/password submits can't deadlock; password screen gated on an explicit event
- projection: record and skip rejected replay ops so sync/rebuild keep advancing; reject negative sizes and overflowing file ids
- files: download to a temp file then rename; shared-drive move now respects uploader ownership; panic recovery on background goroutines
- frontend: humanized backend errors, encryption-hint scope fix, idle RAF loops stopped

Folders stay collaborative (wire format has no creator field yet; noted in README). MTProto connection reuse deferred as a perf refactor.

`go build` / `go vet` / `go test ./...` green.
