### PR TITLE
add long-lived connection lifecycle (tgclient)

### DIFF
--- a/backend/tgclient/session.go
+++ b/backend/tgclient/session.go
@@ -1,0 +1,112 @@
+package tgclient
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var errScopeClosed = errors.New("tgclient: connection scope closed")
+
+// liveConn manages a single long-lived connection "scope" shared by every
+// caller, replacing the previous dial-per-call style.
+//
+// scopeFn must: establish the connection, call ready() exactly once when the
+// connection is usable, then block until its ctx is cancelled (returning that
+// ctx's error). In production scopeFn wraps gotd's client.Run; isolating it
+// here keeps this lifecycle unit-testable without a real Telegram connection.
+//
+// The scope starts lazily on the first acquire and is torn down by Close. A
+// scope that exits on its own (dial error, dropped connection) is restarted on
+// the next acquire, so a transient failure doesn't permanently wedge the app.
+type liveConn struct {
+	scopeFn func(ctx context.Context, ready func()) error
+
+	mu      sync.Mutex
+	closed  bool
+	cancel  context.CancelFunc
+	readyCh chan struct{}
+	doneCh  chan struct{}
+	err     error
+}
+
+func newLiveConn(scopeFn func(ctx context.Context, ready func()) error) *liveConn {
+	return &liveConn{scopeFn: scopeFn}
+}
+
+// acquire ensures the scope is running and blocks until it is ready. Returns
+// nil once ready; the caller may then use the connection until its own ctx
+// ends. Returns the caller's ctx error if it is cancelled first, or the
+// scope's error if the scope failed before becoming ready.
+func (l *liveConn) acquire(ctx context.Context) error {
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return errScopeClosed
+	}
+	if l.readyCh == nil {
+		l.start()
+	}
+	readyCh, doneCh := l.readyCh, l.doneCh
+	l.mu.Unlock()
+
+	select {
+	case <-readyCh:
+		return nil
+	case <-doneCh:
+		l.mu.Lock()
+		err := l.err
+		// Drop the dead scope so the next acquire starts a fresh one.
+		if l.readyCh == readyCh {
+			l.readyCh, l.doneCh = nil, nil
+		}
+		l.mu.Unlock()
+		if err == nil {
+			err = errScopeClosed
+		}
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// start launches the scope goroutine. Caller must hold l.mu.
+func (l *liveConn) start() {
+	runCtx, cancel := context.WithCancel(context.Background())
+	readyCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	l.cancel = cancel
+	l.readyCh = readyCh
+	l.doneCh = doneCh
+	l.err = nil
+
+	var once sync.Once
+	ready := func() { once.Do(func() { close(readyCh) }) }
+
+	go func() {
+		err := l.scopeFn(runCtx, ready)
+		l.mu.Lock()
+		l.err = err
+		l.mu.Unlock()
+		cancel()
+		close(doneCh)
+	}()
+}
+
+// Close tears down the running scope (if any) and blocks until it exits.
+// Idempotent; after Close, acquire returns errScopeClosed.
+func (l *liveConn) Close() {
+	l.mu.Lock()
+	l.closed = true
+	cancel := l.cancel
+	doneCh := l.doneCh
+	l.cancel, l.readyCh, l.doneCh = nil, nil, nil
+	l.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if doneCh != nil {
+		<-doneCh
+	}
+}

--- a/backend/tgclient/session.go
+++ b/backend/tgclient/session.go
@@ -22,11 +22,17 @@ var errScopeClosed = errors.New("tgclient: connection scope closed")
 type liveConn struct {
 	scopeFn func(ctx context.Context, ready func()) error
 
-	mu      sync.Mutex
-	closed  bool
+	mu     sync.Mutex
+	closed bool
+	scope  *connScope
+}
+
+type connScope struct {
 	cancel  context.CancelFunc
 	readyCh chan struct{}
 	doneCh  chan struct{}
+	ready   bool
+	done    bool
 	err     error
 }
 
@@ -39,57 +45,90 @@ func newLiveConn(scopeFn func(ctx context.Context, ready func()) error) *liveCon
 // ends. Returns the caller's ctx error if it is cancelled first, or the
 // scope's error if the scope failed before becoming ready.
 func (l *liveConn) acquire(ctx context.Context) error {
-	l.mu.Lock()
-	if l.closed {
-		l.mu.Unlock()
-		return errScopeClosed
-	}
-	if l.readyCh == nil {
-		l.start()
-	}
-	readyCh, doneCh := l.readyCh, l.doneCh
-	l.mu.Unlock()
-
-	select {
-	case <-readyCh:
-		return nil
-	case <-doneCh:
+	for {
 		l.mu.Lock()
-		err := l.err
-		// Drop the dead scope so the next acquire starts a fresh one.
-		if l.readyCh == readyCh {
-			l.readyCh, l.doneCh = nil, nil
+		if l.closed {
+			l.mu.Unlock()
+			return errScopeClosed
 		}
+		if l.scope == nil || l.scope.done {
+			l.start()
+		}
+		scope := l.scope
+		readyCh, doneCh := scope.readyCh, scope.doneCh
 		l.mu.Unlock()
-		if err == nil {
-			err = errScopeClosed
+
+		select {
+		case <-readyCh:
+			l.mu.Lock()
+			if l.scope != scope {
+				l.mu.Unlock()
+				continue
+			}
+			if scope.done {
+				wasReady, err := scope.ready, scope.err
+				l.scope = nil
+				l.mu.Unlock()
+				if wasReady {
+					continue
+				}
+				if err == nil {
+					err = errScopeClosed
+				}
+				return err
+			}
+			l.mu.Unlock()
+			return nil
+		case <-doneCh:
+			l.mu.Lock()
+			if l.scope != scope {
+				l.mu.Unlock()
+				continue
+			}
+			wasReady, err := scope.ready, scope.err
+			l.scope = nil
+			l.mu.Unlock()
+			if wasReady {
+				continue
+			}
+			if err == nil {
+				err = errScopeClosed
+			}
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
 		}
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
 	}
 }
 
 // start launches the scope goroutine. Caller must hold l.mu.
 func (l *liveConn) start() {
 	runCtx, cancel := context.WithCancel(context.Background())
-	readyCh := make(chan struct{})
-	doneCh := make(chan struct{})
-	l.cancel = cancel
-	l.readyCh = readyCh
-	l.doneCh = doneCh
-	l.err = nil
+	scope := &connScope{
+		cancel:  cancel,
+		readyCh: make(chan struct{}),
+		doneCh:  make(chan struct{}),
+	}
+	l.scope = scope
 
 	var once sync.Once
-	ready := func() { once.Do(func() { close(readyCh) }) }
+	ready := func() {
+		once.Do(func() {
+			l.mu.Lock()
+			scope.ready = true
+			l.mu.Unlock()
+			close(scope.readyCh)
+		})
+	}
 
 	go func() {
 		err := l.scopeFn(runCtx, ready)
 		l.mu.Lock()
-		l.err = err
+		scope.err = err
+		scope.done = true
 		l.mu.Unlock()
 		cancel()
-		close(doneCh)
+		close(scope.doneCh)
 	}()
 }
 
@@ -98,15 +137,12 @@ func (l *liveConn) start() {
 func (l *liveConn) Close() {
 	l.mu.Lock()
 	l.closed = true
-	cancel := l.cancel
-	doneCh := l.doneCh
-	l.cancel, l.readyCh, l.doneCh = nil, nil, nil
+	scope := l.scope
+	l.scope = nil
 	l.mu.Unlock()
 
-	if cancel != nil {
-		cancel()
-	}
-	if doneCh != nil {
-		<-doneCh
+	if scope != nil {
+		scope.cancel()
+		<-scope.doneCh
 	}
 }

--- a/backend/tgclient/session_test.go
+++ b/backend/tgclient/session_test.go
@@ -1,0 +1,138 @@
+package tgclient
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func blockingScope(ready func()) func(context.Context, func()) error {
+	return func(ctx context.Context, r func()) error {
+		if ready != nil {
+			ready()
+		}
+		r()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+}
+
+func TestLiveConnAcquireReady(t *testing.T) {
+	lc := newLiveConn(blockingScope(nil))
+	defer lc.Close()
+	if err := lc.acquire(context.Background()); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+}
+
+func TestLiveConnStartsOnceUnderConcurrency(t *testing.T) {
+	var starts int32
+	lc := newLiveConn(func(ctx context.Context, ready func()) error {
+		atomic.AddInt32(&starts, 1)
+		ready()
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	defer lc.Close()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := lc.acquire(context.Background()); err != nil {
+				t.Errorf("acquire: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&starts); got != 1 {
+		t.Fatalf("scope started %d times, want 1", got)
+	}
+}
+
+func TestLiveConnScopeFailsBeforeReady(t *testing.T) {
+	wantErr := errors.New("dial failed")
+	lc := newLiveConn(func(ctx context.Context, ready func()) error {
+		return wantErr // never signals ready
+	})
+	defer lc.Close()
+
+	if err := lc.acquire(context.Background()); !errors.Is(err, wantErr) {
+		t.Fatalf("acquire err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestLiveConnAcquireRespectsCtx(t *testing.T) {
+	block := make(chan struct{})
+	lc := newLiveConn(func(ctx context.Context, ready func()) error {
+		<-block // never becomes ready
+		return nil
+	})
+	defer func() {
+		close(block)
+		lc.Close()
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := lc.acquire(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("acquire err = %v, want context.Canceled", err)
+	}
+}
+
+func TestLiveConnCloseStopsScope(t *testing.T) {
+	stopped := make(chan struct{})
+	lc := newLiveConn(func(ctx context.Context, ready func()) error {
+		ready()
+		<-ctx.Done()
+		close(stopped)
+		return ctx.Err()
+	})
+
+	if err := lc.acquire(context.Background()); err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	lc.Close()
+
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scope did not stop after Close")
+	}
+	if err := lc.acquire(context.Background()); !errors.Is(err, errScopeClosed) {
+		t.Fatalf("acquire after Close = %v, want errScopeClosed", err)
+	}
+}
+
+func TestLiveConnRestartsAfterFailure(t *testing.T) {
+	var attempt int32
+	lc := newLiveConn(func(ctx context.Context, ready func()) error {
+		if atomic.AddInt32(&attempt, 1) == 1 {
+			return errors.New("first attempt fails")
+		}
+		ready()
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	defer lc.Close()
+
+	if err := lc.acquire(context.Background()); err == nil {
+		t.Fatal("first acquire should fail")
+	}
+	if err := lc.acquire(context.Background()); err != nil {
+		t.Fatalf("second acquire should succeed, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempt); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+}
+
+func TestLiveConnCloseWithoutStart(t *testing.T) {
+	lc := newLiveConn(blockingScope(nil))
+	lc.Close() // must not panic or block
+}

--- a/backend/tgclient/session_test.go
+++ b/backend/tgclient/session_test.go
@@ -132,6 +132,50 @@ func TestLiveConnRestartsAfterFailure(t *testing.T) {
 	}
 }
 
+func TestLiveConnRestartsAfterReadyScopeDies(t *testing.T) {
+	var attempt int32
+	dropFirst := make(chan struct{})
+	lc := newLiveConn(func(ctx context.Context, ready func()) error {
+		n := atomic.AddInt32(&attempt, 1)
+		ready()
+		if n == 1 {
+			<-dropFirst
+			return errors.New("connection dropped")
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	defer lc.Close()
+
+	if err := lc.acquire(context.Background()); err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	close(dropFirst)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		lc.mu.Lock()
+		dead := lc.scope != nil && lc.scope.done
+		lc.mu.Unlock()
+		if dead {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("first scope did not exit")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	if err := lc.acquire(context.Background()); err != nil {
+		t.Fatalf("second acquire should restart and succeed, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempt); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+}
+
 func TestLiveConnCloseWithoutStart(t *testing.T) {
 	lc := newLiveConn(blockingScope(nil))
 	lc.Close() // must not panic or block


### PR DESCRIPTION
Foundation for replacing connect-per-call: liveConn owns one shared connection scope (lazy start, ready signal, restart-on-failure, Close). Lifecycle is isolated from gotd so it's unit-tested under -race (7 cases). Not wired into Gotd yet — next slice routes run/runClient through it.
