### PR TITLE
fix: keyboard + focus for destructive modals

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -92,7 +92,7 @@
             <aside class="sidebar">
                 <div class="logo">TDrive</div>
 
-                <nav id="drives-nav" class="drives-nav">
+                <nav id="drives-nav" class="drives-nav" tabindex="-1" aria-label="Drives">
                     <div class="drives-scroll">
                         <div class="drives-section">
                             <div class="drives-section-title">My Drive</div>
@@ -197,7 +197,7 @@
                     </div>
                 </div>
 
-                <div id="file-list" class="file-list-box">
+                <div id="file-list" class="file-list-box" tabindex="-1" aria-label="Files">
                     <div class="empty-state">Loading...</div>
                 </div>
             </main>

--- a/frontend/src/modules/modals/delete.js
+++ b/frontend/src/modules/modals/delete.js
@@ -7,6 +7,9 @@ import { ensureNotInsideDeletedFolder } from '../navigation.js';
 import { deleteFolder } from '../drive-data.js';
 import { notify, dismissNotification } from '../notifications.js';
 import { openEncryptionPasswordModal } from './encryption-password.js';
+import { installModalA11y } from './modal-a11y.js';
+
+let a11y = null;
 
 function successTitle(item) {
     const name = String(item?.name || '').trim();
@@ -82,6 +85,7 @@ export function openDeleteModal(target) {
     }
 
     modal.style.display = "flex";
+    a11y?.activate();
 }
 
 export function setupDeleteModal() {
@@ -92,6 +96,7 @@ export function setupDeleteModal() {
     if (!modal || !cancelBtn || !confirmBtn) return;
 
     const close = () => {
+        a11y?.deactivate();
         state.pendingDeleteTarget = null;
         modal.style.display = "none";
     };
@@ -100,6 +105,7 @@ export function setupDeleteModal() {
     modal.addEventListener("click", (e) => {
         if (e.target === modal) close();
     });
+    a11y = installModalA11y(modal, { requestClose: close, initialFocus: cancelBtn });
 
     confirmBtn.addEventListener("click", async () => {
         const target = state.pendingDeleteTarget;

--- a/frontend/src/modules/modals/delete.js
+++ b/frontend/src/modules/modals/delete.js
@@ -105,7 +105,11 @@ export function setupDeleteModal() {
     modal.addEventListener("click", (e) => {
         if (e.target === modal) close();
     });
-    a11y = installModalA11y(modal, { requestClose: close, initialFocus: cancelBtn });
+    a11y = installModalA11y(modal, {
+        requestClose: close,
+        initialFocus: cancelBtn,
+        restoreFocus: '#file-list',
+    });
 
     confirmBtn.addEventListener("click", async () => {
         const target = state.pendingDeleteTarget;

--- a/frontend/src/modules/modals/leave-drive.js
+++ b/frontend/src/modules/modals/leave-drive.js
@@ -22,7 +22,11 @@ export function setupLeaveDriveModal() {
 
     cancel.addEventListener('click', close);
     modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
-    a11y = installModalA11y(modal, { requestClose: close, initialFocus: cancel });
+    a11y = installModalA11y(modal, {
+        requestClose: close,
+        initialFocus: cancel,
+        restoreFocus: '#drives-nav',
+    });
 
     confirm.addEventListener('click', async () => {
         if (!pendingTarget) { close(); return; }

--- a/frontend/src/modules/modals/leave-drive.js
+++ b/frontend/src/modules/modals/leave-drive.js
@@ -2,8 +2,10 @@
 
 import { leaveSharedDrive } from '../channels.js';
 import { notify, dismissNotification } from '../notifications.js';
+import { installModalA11y } from './modal-a11y.js';
 
 let pendingTarget = null;
+let a11y = null;
 
 export function setupLeaveDriveModal() {
     const modal = document.getElementById('leave-drive-modal');
@@ -13,12 +15,14 @@ export function setupLeaveDriveModal() {
     if (!modal || !cancel || !confirm) return;
 
     const close = () => {
+        a11y?.deactivate();
         modal.style.display = 'none';
         pendingTarget = null;
     };
 
     cancel.addEventListener('click', close);
     modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+    a11y = installModalA11y(modal, { requestClose: close, initialFocus: cancel });
 
     confirm.addEventListener('click', async () => {
         if (!pendingTarget) { close(); return; }
@@ -66,4 +70,5 @@ export function openLeaveDriveModal({ id, title }) {
         subtitle.textContent = `Leave "${pendingTarget.title}"? You can rejoin later with the invite link.`;
     }
     modal.style.display = 'flex';
+    a11y?.activate();
 }

--- a/frontend/src/modules/modals/logout.js
+++ b/frontend/src/modules/modals/logout.js
@@ -19,7 +19,11 @@ export function setupLogoutModal() {
 
     cancel.addEventListener('click', () => closeLogoutModal());
     modal.addEventListener('click', (e) => { if (e.target === modal) closeLogoutModal(); });
-    a11y = installModalA11y(modal, { requestClose: closeLogoutModal, initialFocus: cancel });
+    a11y = installModalA11y(modal, {
+        requestClose: closeLogoutModal,
+        initialFocus: cancel,
+        restoreFocus: '#profile-trigger',
+    });
 
     confirm.addEventListener('click', async () => {
         const selected = modal.querySelector('input[name="logout-mode"]:checked');

--- a/frontend/src/modules/modals/logout.js
+++ b/frontend/src/modules/modals/logout.js
@@ -7,6 +7,9 @@
 import { Logout } from '../../../wailsjs/go/main/App';
 import { showAuthWrapper, hideAllScreens } from '../auth.js';
 import { notify, dismissNotification } from '../notifications.js';
+import { installModalA11y } from './modal-a11y.js';
+
+let a11y = null;
 
 export function setupLogoutModal() {
     const modal = document.getElementById('logout-modal');
@@ -16,6 +19,7 @@ export function setupLogoutModal() {
 
     cancel.addEventListener('click', () => closeLogoutModal());
     modal.addEventListener('click', (e) => { if (e.target === modal) closeLogoutModal(); });
+    a11y = installModalA11y(modal, { requestClose: closeLogoutModal, initialFocus: cancel });
 
     confirm.addEventListener('click', async () => {
         const selected = modal.querySelector('input[name="logout-mode"]:checked');
@@ -58,9 +62,11 @@ export function openLogoutModal() {
     const soft = modal.querySelector('input[name="logout-mode"][value="soft"]');
     if (soft) soft.checked = true;
     modal.style.display = 'flex';
+    a11y?.activate();
 }
 
 function closeLogoutModal() {
+    a11y?.deactivate();
     const modal = document.getElementById('logout-modal');
     if (modal) modal.style.display = 'none';
 }

--- a/frontend/src/modules/modals/modal-a11y.js
+++ b/frontend/src/modules/modals/modal-a11y.js
@@ -18,11 +18,33 @@ const FOCUSABLE = [
     '[tabindex]:not([tabindex="-1"])',
 ].join(',');
 
-export function installModalA11y(modal, { requestClose, initialFocus } = {}) {
+function resolveTarget(target) {
+    if (typeof target === 'function') return target();
+    if (typeof target === 'string') return document.querySelector(target);
+    return target || null;
+}
+
+function canFocus(el) {
+    return Boolean(
+        el &&
+        typeof el.focus === 'function' &&
+        el.isConnected &&
+        !el.disabled &&
+        el.offsetParent !== null
+    );
+}
+
+function focusIfPossible(el) {
+    if (!canFocus(el)) return false;
+    el.focus({ preventScroll: true });
+    return true;
+}
+
+export function installModalA11y(modal, { requestClose, initialFocus, restoreFocus } = {}) {
     let lastActive = null;
 
     const focusable = () =>
-        Array.from(modal.querySelectorAll(FOCUSABLE)).filter((el) => el.offsetParent !== null);
+        Array.from(modal.querySelectorAll(FOCUSABLE)).filter(canFocus);
 
     const onKeydown = (e) => {
         if (e.key === 'Escape') {
@@ -33,9 +55,17 @@ export function installModalA11y(modal, { requestClose, initialFocus } = {}) {
         }
         if (e.key !== 'Tab') return;
         const items = focusable();
-        if (items.length === 0) return;
+        if (items.length === 0) {
+            e.preventDefault();
+            return;
+        }
         const first = items[0];
         const last = items[items.length - 1];
+        if (!modal.contains(document.activeElement)) {
+            e.preventDefault();
+            first.focus();
+            return;
+        }
         if (e.shiftKey && document.activeElement === first) {
             e.preventDefault();
             last.focus();
@@ -48,18 +78,22 @@ export function installModalA11y(modal, { requestClose, initialFocus } = {}) {
     return {
         activate() {
             lastActive = document.activeElement;
-            modal.addEventListener('keydown', onKeydown);
+            document.addEventListener('keydown', onKeydown, true);
             requestAnimationFrame(() => {
                 const target =
                     (typeof initialFocus === 'function' ? initialFocus() : initialFocus) || focusable()[0];
-                target?.focus();
+                if (!focusIfPossible(target)) {
+                    focusIfPossible(focusable()[0]);
+                }
             });
         },
         deactivate() {
-            modal.removeEventListener('keydown', onKeydown);
+            document.removeEventListener('keydown', onKeydown, true);
             const restore = lastActive;
             lastActive = null;
-            if (restore && typeof restore.focus === 'function') restore.focus();
+            if (!focusIfPossible(restore)) {
+                focusIfPossible(resolveTarget(restoreFocus));
+            }
         },
     };
 }

--- a/frontend/src/modules/modals/modal-a11y.js
+++ b/frontend/src/modules/modals/modal-a11y.js
@@ -1,0 +1,65 @@
+// Keyboard + focus handling shared by the confirm dialogs.
+//
+// Wire it once in a modal's setup() with the modal element, its close callback,
+// and the element to focus on open (use the safe / Cancel control for
+// destructive modals). Call the returned activate() when the modal opens and
+// deactivate() when it closes.
+//
+// Provides: focus the safe control on open, trap Tab inside the dialog, close
+// on Escape (and stop the global Esc handler from firing behind the overlay),
+// and restore focus to whatever was focused before the modal opened.
+
+const FOCUSABLE = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function installModalA11y(modal, { requestClose, initialFocus } = {}) {
+    let lastActive = null;
+
+    const focusable = () =>
+        Array.from(modal.querySelectorAll(FOCUSABLE)).filter((el) => el.offsetParent !== null);
+
+    const onKeydown = (e) => {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            e.stopPropagation();
+            requestClose?.();
+            return;
+        }
+        if (e.key !== 'Tab') return;
+        const items = focusable();
+        if (items.length === 0) return;
+        const first = items[0];
+        const last = items[items.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+        }
+    };
+
+    return {
+        activate() {
+            lastActive = document.activeElement;
+            modal.addEventListener('keydown', onKeydown);
+            requestAnimationFrame(() => {
+                const target =
+                    (typeof initialFocus === 'function' ? initialFocus() : initialFocus) || focusable()[0];
+                target?.focus();
+            });
+        },
+        deactivate() {
+            modal.removeEventListener('keydown', onKeydown);
+            const restore = lastActive;
+            lastActive = null;
+            if (restore && typeof restore.focus === 'function') restore.focus();
+        },
+    };
+}


### PR DESCRIPTION
Shared modal-a11y helper wired into delete / leave-drive / logout: focus Cancel on open, trap Tab inside, Esc cancels (and stops the global Esc from clearing the selection behind the overlay), restore focus on close. No Enter-to-confirm, so it can't trigger an accidental delete. Needs a quick keyboard smoke-test.
