### PR TITLE
fix: hide auth screens before routing

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,7 @@
 
         <div id="auth-wrapper">
             
-            <div id="setupcontainer" class="auth-box" >
+            <div id="setupcontainer" class="auth-box" style="display: none;">
                 <div class="auth-icon-box">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
                 </div>
@@ -35,7 +35,7 @@
                 <button class="primary-btn" onclick="submitSetup()">Save Configuration</button>
             </div>
 
-            <div id="phonecontainer" class="auth-box"> <div class="auth-icon-box">
+            <div id="phonecontainer" class="auth-box" style="display: none;"> <div class="auth-icon-box">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
                 </div>
                 <h2>Welcome Back</h2>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -8,7 +8,7 @@ import { setupSelectionBar } from './modules/selection.js';
 import { setupDownloadProgress, setupUploadProgress, uploadWithParentID } from './modules/transfers.js';
 import { setupBreadcrumb } from './modules/navigation.js';
 import { setupContextMenu } from './modules/context-menu.js';
-import { setupPasswordReveal, setupAuthWindowBindings, checkStatusAndShowScreen } from './modules/auth.js';
+import { setupPasswordReveal, setupAuthWindowBindings, checkStatusAndShowScreen, hideAllScreens } from './modules/auth.js';
 import { setupFileListWindowBindings, refreshFiles } from './modules/file-list.js';
 import { setupSearchBar, runGlobalSearch } from './modules/search.js';
 
@@ -65,6 +65,7 @@ window.initDelete = function(id, name) {
 // Application initialization
 window.onload = async function() {
     console.log("App loaded. Checking Status...");
+    hideAllScreens();
 
     // Notifications surface — must be set up before any other module that
     // might emit toasts. Bell is the unified history; toasts feed into it.


### PR DESCRIPTION
Hides all auth screens before startup routing finishes.
This prevents setup and phone login from rendering side-by-side while CheckSystemStatus is still pending.