### PR TITLE
fix: flood-wait resilient sync

### DIFF
--- a/backend/sync/sync.go
+++ b/backend/sync/sync.go
@@ -15,20 +15,56 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"TDrive/backend/projection"
 	"TDrive/backend/tgclient"
 )
 
-const defaultPageSize = 100
+const (
+	defaultPageSize     = 100
+	maxFloodWaitRetries = 5
+	maxFloodWaitSleep   = 60 * time.Second
+)
 
 type Engine struct {
 	db    *sql.DB
 	tg    tgclient.Client
 	peers PeerResolver
 
+	// OnFloodWait, if set, is invoked before sleeping out a read-side
+	// FLOOD_WAIT. Optional progress/UI hook; nil is fine.
+	OnFloodWait func(channelID int64, wait time.Duration)
+
 	mu    stdsync.Mutex
 	locks map[int64]*stdsync.Mutex
+}
+
+// getHistory wraps tg.GetHistory with bounded FLOOD_WAIT retries. Telegram
+// rate-limits history reads on large channels; without this a single
+// FLOOD_WAIT would abort the whole sync pass.
+func (e *Engine) getHistory(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID, offsetID int64, limit int) ([]tgclient.HistoryMessage, error) {
+	for attempt := 0; ; attempt++ {
+		page, err := e.tg.GetHistory(ctx, peer, minID, offsetID, limit)
+		if err == nil {
+			return page, nil
+		}
+		wait, ok := tgclient.FloodWaitDuration(err)
+		if !ok || attempt >= maxFloodWaitRetries {
+			return nil, err
+		}
+		if wait > maxFloodWaitSleep {
+			wait = maxFloodWaitSleep
+		}
+		if e.OnFloodWait != nil {
+			e.OnFloodWait(channelID, wait)
+		}
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 }
 
 // PeerResolver returns the InputPeer for a given channel id. Channels know
@@ -79,7 +115,7 @@ func (e *Engine) Incremental(ctx context.Context, channelID int64) error {
 	highestSeen := watermark
 	offsetID := int64(0)
 	for {
-		page, err := e.tg.GetHistory(ctx, peer, watermark, offsetID, defaultPageSize)
+		page, err := e.getHistory(ctx, channelID, peer, watermark, offsetID, defaultPageSize)
 		if err != nil {
 			return fmt.Errorf("sync: get history: %w", err)
 		}
@@ -106,9 +142,18 @@ func (e *Engine) Incremental(ctx context.Context, channelID int64) error {
 	}
 
 	SortAscending(allParsed)
+	applied := watermark
 	for _, p := range allParsed {
 		if _, err := projection.ProjectFromOp(e.db, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
+			// Persist progress so a re-run resumes past what already applied
+			// instead of re-fetching the whole channel from the old watermark.
+			if applied > watermark {
+				_ = writeWatermark(e.db, channelID, applied)
+			}
 			return fmt.Errorf("sync: project msg=%d: %w", p.MsgID, err)
+		}
+		if p.MsgID > applied {
+			applied = p.MsgID
 		}
 	}
 	if highestSeen > watermark {
@@ -145,7 +190,7 @@ func (e *Engine) InitialSyncEmptyChannel(ctx context.Context, channelID int64) e
 	var highestSeen int64
 	offsetID := int64(0)
 	for {
-		page, err := e.tg.GetHistory(ctx, peer, 0, offsetID, defaultPageSize)
+		page, err := e.getHistory(ctx, channelID, peer, 0, offsetID, defaultPageSize)
 		if err != nil {
 			return fmt.Errorf("sync: get history: %w", err)
 		}

--- a/backend/sync/sync_test.go
+++ b/backend/sync/sync_test.go
@@ -3,8 +3,10 @@ package sync
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"TDrive/backend/projection"
 	"TDrive/backend/tgclient"
@@ -79,6 +81,46 @@ func TestIncrementalAppliesOpsAscending(t *testing.T) {
 	}
 	if wm != idB {
 		t.Fatalf("watermark = %d, want %d", wm, idB)
+	}
+}
+
+func TestIncrementalRetriesReadFloodWait(t *testing.T) {
+	db, tg, eng := newSyncEnv(t)
+	idA := sendOp(t, tg, projection.Op{Type: projection.OpMkdir, Obj: "d:a", Parent: projection.RootParent, Name: "A"})
+
+	var hooks int
+	eng.OnFloodWait = func(channelID int64, wait time.Duration) { hooks++ }
+	tg.InjectReadFloodWaits(2) // first two history reads flood-wait, then succeed
+
+	if err := eng.Incremental(context.Background(), testChan); err != nil {
+		t.Fatalf("incremental: %v", err)
+	}
+	if !projection.FolderExists(db, testChan, "d:a") {
+		t.Fatal("d:a missing after flood-wait retry")
+	}
+	if hooks != 2 {
+		t.Fatalf("OnFloodWait fired %d times, want 2", hooks)
+	}
+	var wm int64
+	if err := db.QueryRow(`SELECT last_synced_msg FROM channels WHERE channel_id = ?`, testChan).Scan(&wm); err != nil {
+		t.Fatalf("watermark: %v", err)
+	}
+	if wm != idA {
+		t.Fatalf("watermark = %d, want %d", wm, idA)
+	}
+}
+
+func TestIncrementalFailsAfterMaxFloodRetries(t *testing.T) {
+	_, tg, eng := newSyncEnv(t)
+	sendOp(t, tg, projection.Op{Type: projection.OpMkdir, Obj: "d:a", Parent: projection.RootParent, Name: "A"})
+	tg.InjectReadFloodWaits(maxFloodWaitRetries + 2) // never recovers within the retry budget
+
+	err := eng.Incremental(context.Background(), testChan)
+	if err == nil {
+		t.Fatal("expected error after exhausting flood-wait retries")
+	}
+	if !errors.Is(err, tgclient.ErrFloodWait) {
+		t.Fatalf("err = %v, want flood-wait", err)
 	}
 }
 

--- a/backend/tgclient/fake.go
+++ b/backend/tgclient/fake.go
@@ -28,6 +28,7 @@ type Fake struct {
 	sentFiles     []SentFile
 	deletedBatch  [][]int64
 	floodWait     int // counter; pre-injects ErrFloodWait this many times before succeeding
+	readFloodWait int // counter; pre-injects ErrFloodWait on GetHistory this many times
 	failNextSend  bool
 
 	channels       map[int64]fakeChannel
@@ -114,6 +115,14 @@ func (f *Fake) InjectFloodWaits(n int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.floodWait = n
+}
+
+// InjectReadFloodWaits causes the next n GetHistory calls to fail with
+// ErrFloodWait before succeeding. Drives read-side backoff tests.
+func (f *Fake) InjectReadFloodWaits(n int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.readFloodWait = n
 }
 
 // FailNextSend causes the next send to fail with ErrInjectedSend, then
@@ -358,6 +367,11 @@ func (f *Fake) SendFile(ctx context.Context, peer InputPeer, r io.Reader, name, 
 func (f *Fake) GetHistory(ctx context.Context, peer InputPeer, minID, offsetID int64, limit int) ([]HistoryMessage, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
+	if f.readFloodWait > 0 {
+		f.readFloodWait--
+		return nil, NewFloodWaitError(time.Millisecond)
+	}
 
 	if limit <= 0 {
 		limit = 100


### PR DESCRIPTION
GetHistory now retries on FLOOD_WAIT (capped, ctx-cancellable, optional OnFloodWait hook) instead of aborting the whole sync pass. Incremental also persists a partial watermark on mid-apply failure so a re-run resumes instead of refetching the channel. Unit-tested via a new Fake read-flood injector. (Bounded-memory streaming via forward pagination is a separate, larger follow-up.)
