### PR TITLE
fix: retryable login code entry

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/telegram/auth"
 	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgerr"
 )
 
 type ImpCredentials struct {
@@ -27,12 +29,10 @@ type getchanel interface {
 	WaitCode(ctx context.Context) (string, error)
 	WaitPassword(ctx context.Context, hint string) (string, error)
 	SendHint(hint string)
-}
-
-type AuthT struct {
-	Client      *telegram.Client
-	app         getchanel
-	PhoneNumber string
+	// CodeRejected signals that Telegram rejected the last code as invalid.
+	// The flow stays alive and waits for another code, so the UI can let the
+	// user fix a typo instead of restarting login from the phone step.
+	CodeRejected()
 }
 
 func GetConfigPath() string {
@@ -146,50 +146,71 @@ func CheckLogin(ctx context.Context) (bool, error) {
 	return isValid, nil
 }
 
-func (a AuthT) Phone(ctx context.Context) (string, error) {
-	return a.PhoneNumber, nil
-}
-
-func (a AuthT) Code(ctx context.Context, sendcode *tg.AuthSentCode) (string, error) {
-	return a.app.WaitCode(ctx)
-}
-
-func (a AuthT) Password(ctx context.Context) (string, error) {
-	passObj, err := a.Client.API().AccountGetPassword(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	hint := ""
-	if passObj.Hint != "" {
-		hint = "Hint : " + passObj.Hint
-	} else {
-		hint = "NO HINT found"
-	}
-
-	return a.app.WaitPassword(ctx, hint)
-}
-
-func (a AuthT) AcceptTermsOfService(ctx context.Context, tos tg.HelpTermsOfService) error {
-	return nil
-}
-
-func (a AuthT) SignUp(ctx context.Context) (auth.UserInfo, error) {
-	return auth.UserInfo{}, fmt.Errorf("sign-up not implemented: please register manually")
-}
-
+// StartLogin drives the Telegram user-authentication flow: send a code, then
+// sign in. Unlike gotd's one-shot auth.Flow, this keeps the same phone-code
+// hash and re-prompts on an invalid code, so a mistyped code can be corrected
+// without requesting (and waiting for) a brand-new code.
 func StartLogin(ctx context.Context, client *telegram.Client, ch getchanel, phone string) error {
-	authenticator := AuthT{
-		Client:      client,
-		app:         ch,
-		PhoneNumber: phone,
+	return client.Run(ctx, func(ctx context.Context) error {
+		ac := client.Auth()
+
+		status, err := ac.Status(ctx)
+		if err != nil {
+			return err
+		}
+		if status.Authorized {
+			return nil
+		}
+
+		sent, err := ac.SendCode(ctx, phone, auth.SendCodeOptions{})
+		if err != nil {
+			return err
+		}
+		sentCode, ok := sent.(*tg.AuthSentCode)
+		if !ok {
+			return fmt.Errorf("unexpected sent-code type %T", sent)
+		}
+		codeHash := sentCode.PhoneCodeHash
+
+		for {
+			code, err := ch.WaitCode(ctx)
+			if err != nil {
+				return err
+			}
+
+			_, err = ac.SignIn(ctx, phone, code, codeHash)
+			switch {
+			case err == nil:
+				return nil
+			case errors.Is(err, auth.ErrPasswordAuthNeeded):
+				return signInWithPassword(ctx, client, ch)
+			case tgerr.Is(err, "PHONE_CODE_INVALID", "PHONE_CODE_EMPTY"):
+				// Retryable: the code hash is still valid, just ask again.
+				ch.CodeRejected()
+				continue
+			default:
+				// Terminal (expired code, unregistered number, flood, ...).
+				return err
+			}
+		}
+	})
+}
+
+// signInWithPassword completes a 2FA login. The hint is best-effort: failing to
+// fetch it must not block the password prompt.
+func signInWithPassword(ctx context.Context, client *telegram.Client, ch getchanel) error {
+	hint := "NO HINT found"
+	if passObj, err := client.API().AccountGetPassword(ctx); err == nil && passObj.Hint != "" {
+		hint = "Hint : " + passObj.Hint
 	}
 
-	flow := auth.NewFlow(authenticator, auth.SendCodeOptions{})
+	password, err := ch.WaitPassword(ctx, hint)
+	if err != nil {
+		return err
+	}
 
-	return client.Run(ctx, func(ctx context.Context) error {
-		return client.Auth().IfNecessary(ctx, flow)
-	})
+	_, err = client.Auth().Password(ctx, password)
+	return err
 }
 
 func ResolveDriveChannel(ctx context.Context, api *tg.Client, channelID int64) (*tg.InputChannel, *tg.InputPeerChannel, error) {

--- a/backend/services/auth/service.go
+++ b/backend/services/auth/service.go
@@ -117,6 +117,13 @@ func (s *Service) SendHint(hint string) {
 	s.emit("gothint", hint)
 }
 
+// CodeRejected is called by the login flow when Telegram rejects the entered
+// code. The attempt stays alive and loops back to WaitCode, so we only need to
+// tell the UI to clear the field and let the user try again.
+func (s *Service) CodeRejected() {
+	s.emit("login-code-invalid", true)
+}
+
 func (s *Service) WaitCode(ctx context.Context) (string, error) {
 	s.setStage(stageWaitingCode)
 	select {

--- a/backend/services/auth/service_test.go
+++ b/backend/services/auth/service_test.go
@@ -64,6 +64,62 @@ func TestSubmitCodeUnblocksWaitCode(t *testing.T) {
 	}
 }
 
+func TestCodeRejectedEmitsInvalidEvent(t *testing.T) {
+	events := &fakeEvents{}
+	svc := NewService(events)
+
+	svc.CodeRejected()
+
+	if len(events.events) != 1 || events.events[0].name != "login-code-invalid" {
+		t.Fatalf("events = %+v, want one login-code-invalid", events.events)
+	}
+}
+
+func TestCodeRetryDeliversNewCodeAfterRejection(t *testing.T) {
+	events := &fakeEvents{}
+	svc := NewService(events)
+	svc.resetAttempt(stageStarted)
+
+	// The flow asks for a code; the user submits a wrong one.
+	first := make(chan string, 1)
+	go func() {
+		code, _ := svc.WaitCode(context.Background())
+		first <- code
+	}()
+	svc.SubmitCode("11111")
+	if got := <-first; got != "11111" {
+		t.Fatalf("first code = %q, want 11111", got)
+	}
+
+	// Telegram rejects it; the flow loops back and waits for another code.
+	svc.CodeRejected()
+
+	second := make(chan string, 1)
+	go func() {
+		code, _ := svc.WaitCode(context.Background())
+		second <- code
+	}()
+	svc.SubmitCode("22222")
+	select {
+	case got := <-second:
+		if got != "22222" {
+			t.Fatalf("retry code = %q, want 22222", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("retry code was not accepted after rejection")
+	}
+
+	invalid := 0
+	for _, e := range events.events {
+		if e.name == "login-code-invalid" {
+			invalid++
+		}
+	}
+	if invalid != 1 {
+		t.Fatalf("login-code-invalid count = %d, want 1", invalid)
+	}
+}
+
 func TestSubmitPasswordWithoutPasswordRequestDoesNotBlock(t *testing.T) {
 	events := &fakeEvents{}
 	svc := NewService(events)

--- a/frontend/src/modules/auth.js
+++ b/frontend/src/modules/auth.js
@@ -222,7 +222,11 @@ export function setupAuthWindowBindings() {
     };
 
     window.sendCode = function () {
-        const code = document.getElementById("entercode").value;
+        const code = (document.getElementById("entercode").value || "").trim();
+        if (!code) {
+            notify({ level: 'warning', title: 'Enter the code from Telegram' });
+            return;
+        }
         SumbitCode(code).catch((err) => {
             notify({ level: 'error', title: 'Could not submit code', body: String(err) });
         });
@@ -258,6 +262,21 @@ export function setupAuthWindowBindings() {
 
     window.runtime.EventsOn("login-error", (msg) => {
         notify({ level: 'error', title: 'Login failed', body: String(msg || 'Try again.') });
+    });
+
+    // Wrong code: the backend keeps the login attempt alive and waits for a new
+    // code, so stay on the code screen, clear the field, and let the user retry.
+    window.runtime.EventsOn("login-code-invalid", () => {
+        showAuthWrapper();
+        hideAllScreens();
+        document.getElementById("codecontainer").style.display = "block";
+
+        const codeEl = document.getElementById("entercode");
+        if (codeEl) {
+            codeEl.value = "";
+            codeEl.focus();
+        }
+        notify({ level: 'error', title: 'Wrong code', body: 'That code was incorrect — try again.' });
     });
 
     window.runtime.EventsOn("gothint", (hint) => {


### PR DESCRIPTION
Mistyping the SMS code used to dead-end login: gotd's `auth.Flow` returns on `PHONE_CODE_INVALID`, so the attempt died, the code screen stayed up, and resubmitting was rejected ("not waiting for a code").

Replaces the one-shot flow with an explicit `SendCode` → `SignIn` loop that reuses the same phone-code hash, so a wrong code re-prompts in place instead of requesting a fresh SMS. The frontend stays on the code screen, clears the field, and shows a retry message via a new `login-code-invalid` event. 2FA and terminal errors (expired code, unregistered number) behave as before.

`go build` / `go vet` / `go test ./...` (+ `-race` on the auth package) and `npm run build` all green.
