### PR TITLE
fix: keep file-list scroll on same-folder refresh

### DIFF
--- a/frontend/src/modules/file-list.js
+++ b/frontend/src/modules/file-list.js
@@ -165,6 +165,10 @@ export function collectDescendants(folderId, children) {
 // re-render can restore the scroll position instead of jumping to the top.
 let lastRenderedFolderId = null;
 
+export function resetFileListScrollRestore() {
+    lastRenderedFolderId = null;
+}
+
 export function refreshFiles() {
     if (state.virtualView === "orphaned") {
         return refreshOrphanView();

--- a/frontend/src/modules/file-list.js
+++ b/frontend/src/modules/file-list.js
@@ -161,6 +161,10 @@ export function collectDescendants(folderId, children) {
     return out;
 }
 
+// Tracks the folder whose rows are currently rendered, so a same-folder
+// re-render can restore the scroll position instead of jumping to the top.
+let lastRenderedFolderId = null;
+
 export function refreshFiles() {
     if (state.virtualView === "orphaned") {
         return refreshOrphanView();
@@ -172,6 +176,12 @@ export function refreshFiles() {
     resetFolderCaches();
     const folderEpoch = state.folderSizeEpoch;
     clearSelection();
+
+    // Preserve scroll on a same-folder re-render (upload, delete, rename,
+    // sync); navigation into a different folder still starts at the top.
+    // Captured before the "Loading…" wipe resets scrollTop.
+    const prevScrollTop = list.scrollTop;
+    const keepScroll = lastRenderedFolderId === requestedFolderId;
 
     list.innerHTML = '<div style="padding:20px; color:#565f89;">Loading...</div>';
     if (storageUsed) {
@@ -299,6 +309,7 @@ export function refreshFiles() {
 
             if (folders.length === 0 && files.length === 0 && orphanCount === 0 && pendingForParent.length === 0) {
                 list.innerHTML = '<div style="padding:20px; color:#565f89;">This folder is empty.</div>';
+                lastRenderedFolderId = requestedFolderId;
                 return;
             }
 
@@ -483,6 +494,14 @@ export function refreshFiles() {
                 }
                 list.appendChild(row);
             });
+
+            // Restore prior scroll on a same-folder re-render. Before
+            // pendingFocus so a just-uploaded/renamed file can still scroll
+            // itself into view and win.
+            lastRenderedFolderId = requestedFolderId;
+            if (keepScroll && state.currentFolderId === requestedFolderId) {
+                list.scrollTop = prevScrollTop;
+            }
 
             if (state.pendingFocus && state.pendingFocus.type === "file") {
                 const targetID = String(state.pendingFocus.id || "");

--- a/frontend/src/modules/search.js
+++ b/frontend/src/modules/search.js
@@ -3,7 +3,7 @@ import { icons } from '../constants.js';
 import { escapeHtml, splitNameAndExt, formatBytes } from '../utils.js';
 import { clearSelection, handleRowSelection } from './selection.js';
 import { renderBreadcrumb } from './navigation.js';
-import { fillUploaderSlot, refreshFolderIndex } from './file-list.js';
+import { fillUploaderSlot, refreshFolderIndex, resetFileListScrollRestore } from './file-list.js';
 import { populateUploaderChips } from './uploaders.js';
 
 let activeToken = 0;
@@ -148,6 +148,7 @@ function clearSearch({ refresh = true } = {}) {
     const input = getSearchInput();
     if (input) input.value = "";
     state.searchQuery = "";
+    resetFileListScrollRestore();
     setHeaderMode(false);
     clearSelection();
     if (refresh) window.refreshFiles();


### PR DESCRIPTION
Capture #file-list scrollTop before the re-render wipe, restore it when the folder is unchanged (upload/delete/rename/sync). Navigating into a folder still starts at top; a just-uploaded file still scrolls into view.
