### PR TITLE
chore: add typescript and typed wails data boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
+      - name: Typecheck frontend
+        working-directory: frontend
+        run: npm run typecheck
+
       - name: Build frontend
         working-directory: frontend
         run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ frontend/dist
 .env.local
 secret.json
 *.json
+# Tracked config that the blanket *.json above would otherwise hide.
+!frontend/tsconfig.json
 
 # --- Wails / Build Artifacts ---
 build/bin/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "1.0.0",
       "devDependencies": {
+        "typescript": "^5.6.0",
         "vite": "^3.0.7"
       }
     },
@@ -597,6 +598,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "typescript": "^5.6.0",
     "vite": "^3.0.7"
   }
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,94 @@
+// Typed boundary over the generated Wails bindings.
+//
+// Every read that returns drive data goes through here so the snake_case Go
+// payloads are normalized into the camelCase types in `types.ts` exactly once.
+// UI modules should import from this module instead of calling the raw
+// `wailsjs/go/main/App` functions directly.
+
+import {
+    GetFolderContents as rawGetFolderContents,
+    GetFileList as rawGetFileList,
+    GetOrphanedFiles as rawGetOrphanedFiles,
+    Search as rawSearch,
+} from "../wailsjs/go/main/App";
+import type { backend, main } from "../wailsjs/go/models";
+import type {
+    FileItem,
+    FolderItem,
+    FolderContents,
+    RootFile,
+    SearchHit,
+    SearchHitType,
+} from "./types";
+
+function toFileItem(f: backend.FileMetaData): FileItem {
+    return {
+        msgId: Number(f.msg_id ?? 0),
+        name: String(f.name ?? ""),
+        size: Number(f.size ?? 0),
+        parentId: String(f.parent_id ?? ""),
+        uploadTime: Number(f.upload_time ?? 0),
+        uploaderId: Number(f.uploader_id ?? 0),
+        encrypted: Boolean(f.encrypted),
+        plaintextSize: Number(f.plaintext_size ?? 0),
+    };
+}
+
+function toFolderItem(d: backend.Folder): FolderItem {
+    return {
+        id: String(d.id ?? ""),
+        name: String(d.name ?? ""),
+        parentId: String(d.parent_id ?? ""),
+    };
+}
+
+function toRootFile(f: main.TDriveFile): RootFile {
+    return {
+        msgId: Number(f.id ?? 0),
+        name: String(f.name ?? ""),
+        size: Number(f.size ?? 0),
+        accessHash: Number(f.access_hash ?? 0),
+        date: Number(f.date ?? 0),
+    };
+}
+
+function toSearchHit(h: backend.SearchResult): SearchHit {
+    const type: SearchHitType = h.type === "folder" ? "folder" : "file";
+    return {
+        type,
+        id: String(h.id ?? ""),
+        name: String(h.name ?? ""),
+        parentId: String(h.parent_id ?? ""),
+        size: Number(h.size ?? 0),
+        uploadTime: Number(h.upload_time ?? 0),
+        uploaderId: Number(h.uploader_id ?? 0),
+        path: String(h.path ?? ""),
+    };
+}
+
+/** Subfolders and files under a parent folder, normalized. */
+export async function getFolderContents(parentId: string): Promise<FolderContents> {
+    const fs = await rawGetFolderContents(parentId);
+    return {
+        folders: (fs?.folders ?? []).map(toFolderItem),
+        files: (fs?.files ?? []).map(toFileItem),
+    };
+}
+
+/** Flat list of root files read straight from Telegram history, normalized. */
+export async function getFileList(): Promise<RootFile[]> {
+    const files = await rawGetFileList();
+    return (files ?? []).map(toRootFile);
+}
+
+/** Files whose parent folder was deleted, surfaced in the Orphaned view. */
+export async function getOrphanedFiles(): Promise<FileItem[]> {
+    const files = await rawGetOrphanedFiles();
+    return (files ?? []).map(toFileItem);
+}
+
+/** Search files and folders in the active drive, normalized. */
+export async function search(query: string, limit: number): Promise<SearchHit[]> {
+    const hits = await rawSearch(query, limit);
+    return (hits ?? []).map(toSearchHit);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,53 @@
+// Normalized, camelCase data shapes for the TDrive UI.
+//
+// Wails serializes the Go structs with snake_case JSON tags (msg_id,
+// uploader_id, parent_id, ...). The UI historically read those raw and
+// inconsistently — e.g. `f.uploaderId ?? f.uploader_id`, `f.upload_time` in one
+// module and `f.uploadTime` in another. These interfaces are the single shape
+// the UI should consume; `api.ts` maps each raw Wails response onto them once,
+// so nothing downstream has to guess at field names again.
+
+export interface FileItem {
+    msgId: number;
+    name: string;
+    size: number;
+    parentId: string;
+    uploadTime: number;
+    uploaderId: number;
+    encrypted: boolean;
+    plaintextSize: number;
+}
+
+export interface FolderItem {
+    id: string;
+    name: string;
+    parentId: string;
+}
+
+export interface FolderContents {
+    folders: FolderItem[];
+    files: FileItem[];
+}
+
+// Root listing comes from the leaner Telegram-backed struct (TDriveFile),
+// which keys files by Telegram message id and carries an access hash.
+export interface RootFile {
+    msgId: number;
+    name: string;
+    size: number;
+    accessHash: number;
+    date: number;
+}
+
+export type SearchHitType = "file" | "folder";
+
+export interface SearchHit {
+    type: SearchHitType;
+    id: string;
+    name: string;
+    parentId: string;
+    size: number;
+    uploadTime: number;
+    uploaderId: number;
+    path: string;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
First step of the frontend-health track: a TypeScript foundation that coexists with the existing JS, plus one typed boundary over the Wails bindings.

- `tsconfig.json` with `allowJs` / `checkJs: false`, so existing `.js` is untouched and only new `.ts` is strictly checked. `npm run typecheck` runs `tsc --noEmit`.
- `types.ts`: normalized camelCase DTOs (`FileItem`, `FolderItem`, `SearchHit`, …).
- `api.ts`: typed wrappers over the read calls (folder contents, file list, orphaned, search) that map the snake_case Go payloads onto those DTOs once — the fix for the scattered `f.uploaderId ?? f.uploader_id` and `upload_time` vs `uploadTime` guessing across the UI.

Intentionally **not** wired into the UI modules yet — this is the seam; consumers migrate onto it surface-by-surface in follow-up PRs (file-list first), which keeps each diff reviewable.

Also un-ignores `frontend/tsconfig.json`: `.gitignore` has a blanket `*.json` under "Security" that silently hides config files (worth narrowing later — flagged for a separate cleanup).

`npm run typecheck` and `npm run build` both green.
