### PR TITLE
refactor: reuse one long-lived telegram connection

### DIFF
--- a/app.go
+++ b/app.go
@@ -496,6 +496,14 @@ func (a *App) CreateFolder(foldername string, parentID string) (backend.Folder, 
 	}, nil
 }
 
+// shutdown runs on app exit. Tear down the shared Telegram connection so the
+// background Run scope's goroutine exits cleanly.
+func (a *App) shutdown(ctx context.Context) {
+	if a.tg != nil {
+		a.tg.Close()
+	}
+}
+
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 	if a.active == nil {

--- a/app.go
+++ b/app.go
@@ -65,24 +65,14 @@ func (a *App) resolvePeer(ctx context.Context, channelID int64) (tgclient.InputP
 	return a.channelPeer(ctx, channelID)
 }
 
-// channelPeer resolves the active drive's tgclient.InputPeer. Used by every
-// op that needs to send into Telegram. Resolution may hit Telegram once per
-// call; callers should not hold this across long operations.
+// channelPeer resolves the active drive's tgclient.InputPeer through the shared
+// Telegram client. Used by every op that needs to send into Telegram; callers
+// should not hold this across long operations.
 func (a *App) channelPeer(ctx context.Context, channelID int64) (tgclient.InputPeer, error) {
-	client, err := auth.Connect()
-	if err != nil {
-		return tgclient.InputPeer{}, err
+	if a.tg == nil {
+		return tgclient.InputPeer{}, fmt.Errorf("tg client not ready")
 	}
-	var peer tgclient.InputPeer
-	err = client.Run(ctx, func(rctx context.Context) error {
-		_, ip, err := auth.ResolveDriveChannel(rctx, client.API(), channelID)
-		if err != nil {
-			return err
-		}
-		peer = tgclient.InputPeer{ChannelID: ip.ChannelID, AccessHash: ip.AccessHash}
-		return nil
-	})
-	return peer, err
+	return a.tg.ResolveDriveChannel(ctx, channelID)
 }
 
 // emitAndProject sends a control op and projects it locally. Returns the

--- a/backend/tgclient/client.go
+++ b/backend/tgclient/client.go
@@ -182,4 +182,7 @@ type Client interface {
 	HideJoinRequest(ctx context.Context, peer InputPeer, userID, accessHash int64, approved bool) error
 	ResolveDriveChannel(ctx context.Context, channelID int64) (InputPeer, error)
 	LeaveChannel(ctx context.Context, peer InputPeer) error
+
+	// Close releases the shared connection. Called once at app shutdown.
+	Close()
 }

--- a/backend/tgclient/fake.go
+++ b/backend/tgclient/fake.go
@@ -91,6 +91,9 @@ func (f *Fake) SetSelfID(id int64) {
 	f.self = id
 }
 
+// Close satisfies Client. The fake holds no connection.
+func (f *Fake) Close() {}
+
 // SeedHistory pre-loads messages as if they already existed in the channel.
 // Useful for sync tests. Auto-sorts ascending by msg_id.
 func (f *Fake) SeedHistory(msgs ...HistoryMessage) {

--- a/backend/tgclient/gotd.go
+++ b/backend/tgclient/gotd.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	"TDrive/backend/auth"
@@ -17,39 +18,79 @@ import (
 	"github.com/gotd/td/tg"
 )
 
-// Gotd is the production Client implementation. Each call opens a fresh
-// gotd Run scope so we don't have to keep a long-lived client in TDrive's
-// previous style.
+// Gotd is the production Client implementation. It keeps one long-lived gotd
+// Run scope (a single authenticated connection) and dispatches every call onto
+// it, instead of dialing a fresh connection per call. The scope starts lazily
+// on first use and is torn down by Close.
 type Gotd struct {
 	connect func() (*telegram.Client, error)
+	conn    *liveConn
+
+	mu     sync.Mutex
+	client *telegram.Client
 }
 
-// NewGotd constructs a Client that uses the given factory to spin up gotd
-// clients on demand. In production wire this to auth.Connect.
+// NewGotd constructs a Client that dispatches onto one shared connection built
+// from the given factory. In production wire this to auth.Connect.
 func NewGotd(connect func() (*telegram.Client, error)) *Gotd {
-	return &Gotd{connect: connect}
+	g := &Gotd{connect: connect}
+	g.conn = newLiveConn(g.scope)
+	return g
+}
+
+// scope is the liveConn scopeFn: connect, publish the client, signal ready,
+// then block until the connection's context is cancelled (Close or a dropped
+// link). The connection stays usable for concurrent API calls while blocked.
+func (g *Gotd) scope(runCtx context.Context, ready func()) error {
+	client, err := g.connect()
+	if err != nil {
+		return fmt.Errorf("tgclient: connect: %w", err)
+	}
+	return client.Run(runCtx, func(rctx context.Context) error {
+		g.mu.Lock()
+		g.client = client
+		g.mu.Unlock()
+		ready()
+		<-rctx.Done()
+		return rctx.Err()
+	})
+}
+
+// acquire blocks until the shared connection is ready, then returns the live
+// client. The per-call ctx bounds the wait and the API calls the caller makes;
+// the connection itself lives under the liveConn's own lifetime, not ctx.
+func (g *Gotd) acquire(ctx context.Context) (*telegram.Client, error) {
+	if err := g.conn.acquire(ctx); err != nil {
+		return nil, err
+	}
+	g.mu.Lock()
+	client := g.client
+	g.mu.Unlock()
+	if client == nil {
+		return nil, fmt.Errorf("tgclient: client unavailable after connect")
+	}
+	return client, nil
 }
 
 func (g *Gotd) run(ctx context.Context, fn func(ctx context.Context, api *tg.Client) error) error {
-	client, err := g.connect()
+	client, err := g.acquire(ctx)
 	if err != nil {
-		return fmt.Errorf("tgclient: connect: %w", err)
+		return normalizeError(err)
 	}
-	err = client.Run(ctx, func(rctx context.Context) error {
-		return fn(rctx, client.API())
-	})
-	return normalizeError(err)
+	return normalizeError(fn(ctx, client.API()))
 }
 
 func (g *Gotd) runClient(ctx context.Context, fn func(ctx context.Context, client *telegram.Client) error) error {
-	client, err := g.connect()
+	client, err := g.acquire(ctx)
 	if err != nil {
-		return fmt.Errorf("tgclient: connect: %w", err)
+		return normalizeError(err)
 	}
-	err = client.Run(ctx, func(rctx context.Context) error {
-		return fn(rctx, client)
-	})
-	return normalizeError(err)
+	return normalizeError(fn(ctx, client))
+}
+
+// Close tears down the shared connection. Safe to call once at shutdown.
+func (g *Gotd) Close() {
+	g.conn.Close()
 }
 
 func normalizeError(err error) error {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 		},
 		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
 		OnStartup:        app.startup,
+		OnShutdown:       app.shutdown,
 		Bind: []interface{}{
 			app,
 		},


### PR DESCRIPTION
Wire run/runClient onto liveConn: every Telegram call now dispatches onto one shared, persistent client instead of dialing per call. Close() tears it down on app shutdown (OnShutdown hook). Interface gains Close(); Fake is a no-op.

Behavior-changing and NOT fake-covered (gotd's real Run) — needs a manual run-through before merge: login, several concurrent uploads, a download, a sync/refresh, leave idle ~1 min, then logout. Watch for stalls or auth errors.
