### PR TITLE
Large-file multipart upload (>2GB)

### DIFF
--- a/app.go
+++ b/app.go
@@ -237,6 +237,16 @@ func (a *App) endUpload() {
 	a.transferMu.Unlock()
 }
 
+// sweepOrphanParts retries deleting the part bodies of already-deleted multipart
+// files whose cleanup didn't finish. It only touches parts behind a tombstone,
+// never an upload still in flight, so it's safe to run at the start of an upload
+// flow. Best effort — a normal session finds nothing and never hits Telegram.
+func (a *App) sweepOrphanParts(ctx context.Context) {
+	if err := a.fileService().SweepOrphanParts(ctx, a.ActiveChannelID()); err != nil {
+		fmt.Printf("warn: orphan-part sweep failed: %v\n", err)
+	}
+}
+
 // CancelUpload cancels the in-flight upload or import: in-flight sends abort and
 // the rest are skipped. The frontend marks the affected transfers canceled.
 func (a *App) CancelUpload() {
@@ -278,9 +288,9 @@ func (a *App) CancelDownload() {
 }
 
 func (a *App) UploadToDriveFS(filePaths []string, parentIDs []string, encrypt bool) ([]backend.FileMetaData, error) {
-	a.applyUploadLimit(a.fileService())
 	ctx := a.beginUpload()
 	defer a.endUpload()
+	a.sweepOrphanParts(ctx)
 	files, err := a.fileService().Upload(ctx, a.ActiveChannelID(), filePaths, parentIDs, encrypt)
 	if err != nil {
 		out := make([]backend.FileMetaData, 0, len(files))
@@ -301,7 +311,6 @@ func (a *App) UploadToDriveFS(filePaths []string, parentIDs []string, encrypt bo
 // mutates nothing.
 func (a *App) PlanImport(paths []string, encrypt bool, extractArchives bool) fileservice.ImportPlan {
 	svc := a.fileService()
-	a.applyUploadLimit(svc)
 	return svc.PlanImport(paths, encrypt, extractArchives)
 }
 
@@ -311,25 +320,10 @@ func (a *App) PlanImport(paths []string, encrypt bool, extractArchives bool) fil
 // per-file upload_* events.
 func (a *App) ImportPaths(paths []string, parentID string, encrypt bool, extractArchives bool) error {
 	svc := a.fileService()
-	a.applyUploadLimit(svc)
 	ctx := a.beginUpload()
 	defer a.endUpload()
+	a.sweepOrphanParts(ctx)
 	return svc.RunImport(ctx, a.ActiveChannelID(), paths, parentID, encrypt, extractArchives)
-}
-
-// applyUploadLimit raises the file service's per-file cap to the Premium limit
-// when the account is Telegram Premium; otherwise the standard 2 GiB cap stands.
-func (a *App) applyUploadLimit(svc *fileservice.Service) {
-	svc.MaxUploadBytes = a.accountMaxUploadBytes()
-}
-
-func (a *App) accountMaxUploadBytes() int64 {
-	if a.tg != nil {
-		if p, err := a.tg.SelfProfile(a.ctx); err == nil && p.Premium {
-			return fileservice.MaxUploadBytesPremium
-		}
-	}
-	return fileservice.MaxUploadBytesStandard
 }
 
 func uploadMetaToBackend(f fileservice.Metadata) backend.FileMetaData {

--- a/backend/projection/apply.go
+++ b/backend/projection/apply.go
@@ -42,6 +42,10 @@ func ApplyOp(tx *sql.Tx, channelID int64, msgID int64, op Op, actorID int64) err
 		return applyMkdir(tx, channelID, op)
 	case OpFileUpload, OpMeta:
 		return applyFileMeta(tx, channelID, msgID, op, actorID)
+	case OpFilePart:
+		return applyFilePart(tx, channelID, msgID, op)
+	case OpFileManifest:
+		return applyManifest(tx, channelID, msgID, op, actorID)
 	case OpRename:
 		return applyRename(tx, channelID, op)
 	case OpMove:
@@ -127,6 +131,80 @@ func applyFileMeta(tx *sql.Tx, channelID int64, msgID int64, op Op, actorID int6
 			encryption_version = CASE WHEN excluded.encryption_version > 0 THEN excluded.encryption_version ELSE files.encryption_version END
 	`, channelID, fileMsgID, op.Name, op.FileSize, op.Parent, op.FileUploadTime, actorID,
 		encryptedFlag, op.PlaintextSize, encryptionVersion)
+	return err
+}
+
+// applyFilePart records one part of a multipart file in file_parts. Parts never
+// enter the files table, so they never surface as files or as orphans. The
+// manifest op (applied last, with a higher msg_id) creates the single logical
+// file row that references these parts by upload_uuid.
+func applyFilePart(tx *sql.Tx, channelID int64, msgID int64, op Op) error {
+	if strings.TrimSpace(op.UploadUUID) == "" {
+		return fmt.Errorf("%w: part requires upload uuid", ErrBadOp)
+	}
+	if op.PartIndex < 0 {
+		return fmt.Errorf("%w: part index must be >= 0", ErrBadOp)
+	}
+	if msgID <= 0 {
+		return fmt.Errorf("%w: part requires msg id", ErrBadOp)
+	}
+	// First-write-wins, like applyMkdir: a duplicate part op (same uuid+index)
+	// must not repoint to a different message, which would strand the original
+	// body (delete would clean up the replacement and miss the original).
+	_, err := tx.Exec(`
+		INSERT INTO file_parts (channel_id, upload_uuid, part_index, msg_id, size)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(channel_id, upload_uuid, part_index) DO NOTHING
+	`, channelID, op.UploadUUID, op.PartIndex, msgID, op.FileSize)
+	return err
+}
+
+// applyManifest commits a multipart file: it creates the single logical file
+// row whose identity is the manifest's own msg_id (f:<msgID>), mirroring how a
+// normal file row keys off its upload message. The part rows already exist
+// (their ops carry lower msg_ids), linked by upload_uuid. size is the stored
+// (ciphertext) total; plaintext_size is the display size.
+func applyManifest(tx *sql.Tx, channelID int64, msgID int64, op Op, actorID int64) error {
+	if op.Parent != RootParent && !IsFolderID(op.Parent) {
+		return fmt.Errorf("%w: manifest parent must be root or d:", ErrBadOp)
+	}
+	if strings.TrimSpace(op.Name) == "" {
+		return fmt.Errorf("%w: manifest requires name", ErrBadOp)
+	}
+	if strings.TrimSpace(op.UploadUUID) == "" {
+		return fmt.Errorf("%w: manifest requires upload uuid", ErrBadOp)
+	}
+	if op.PartCount <= 0 {
+		return fmt.Errorf("%w: manifest requires part count", ErrBadOp)
+	}
+	if msgID <= 0 {
+		return fmt.Errorf("%w: manifest requires msg id", ErrBadOp)
+	}
+
+	encryptedFlag := 0
+	if op.Encrypted {
+		encryptedFlag = 1
+	}
+	encryptionVersion := op.EncryptionVersion
+	if op.Encrypted && encryptionVersion == 0 {
+		encryptionVersion = 1
+	}
+	_, err := tx.Exec(`
+		INSERT INTO files (channel_id, msg_id, name, size, parent_id, upload_time, uploader_user_id, tombstoned, encrypted, plaintext_size, encryption_version, upload_uuid, part_count)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?)
+		ON CONFLICT(channel_id, msg_id) DO UPDATE SET
+			name = excluded.name,
+			parent_id = excluded.parent_id,
+			size = CASE WHEN excluded.size > 0 THEN excluded.size ELSE files.size END,
+			upload_time = CASE WHEN excluded.upload_time > 0 THEN excluded.upload_time ELSE files.upload_time END,
+			uploader_user_id = CASE WHEN files.uploader_user_id > 0 THEN files.uploader_user_id ELSE excluded.uploader_user_id END,
+			encrypted = CASE WHEN excluded.encrypted = 1 THEN 1 ELSE files.encrypted END,
+			plaintext_size = CASE WHEN excluded.plaintext_size > 0 THEN excluded.plaintext_size ELSE files.plaintext_size END,
+			encryption_version = CASE WHEN excluded.encryption_version > 0 THEN excluded.encryption_version ELSE files.encryption_version END,
+			upload_uuid = excluded.upload_uuid,
+			part_count = excluded.part_count
+	`, channelID, msgID, op.Name, op.FileSize, op.Parent, op.FileUploadTime, actorID,
+		encryptedFlag, op.PlaintextSize, encryptionVersion, op.UploadUUID, op.PartCount)
 	return err
 }
 

--- a/backend/projection/channels.go
+++ b/backend/projection/channels.go
@@ -45,7 +45,8 @@ func InsertChannel(db *sql.DB, c Channel) error {
 }
 
 // DeleteChannel removes the channel row plus everything scoped to it:
-// replay_log, replay_log_tamper, folders, files, backfill_progress.
+// replay_log, replay_log_tamper, folders, files, file_parts,
+// pending_part_cleanup, backfill_progress.
 //
 // Used by LeaveSharedDrive. Wraps the cascade in a single transaction so a
 // crash mid-delete leaves the channel intact rather than half-deleted.
@@ -61,6 +62,8 @@ func DeleteChannel(db *sql.DB, channelID int64) error {
 
 	for _, q := range []string{
 		`DELETE FROM files WHERE channel_id = ?`,
+		`DELETE FROM file_parts WHERE channel_id = ?`,
+		`DELETE FROM pending_part_cleanup WHERE channel_id = ?`,
 		`DELETE FROM folders WHERE channel_id = ?`,
 		`DELETE FROM replay_log WHERE channel_id = ?`,
 		`DELETE FROM replay_log_tamper WHERE channel_id = ?`,

--- a/backend/projection/multipart.go
+++ b/backend/projection/multipart.go
@@ -1,0 +1,221 @@
+package projection
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// FilePart is one stored segment of a multipart large file, ordered by
+// PartIndex. MsgID is the Telegram document message holding the part bytes;
+// Size is that document's stored (ciphertext) size.
+type FilePart struct {
+	PartIndex int
+	MsgID     int64
+	Size      int64
+}
+
+// MultipartParts returns the ordered parts of the multipart file identified by
+// its manifest msg_id. It returns nil (and no error) for a normal single-message
+// file, i.e. one whose files row carries no upload_uuid — callers treat a nil
+// result as "not multipart, use the single-message path".
+func MultipartParts(db *sql.DB, channelID int64, fileMsgID int64) ([]FilePart, error) {
+	var uuid string
+	err := db.QueryRow(`
+		SELECT upload_uuid FROM files
+		WHERE channel_id = ? AND msg_id = ?
+	`, channelID, fileMsgID).Scan(&uuid)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if uuid == "" {
+		return nil, nil
+	}
+	return PartsForUUID(db, channelID, uuid)
+}
+
+// PartsForUUID returns the parts of an upload grouped by upload_uuid, ordered by
+// part_index ascending.
+func PartsForUUID(db *sql.DB, channelID int64, uuid string) ([]FilePart, error) {
+	rows, err := db.Query(`
+		SELECT part_index, msg_id, size FROM file_parts
+		WHERE channel_id = ? AND upload_uuid = ?
+		ORDER BY part_index ASC
+	`, channelID, uuid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []FilePart
+	for rows.Next() {
+		var p FilePart
+		if err := rows.Scan(&p.PartIndex, &p.MsgID, &p.Size); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// OrphanPartMessages returns Telegram msg_ids of multipart parts whose manifest
+// row exists but is tombstoned — i.e. a deleted file whose part-body cleanup
+// didn't finish. The GC sweep deletes these from Telegram and drops the rows.
+//
+// It deliberately does NOT return parts that have *no* manifest row: those could
+// be an upload still in flight (this client, another instance, or another user
+// on a shared drive) whose manifest simply hasn't landed yet, and deleting them
+// would corrupt that upload. A failed/canceled upload from this client cleans up
+// its own parts inline (see uploadMultipart's abort), so the only orphans we act
+// on here are the safe, definitely-dead ones behind a tombstone.
+func OrphanPartMessages(db *sql.DB, channelID int64) ([]int64, error) {
+	rows, err := db.Query(`
+		SELECT fp.msg_id FROM file_parts fp
+		WHERE fp.channel_id = ?
+		  AND EXISTS (
+			SELECT 1 FROM files f
+			WHERE f.channel_id = fp.channel_id
+			  AND f.upload_uuid = fp.upload_uuid
+			  AND f.tombstoned = 1
+		  )
+		ORDER BY fp.msg_id ASC
+	`, channelID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// DeleteFileParts removes all file_parts rows for an upload uuid. Used by the
+// upload orchestrator's clean-up-and-fail path.
+func DeleteFileParts(db *sql.DB, channelID int64, uuid string) error {
+	_, err := db.Exec(`
+		DELETE FROM file_parts WHERE channel_id = ? AND upload_uuid = ?
+	`, channelID, uuid)
+	return err
+}
+
+// DeleteFilePartsByMsgIDs removes file_parts rows by their Telegram msg_ids.
+// Used by the GC sweep after the corresponding messages are deleted from
+// Telegram. Chunked to stay under SQLite's bound-variable limit.
+func DeleteFilePartsByMsgIDs(db *sql.DB, channelID int64, msgIDs []int64) error {
+	return deleteByMsgIDs(db, "file_parts", channelID, msgIDs)
+}
+
+func deleteByMsgIDs(db *sql.DB, table string, channelID int64, msgIDs []int64) error {
+	const chunk = 500
+	for start := 0; start < len(msgIDs); start += chunk {
+		end := min(start+chunk, len(msgIDs))
+		batch := msgIDs[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, 0, len(batch)+1)
+		args = append(args, channelID)
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		// table is an internal constant, never user input.
+		q := "DELETE FROM " + table + " WHERE channel_id = ? AND msg_id IN (" + strings.Join(placeholders, ",") + ")"
+		if _, err := db.Exec(q, args...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MultipartComplete verifies that a multipart file's parts form a complete,
+// contiguous, correctly-sized set per the manifest, so a sync gap or a missing
+// part can't yield a silently-truncated download. parts must be ordered by
+// part_index ascending (as PartsForUUID returns them).
+func MultipartComplete(db *sql.DB, channelID, fileMsgID int64, parts []FilePart) error {
+	var (
+		partCount int
+		size      int64
+	)
+	if err := db.QueryRow(`SELECT part_count, size FROM files WHERE channel_id = ? AND msg_id = ?`, channelID, fileMsgID).Scan(&partCount, &size); err != nil {
+		return err
+	}
+	if len(parts) != partCount {
+		return fmt.Errorf("multipart file is incomplete: have %d of %d parts", len(parts), partCount)
+	}
+	var sum int64
+	for i, p := range parts {
+		if p.PartIndex != i {
+			return fmt.Errorf("multipart file is incomplete: missing part %d", i)
+		}
+		sum += p.Size
+	}
+	if sum != size {
+		return fmt.Errorf("multipart file is incomplete: parts total %d bytes, expected %d", sum, size)
+	}
+	return nil
+}
+
+// MultipartFileMsgIDs returns the set of live multipart-file msg_ids (manifests).
+// Views that can't operate on a manifest (a text message, not a document) use it
+// to exclude multipart files — e.g. the Photos gallery thumbnail/preview path.
+func MultipartFileMsgIDs(db *sql.DB, channelID int64) (map[int64]bool, error) {
+	rows, err := db.Query(`SELECT msg_id FROM files WHERE channel_id = ? AND upload_uuid != '' AND tombstoned = 0`, channelID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[int64]bool)
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = true
+	}
+	return out, rows.Err()
+}
+
+// QueuePartCleanup records part message ids whose bodies couldn't be deleted
+// during a failed multipart upload's cleanup, so a later sweep can retry them.
+// pending_part_cleanup is local-only (never synced, never replayed), so it can
+// only ever hold this client's own abandoned parts and cannot cause another
+// client's in-flight upload to be swept. It also survives a projection rebuild.
+func QueuePartCleanup(db *sql.DB, channelID int64, msgIDs []int64) error {
+	for _, id := range msgIDs {
+		if _, err := db.Exec(`INSERT OR IGNORE INTO pending_part_cleanup (channel_id, msg_id) VALUES (?, ?)`, channelID, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// PendingPartCleanup returns the queued part message ids awaiting a retry delete.
+func PendingPartCleanup(db *sql.DB, channelID int64) ([]int64, error) {
+	rows, err := db.Query(`SELECT msg_id FROM pending_part_cleanup WHERE channel_id = ? ORDER BY msg_id ASC`, channelID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// ClearPartCleanup removes queued ids once their bodies are deleted.
+func ClearPartCleanup(db *sql.DB, channelID int64, msgIDs []int64) error {
+	return deleteByMsgIDs(db, "pending_part_cleanup", channelID, msgIDs)
+}

--- a/backend/projection/multipart_test.go
+++ b/backend/projection/multipart_test.go
@@ -1,0 +1,278 @@
+package projection
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// applyMultipartUpload applies N part ops then the manifest, the way an upload
+// emits them: parts first (ascending msg_ids), manifest last (its msg_id becomes
+// the file id). Each part is 100 stored bytes.
+func applyMultipartUpload(t *testing.T, db *sql.DB, uuid string, partMsgIDs []int64, manifestMsgID int64, name, parent string, encrypted bool) {
+	t.Helper()
+	for i, msgID := range partMsgIDs {
+		op := Op{Type: OpFilePart, UploadUUID: uuid, PartIndex: i, FileSize: 100}
+		if err := runOp(t, db, testChan, msgID, op); err != nil {
+			t.Fatalf("apply part %d: %v", i, err)
+		}
+	}
+	manifest := Op{
+		Type:       OpFileManifest,
+		UploadUUID: uuid,
+		Parent:     parent,
+		Name:       name,
+		FileSize:   int64(len(partMsgIDs)) * 100,
+		PartCount:  len(partMsgIDs),
+	}
+	if encrypted {
+		manifest.Encrypted = true
+		manifest.PlaintextSize = int64(len(partMsgIDs))*100 - 66
+		manifest.EncryptionVersion = 1
+	}
+	if err := runOp(t, db, testChan, manifestMsgID, manifest); err != nil {
+		t.Fatalf("apply manifest: %v", err)
+	}
+}
+
+func countLiveFilesP(t *testing.T, db *sql.DB) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM files WHERE channel_id = ? AND tombstoned = 0`, testChan).Scan(&n); err != nil {
+		t.Fatalf("count files: %v", err)
+	}
+	return n
+}
+
+func TestManifestCommitsOneFileFromParts(t *testing.T) {
+	db := newTestDB(t)
+	applyMultipartUpload(t, db, "u1", []int64{1, 2, 3}, 4, "movie.mkv", RootParent, false)
+
+	// Exactly one visible file: the manifest. Parts are not files.
+	if n := countLiveFilesP(t, db); n != 1 {
+		t.Fatalf("files = %d, want 1 (the manifest only)", n)
+	}
+	var (
+		uuid      string
+		partCount int
+		size      int64
+	)
+	if err := db.QueryRow(`SELECT upload_uuid, part_count, size FROM files WHERE channel_id = ? AND msg_id = 4`, testChan).
+		Scan(&uuid, &partCount, &size); err != nil {
+		t.Fatalf("read manifest file: %v", err)
+	}
+	if uuid != "u1" || partCount != 3 || size != 300 {
+		t.Fatalf("manifest file: uuid=%q partCount=%d size=%d, want u1,3,300", uuid, partCount, size)
+	}
+
+	parts, err := MultipartParts(db, testChan, 4)
+	if err != nil {
+		t.Fatalf("MultipartParts: %v", err)
+	}
+	if len(parts) != 3 {
+		t.Fatalf("parts = %d, want 3", len(parts))
+	}
+	for i, p := range parts {
+		if p.PartIndex != i || p.MsgID != int64(i+1) {
+			t.Errorf("part %d = %+v, want index %d msg %d", i, p, i, i+1)
+		}
+	}
+
+	// A normal single file (no upload_uuid) returns no parts.
+	if err := runOp(t, db, testChan, 10, Op{Type: OpFileUpload, Parent: RootParent, Name: "single.txt", FileSize: 5}); err != nil {
+		t.Fatalf("single upload: %v", err)
+	}
+	if parts, err := MultipartParts(db, testChan, 10); err != nil || parts != nil {
+		t.Fatalf("single file MultipartParts = %v, %v, want nil,nil", parts, err)
+	}
+}
+
+func TestPartsNeverSurfaceAsFilesOrOrphans(t *testing.T) {
+	db := newTestDB(t)
+	// Parts only, no manifest — a failed or in-flight upload.
+	for i, msgID := range []int64{1, 2, 3} {
+		op := Op{Type: OpFilePart, UploadUUID: "u1", PartIndex: i, FileSize: 100}
+		if err := runOp(t, db, testChan, msgID, op); err != nil {
+			t.Fatalf("apply part: %v", err)
+		}
+	}
+	if n := countLiveFilesP(t, db); n != 0 {
+		t.Fatalf("files = %d, want 0 (parts are not files)", n)
+	}
+	// Parts never appear in a folder listing.
+	_, files, err := ListFolderContents(db, testChan, RootParent)
+	if err != nil {
+		t.Fatalf("ListFolderContents: %v", err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("root listing shows %d files, want 0", len(files))
+	}
+	// Orphan detection (which queries files) must not surface parts.
+	orphans, err := OrphanedFiles(db, testChan)
+	if err != nil {
+		t.Fatalf("OrphanedFiles: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Fatalf("orphans = %d, want 0 (parts must never surface)", len(orphans))
+	}
+	// Parts with no manifest are NOT swept: they could belong to an upload still
+	// in flight (another instance/user on a shared drive) whose manifest hasn't
+	// landed yet. The sweep only acts on parts behind a tombstone.
+	ids, err := OrphanPartMessages(db, testChan)
+	if err != nil {
+		t.Fatalf("OrphanPartMessages: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("orphan parts (no manifest) = %v, want 0 (in-flight protection)", ids)
+	}
+}
+
+func TestCommittedPartsAreNotOrphans(t *testing.T) {
+	db := newTestDB(t)
+	applyMultipartUpload(t, db, "u1", []int64{1, 2, 3}, 4, "a.bin", RootParent, false)
+	ids, err := OrphanPartMessages(db, testChan)
+	if err != nil {
+		t.Fatalf("OrphanPartMessages: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("orphan parts = %v, want 0 (manifest committed)", ids)
+	}
+}
+
+func TestTombstonedMultipartPartsBecomeOrphansThenGCd(t *testing.T) {
+	db := newTestDB(t)
+	applyMultipartUpload(t, db, "u1", []int64{1, 2, 3}, 4, "a.bin", RootParent, false)
+
+	// Delete the file by tombing the manifest.
+	if err := runOp(t, db, testChan, 5, Op{Type: OpTomb, Obj: "f:4"}); err != nil {
+		t.Fatalf("tomb: %v", err)
+	}
+	ids, err := OrphanPartMessages(db, testChan)
+	if err != nil {
+		t.Fatalf("OrphanPartMessages: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("orphan parts after delete = %v, want 3", ids)
+	}
+
+	if err := DeleteFilePartsByMsgIDs(db, testChan, ids); err != nil {
+		t.Fatalf("DeleteFilePartsByMsgIDs: %v", err)
+	}
+	left, err := OrphanPartMessages(db, testChan)
+	if err != nil {
+		t.Fatalf("OrphanPartMessages after GC: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("orphan parts after GC = %v, want 0", left)
+	}
+}
+
+func TestMultipartWireRoundTrip(t *testing.T) {
+	part := Op{Type: OpFilePart, UploadUUID: "abc-123", PartIndex: 5, FileSize: 2048}
+	got, err := Parse(Format(part))
+	if err != nil {
+		t.Fatalf("parse part: %v", err)
+	}
+	if got.Type != OpFilePart || got.UploadUUID != "abc-123" || got.PartIndex != 5 || got.FileSize != 2048 {
+		t.Fatalf("part round-trip = %+v", got)
+	}
+
+	man := Op{
+		Type: OpFileManifest, UploadUUID: "abc-123", Parent: "d:folder",
+		Name: "My File.mkv", FileSize: 5000, PlaintextSize: 4096, PartCount: 3,
+		Encrypted: true, EncryptionVersion: 1, FileUploadTime: 1700,
+	}
+	got, err = Parse(Format(man))
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if got.Type != OpFileManifest || got.UploadUUID != "abc-123" || got.Parent != "d:folder" ||
+		got.Name != "My File.mkv" || got.PartCount != 3 || got.FileSize != 5000 ||
+		got.PlaintextSize != 4096 || !got.Encrypted {
+		t.Fatalf("manifest round-trip = %+v", got)
+	}
+}
+
+func TestMultipartCompleteValidatesParts(t *testing.T) {
+	db := newTestDB(t)
+	applyMultipartUpload(t, db, "u1", []int64{1, 2, 3}, 4, "movie.mkv", RootParent, false)
+	parts, err := MultipartParts(db, testChan, 4)
+	if err != nil || len(parts) != 3 {
+		t.Fatalf("parts = %+v err %v", parts, err)
+	}
+
+	// A complete, contiguous, correctly-sized set passes.
+	if err := MultipartComplete(db, testChan, 4, parts); err != nil {
+		t.Fatalf("complete set should pass: %v", err)
+	}
+	// A missing part is rejected.
+	if err := MultipartComplete(db, testChan, 4, parts[:2]); err == nil {
+		t.Fatal("2 of 3 parts should be rejected")
+	}
+	// A size mismatch (a truncated part) is rejected.
+	short := append([]FilePart(nil), parts...)
+	short[1].Size = 1
+	if err := MultipartComplete(db, testChan, 4, short); err == nil {
+		t.Fatal("size mismatch should be rejected")
+	}
+}
+
+func TestPartFirstWriteWins(t *testing.T) {
+	db := newTestDB(t)
+	if err := runOp(t, db, testChan, 1, Op{Type: OpFilePart, UploadUUID: "u1", PartIndex: 0, FileSize: 100}); err != nil {
+		t.Fatalf("part: %v", err)
+	}
+	// A duplicate part op (same uuid+index) with a different msg_id must not
+	// repoint the part, which would strand the original body.
+	if err := runOp(t, db, testChan, 999, Op{Type: OpFilePart, UploadUUID: "u1", PartIndex: 0, FileSize: 100}); err != nil {
+		t.Fatalf("dup part: %v", err)
+	}
+	parts, err := PartsForUUID(db, testChan, "u1")
+	if err != nil || len(parts) != 1 {
+		t.Fatalf("parts = %+v err %v, want 1", parts, err)
+	}
+	if parts[0].MsgID != 1 {
+		t.Fatalf("part msg_id = %d, want 1 (first write wins)", parts[0].MsgID)
+	}
+}
+
+func TestDeleteChannelClearsFileParts(t *testing.T) {
+	db := newTestDB(t)
+	applyMultipartUpload(t, db, "u1", []int64{1, 2, 3}, 4, "a.bin", RootParent, false)
+	if err := QueuePartCleanup(db, testChan, []int64{9}); err != nil {
+		t.Fatalf("queue cleanup: %v", err)
+	}
+	if parts, _ := PartsForUUID(db, testChan, "u1"); len(parts) != 3 {
+		t.Fatalf("setup: want 3 parts")
+	}
+
+	if err := DeleteChannel(db, testChan); err != nil {
+		t.Fatalf("delete channel: %v", err)
+	}
+
+	if parts, _ := PartsForUUID(db, testChan, "u1"); len(parts) != 0 {
+		t.Fatalf("file_parts survived channel delete = %d, want 0", len(parts))
+	}
+	if ids, _ := PendingPartCleanup(db, testChan); len(ids) != 0 {
+		t.Fatalf("pending_part_cleanup survived channel delete = %v, want none", ids)
+	}
+}
+
+func TestPendingPartCleanupRoundtrip(t *testing.T) {
+	db := newTestDB(t)
+	if err := QueuePartCleanup(db, testChan, []int64{5, 6, 7}); err != nil {
+		t.Fatalf("queue: %v", err)
+	}
+	if err := QueuePartCleanup(db, testChan, []int64{7}); err != nil { // idempotent
+		t.Fatalf("queue dup: %v", err)
+	}
+	ids, err := PendingPartCleanup(db, testChan)
+	if err != nil || len(ids) != 3 {
+		t.Fatalf("pending = %v err %v, want 3", ids, err)
+	}
+	if err := ClearPartCleanup(db, testChan, []int64{5, 6}); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if ids, _ := PendingPartCleanup(db, testChan); len(ids) != 1 || ids[0] != 7 {
+		t.Fatalf("after clear = %v, want [7]", ids)
+	}
+}

--- a/backend/projection/rebuild.go
+++ b/backend/projection/rebuild.go
@@ -29,6 +29,9 @@ func RebuildProjection(db *sql.DB, channelID int64) error {
 	if _, err := tx.Exec(`DELETE FROM encryption WHERE channel_id = ?`, channelID); err != nil {
 		return fmt.Errorf("projection: rebuild clear encryption: %w", err)
 	}
+	if _, err := tx.Exec(`DELETE FROM file_parts WHERE channel_id = ?`, channelID); err != nil {
+		return fmt.Errorf("projection: rebuild clear file_parts: %w", err)
+	}
 
 	rows, err := tx.Query(`
 		SELECT msg_id, op_type, op_payload_json, actor_user_id

--- a/backend/projection/rebuild_test.go
+++ b/backend/projection/rebuild_test.go
@@ -50,6 +50,38 @@ func TestRebuildEmptyChannelClears(t *testing.T) {
 	}
 }
 
+func TestRebuildClearsAndReplaysFileParts(t *testing.T) {
+	db := newRebuildDB(t)
+
+	// A stale file_parts row that no replay_log op accounts for.
+	if _, err := db.Exec(`INSERT INTO file_parts (channel_id, upload_uuid, part_index, msg_id, size) VALUES (?, 'stale', 0, 999, 10)`, testChan); err != nil {
+		t.Fatalf("seed stale part: %v", err)
+	}
+
+	// A real multipart file in the log: two part ops then a manifest.
+	seedReplay(t, db, testChan, 1, Op{Type: OpFilePart, UploadUUID: "u1", PartIndex: 0, FileSize: 100})
+	seedReplay(t, db, testChan, 2, Op{Type: OpFilePart, UploadUUID: "u1", PartIndex: 1, FileSize: 100})
+	seedReplay(t, db, testChan, 3, Op{Type: OpFileManifest, UploadUUID: "u1", Parent: RootParent, Name: "big.bin", FileSize: 200, PartCount: 2})
+
+	if err := RebuildProjection(db, testChan); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	// The stale row is gone — file_parts reflects exactly the replayed log.
+	var staleCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM file_parts WHERE channel_id = ? AND upload_uuid = 'stale'`, testChan).Scan(&staleCount); err != nil {
+		t.Fatalf("count stale: %v", err)
+	}
+	if staleCount != 0 {
+		t.Fatalf("stale file_parts survived rebuild = %d, want 0", staleCount)
+	}
+	// And the real multipart file rebuilt cleanly.
+	parts, err := MultipartParts(db, testChan, 3)
+	if err != nil || len(parts) != 2 {
+		t.Fatalf("rebuilt parts = %+v (err %v), want 2", parts, err)
+	}
+}
+
 func TestRebuildReplaysAscending(t *testing.T) {
 	db := newRebuildDB(t)
 	seedReplay(t, db, testChan, 10, Op{Type: OpMkdir, Obj: "d:a", Parent: RootParent, Name: "First"})

--- a/backend/projection/schema.go
+++ b/backend/projection/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const currentSchemaVersion = 6
+const currentSchemaVersion = 7
 
 func EnsureSchema(db *sql.DB) error {
 	if db == nil {
@@ -83,6 +83,20 @@ func EnsureSchema(db *sql.DB) error {
 			hint                TEXT    NOT NULL DEFAULT '',
 			created_at          INTEGER NOT NULL,
 			version             INTEGER NOT NULL DEFAULT 1
+		);`,
+		`CREATE TABLE IF NOT EXISTS file_parts (
+			channel_id   INTEGER NOT NULL,
+			upload_uuid  TEXT NOT NULL,
+			part_index   INTEGER NOT NULL,
+			msg_id       INTEGER NOT NULL,
+			size         INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (channel_id, upload_uuid, part_index)
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_file_parts_msg ON file_parts(channel_id, msg_id);`,
+		`CREATE TABLE IF NOT EXISTS pending_part_cleanup (
+			channel_id  INTEGER NOT NULL,
+			msg_id      INTEGER NOT NULL,
+			PRIMARY KEY (channel_id, msg_id)
 		);`,
 	}
 
@@ -165,6 +179,11 @@ func MigratePersonalChannel(db *sql.DB, personalChannelID int64) error {
 	}
 	if v < 6 {
 		// replay_log_rejects is created by EnsureSchema above. Nothing to backfill.
+	}
+	if v < 7 {
+		if err := addMultipartColumnsToFiles(tx); err != nil {
+			return err
+		}
 	}
 
 	if _, err := tx.Exec(`DELETE FROM schema_version`); err != nil {
@@ -388,6 +407,8 @@ func createFreshFiles(tx *sql.Tx) error {
 			encrypted           INTEGER NOT NULL DEFAULT 0,
 			plaintext_size      INTEGER NOT NULL DEFAULT 0,
 			encryption_version  INTEGER NOT NULL DEFAULT 0,
+			upload_uuid         TEXT NOT NULL DEFAULT '',
+			part_count          INTEGER NOT NULL DEFAULT 0,
 			PRIMARY KEY (channel_id, msg_id)
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_files_channel_parent
@@ -443,6 +464,34 @@ func addEncryptionHintColumn(tx *sql.Tx) error {
 	}
 	if _, err := tx.Exec(`ALTER TABLE encryption ADD COLUMN hint TEXT NOT NULL DEFAULT ''`); err != nil {
 		return fmt.Errorf("projection: add encryption.hint: %w", err)
+	}
+	return nil
+}
+
+// addMultipartColumnsToFiles tops up an existing files table with the multipart
+// large-file columns. SQLite ADD COLUMN is constant-time and non-destructive.
+// The file_parts table itself is created by EnsureSchema (CREATE IF NOT EXISTS),
+// so this only handles the files-table columns. Idempotent. Skips when files
+// doesn't exist yet — the v0→v1 reshape's createFreshFiles already includes them.
+func addMultipartColumnsToFiles(tx *sql.Tx) error {
+	if !tableExists(tx, "files") {
+		return nil
+	}
+	cols, err := tableColumnSet(tx, "files")
+	if err != nil {
+		return err
+	}
+	stmts := map[string]string{
+		"upload_uuid": `ALTER TABLE files ADD COLUMN upload_uuid TEXT NOT NULL DEFAULT ''`,
+		"part_count":  `ALTER TABLE files ADD COLUMN part_count INTEGER NOT NULL DEFAULT 0`,
+	}
+	for col, stmt := range stmts {
+		if _, present := cols[col]; present {
+			continue
+		}
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("projection: add files.%s: %w", col, err)
+		}
 	}
 	return nil
 }

--- a/backend/projection/types.go
+++ b/backend/projection/types.go
@@ -23,6 +23,13 @@ const (
 	OpTomb       OpType = "tomb"
 	OpMeta       OpType = "meta"
 	OpEncConfig  OpType = "encfg"
+
+	// Multipart large files. A file too big for one Telegram message is stored
+	// as N OpFilePart document messages followed by one OpFileManifest text op
+	// whose msg_id becomes the logical file's identity. Parts never enter the
+	// files table, so they never surface as files or orphans.
+	OpFilePart     OpType = "part"
+	OpFileManifest OpType = "manifest"
 )
 
 type Op struct {
@@ -41,6 +48,13 @@ type Op struct {
 	Encrypted         bool
 	PlaintextSize     int64
 	EncryptionVersion int
+
+	// Multipart large-file metadata. UploadUUID groups the parts and manifest
+	// of one logical file. PartIndex is the 0-based position of a part;
+	// PartCount is the total number of parts (carried on the manifest).
+	UploadUUID string
+	PartIndex  int
+	PartCount  int
 
 	// Personal-drive encryption password metadata. This is safe to store in
 	// Telegram because the master key stays wrapped under the user's password.

--- a/backend/projection/uuid.go
+++ b/backend/projection/uuid.go
@@ -5,3 +5,9 @@ import "github.com/google/uuid"
 func newUUID() string {
 	return uuid.NewString()
 }
+
+// NewUploadUUID returns a fresh random identifier used to group the parts and
+// manifest of one multipart upload.
+func NewUploadUUID() string {
+	return newUUID()
+}

--- a/backend/projection/wire.go
+++ b/backend/projection/wire.go
@@ -104,6 +104,26 @@ func Parse(raw string) (Op, error) {
 		if err := setObj(&op, kv["obj"], FileIDPrefix); err != nil {
 			return Op{}, err
 		}
+	case OpFilePart:
+		if err := setUUID(&op, kv["u"]); err != nil {
+			return Op{}, err
+		}
+		if err := setPartIndex(&op, kv["pix"]); err != nil {
+			return Op{}, err
+		}
+	case OpFileManifest:
+		if err := setUUID(&op, kv["u"]); err != nil {
+			return Op{}, err
+		}
+		if err := setParent(&op, kv["p"]); err != nil {
+			return Op{}, err
+		}
+		if err := setName(&op, kv["n"]); err != nil {
+			return Op{}, err
+		}
+		if err := setPartCount(&op, kv["pc"]); err != nil {
+			return Op{}, err
+		}
 	case OpEncConfig:
 		if err := setB64(&op.KDFSalt, kv["salt"]); err != nil {
 			return Op{}, err
@@ -216,6 +236,25 @@ func Format(op Op) string {
 	case OpRmdir, OpTomb:
 		b.WriteString("|obj=")
 		b.WriteString(op.Obj)
+	case OpFilePart:
+		b.WriteString("|u=")
+		b.WriteString(op.UploadUUID)
+		b.WriteString("|pix=")
+		b.WriteString(strconv.Itoa(op.PartIndex))
+		if op.FileSize > 0 {
+			b.WriteString("|sz=")
+			b.WriteString(strconv.FormatInt(op.FileSize, 10))
+		}
+	case OpFileManifest:
+		b.WriteString("|u=")
+		b.WriteString(op.UploadUUID)
+		b.WriteString("|p=")
+		b.WriteString(op.Parent)
+		b.WriteString("|n=")
+		b.WriteString(url.QueryEscape(op.Name))
+		b.WriteString("|pc=")
+		b.WriteString(strconv.Itoa(op.PartCount))
+		appendFileAttrs(&b, op)
 	case OpEncConfig:
 		b.WriteString("|salt=")
 		b.WriteString(base64.RawURLEncoding.EncodeToString(op.KDFSalt))
@@ -328,5 +367,31 @@ func setName(op *Op, raw string) error {
 		return ErrWireMalformed
 	}
 	op.Name = decoded
+	return nil
+}
+
+func setUUID(op *Op, raw string) error {
+	if raw == "" {
+		return ErrWireMalformed
+	}
+	op.UploadUUID = raw
+	return nil
+}
+
+func setPartIndex(op *Op, raw string) error {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return ErrWireMalformed
+	}
+	op.PartIndex = n
+	return nil
+}
+
+func setPartCount(op *Op, raw string) error {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return ErrWireMalformed
+	}
+	op.PartCount = n
 	return nil
 }

--- a/backend/services/file/import.go
+++ b/backend/services/file/import.go
@@ -120,7 +120,7 @@ func archiveFolderName(p string) string {
 // dialog. encrypt and extractArchives must match what RunImport will be called
 // with so the totals line up. It never mutates anything.
 func (s *Service) PlanImport(paths []string, encrypt, extractArchives bool) ImportPlan {
-	plan := ImportPlan{MaxBytes: s.maxUploadBytes()}
+	plan := ImportPlan{MaxBytes: s.largeFileMaxBytes()}
 	for _, p := range paths {
 		info, err := os.Stat(p)
 		if err != nil {
@@ -145,7 +145,7 @@ func (s *Service) PlanImport(paths []string, encrypt, extractArchives bool) Impo
 }
 
 func (s *Service) planFile(size int64, encrypt bool, plan *ImportPlan) {
-	if uploadByteSize(size, encrypt) > s.maxUploadBytes() {
+	if uploadByteSize(size, encrypt) > s.largeFileMaxBytes() {
 		plan.Oversize++
 		return
 	}
@@ -365,7 +365,7 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 // addFileTask queues a single file for upload, skipping (and counting) it if it
 // exceeds the per-file limit.
 func (s *Service) addFileTask(srcPath string, size int64, parentID string, encrypt bool, tasks *importTasks) {
-	if uploadByteSize(size, encrypt) > s.maxUploadBytes() {
+	if uploadByteSize(size, encrypt) > s.largeFileMaxBytes() {
 		tasks.oversize++
 		return
 	}
@@ -471,7 +471,7 @@ func (s *Service) extractArchiveToTemp(archivePath, tmpRoot string, encrypt bool
 	// could not be uploaded anyway, and the cap stops a decompression bomb (a
 	// tiny entry that expands to fill the disk) from writing more than the limit;
 	// importTree then skips the oversize result.
-	limit := s.maxUploadBytes()
+	limit := s.largeFileMaxBytes()
 	readLimit := limit
 	if readLimit < math.MaxInt64 {
 		readLimit++
@@ -576,7 +576,7 @@ func createUniqueExtractFile(dest string) (*os.File, string, error) {
 }
 
 func (s *Service) maxArchiveExtractBytes() int64 {
-	limit := s.maxUploadBytes()
+	limit := s.largeFileMaxBytes()
 	if limit > math.MaxInt64/archiveExtractedBytesLimitMultiplier {
 		return math.MaxInt64
 	}

--- a/backend/services/file/import_test.go
+++ b/backend/services/file/import_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"TDrive/backend/projection"
@@ -127,21 +128,25 @@ func TestPlanImportCountsTreeAndArchive(t *testing.T) {
 
 func TestPlanImportFlagsOversize(t *testing.T) {
 	svc, _, _, _ := newTestService(t)
-	svc.MaxUploadBytes = 3
+	svc.MaxUploadBytes = 3 // part size 3, hard cap = 3*MaxParts
+	hardCap := int64(3) * int64(MaxParts)
 
 	root := filepath.Join(t.TempDir(), "Big")
-	mkfile(t, filepath.Join(root, "a.txt"), "hello") // 5 bytes, over 3
-	mkfile(t, filepath.Join(root, "b.txt"), "world") // 5 bytes, over 3
+	// 5 bytes: over the part size but well under the hard cap — splittable, so
+	// it counts as an importable file, not oversize.
+	mkfile(t, filepath.Join(root, "split.txt"), "hello")
+	// Over the hard cap: genuinely too large, flagged oversize.
+	mkfile(t, filepath.Join(root, "huge.txt"), strings.Repeat("x", int(hardCap)+50))
 
 	plan := svc.PlanImport([]string{root}, false, false)
-	if plan.Oversize != 2 {
-		t.Errorf("plan.Oversize = %d, want 2", plan.Oversize)
+	if plan.Oversize != 1 {
+		t.Errorf("plan.Oversize = %d, want 1 (only the over-cap file)", plan.Oversize)
 	}
-	if plan.Files != 0 {
-		t.Errorf("plan.Files = %d, want 0 (all oversize)", plan.Files)
+	if plan.Files != 1 {
+		t.Errorf("plan.Files = %d, want 1 (the splittable file)", plan.Files)
 	}
-	if plan.MaxBytes != 3 {
-		t.Errorf("plan.MaxBytes = %d, want 3", plan.MaxBytes)
+	if plan.MaxBytes != hardCap {
+		t.Errorf("plan.MaxBytes = %d, want %d", plan.MaxBytes, hardCap)
 	}
 }
 
@@ -262,11 +267,12 @@ func TestRunImportNameCollisionSuffixes(t *testing.T) {
 func TestRunImportSkipsOversize(t *testing.T) {
 	svc, db, _, _ := newTestService(t)
 	svc.CreateFolder = testFolderCreator(db)
-	svc.MaxUploadBytes = 10
+	svc.MaxUploadBytes = 5 // part size 5, hard cap = 5*MaxParts
+	hardCap := int64(5) * int64(MaxParts)
 
 	root := filepath.Join(t.TempDir(), "Mix")
-	mkfile(t, filepath.Join(root, "small.txt"), "hello")                  // 5 bytes
-	mkfile(t, filepath.Join(root, "big.txt"), "this is over ten bytes!!") // > 10
+	mkfile(t, filepath.Join(root, "small.txt"), "hello")                           // 5 bytes: single upload
+	mkfile(t, filepath.Join(root, "big.txt"), strings.Repeat("x", int(hardCap)+50)) // over the hard cap: skipped
 
 	if err := svc.RunImport(context.Background(), personalChannelID, []string{root}, "", false, false); err != nil {
 		t.Fatalf("RunImport: %v", err)
@@ -346,13 +352,14 @@ func TestRunImportArchiveCollapsesDuplicateRootAndSkipsMacOSMetadata(t *testing.
 func TestRunImportArchiveSkipsOversizeEntry(t *testing.T) {
 	svc, db, _, _ := newTestService(t)
 	svc.CreateFolder = testFolderCreator(db)
-	svc.MaxUploadBytes = 10
+	svc.MaxUploadBytes = 5 // part size 5, hard cap = 5*MaxParts
+	hardCap := int64(5) * int64(MaxParts)
 
-	// big.txt exceeds the cap and must be skipped during extraction/upload;
+	// big.txt exceeds the hard cap and must be skipped during extraction/upload;
 	// small.txt is imported normally.
 	zip := buildZip(t, map[string]string{
 		"small.txt": "hi",
-		"big.txt":   "this content is definitely well over ten bytes",
+		"big.txt":   strings.Repeat("x", int(hardCap)+50),
 	}, nil, nil)
 
 	if err := svc.RunImport(context.Background(), personalChannelID, []string{zip}, "", false, true); err != nil {

--- a/backend/services/file/limits.go
+++ b/backend/services/file/limits.go
@@ -7,33 +7,53 @@ import (
 	tdcrypto "TDrive/backend/crypto"
 )
 
-// Telegram caps a single uploaded file at 2 GB for standard accounts and 4 GB
-// for Premium. We guard against it before uploading so an oversize file fails
-// fast with a clear message (and folder/archive imports can skip it and report)
-// instead of dying mid-stream with an opaque MTProto error.
+// Telegram caps a single uploaded document at ~2 GiB. A file whose stored
+// (ciphertext) size fits in one message uploads as one message; a larger file
+// is split into multiple part messages plus a manifest (see uploadMultipart).
+// The limits are uniform for every account — we don't special-case Premium.
 const (
-	MaxUploadBytesStandard int64 = 2 * 1024 * 1024 * 1024 // 2 GiB
-	MaxUploadBytesPremium  int64 = 4 * 1024 * 1024 * 1024 // 4 GiB
+	// MaxPartBytes is the largest stored (ciphertext) size we put in a single
+	// Telegram message. Kept a hair under Telegram's 2 GiB document limit so
+	// encryption overhead never pushes a part over the wire limit.
+	MaxPartBytes int64 = 1900 * 1024 * 1024 // ~1.855 GiB
+
+	// LargeFileMaxBytes is the largest stored size we will split and upload.
+	// Beyond this a file is rejected rather than producing an unwieldy number
+	// of parts.
+	LargeFileMaxBytes int64 = 40 * 1024 * 1024 * 1024 // 40 GiB
+
+	// MaxParts bounds the parts per file (defense in depth alongside
+	// LargeFileMaxBytes; 40 GiB / ~1.86 GiB ≈ 22).
+	MaxParts = 32
 )
 
-// ErrFileTooLarge is wrapped into the error returned for an oversize file, so
-// import can classify a skipped file with errors.Is.
-var ErrFileTooLarge = errors.New("file exceeds the per-file upload limit")
+// ErrFileTooLarge is wrapped into the error returned for a file beyond the hard
+// cap, so import can classify a skipped file with errors.Is.
+var ErrFileTooLarge = errors.New("file exceeds the maximum upload size")
 
-// maxUploadBytes is the active per-file limit: the Service override when set
-// (raised to the Premium cap once the account is known to be Premium), else the
-// standard 2 GiB cap.
-func (s *Service) maxUploadBytes() int64 {
+// maxPartBytes is the active per-part ceiling: the Service override when set
+// (tests force splitting at small sizes), else MaxPartBytes.
+func (s *Service) maxPartBytes() int64 {
 	if s.MaxUploadBytes > 0 {
 		return s.MaxUploadBytes
 	}
-	return MaxUploadBytesStandard
+	return MaxPartBytes
+}
+
+// largeFileMaxBytes is the active hard cap on a file's stored size. With a part
+// override set (tests), scale to MaxParts parts so the two limits stay
+// consistent; otherwise use LargeFileMaxBytes.
+func (s *Service) largeFileMaxBytes() int64 {
+	if s.MaxUploadBytes > 0 {
+		return s.MaxUploadBytes * int64(MaxParts)
+	}
+	return LargeFileMaxBytes
 }
 
 // uploadByteSize is the number of bytes actually sent to Telegram for a file of
-// the given plaintext size: the ciphertext size when the upload is encrypted
-// (the header + per-chunk tags can push a file just under the limit over it),
-// otherwise the plaintext size itself.
+// the given plaintext size: the ciphertext size when encrypting (the header +
+// per-chunk tags can push a file just under a limit over it), else the plaintext
+// size itself.
 func uploadByteSize(plaintextSize int64, encrypt bool) int64 {
 	if encrypt {
 		return tdcrypto.CiphertextSize(plaintextSize)
@@ -41,15 +61,16 @@ func uploadByteSize(plaintextSize int64, encrypt bool) int64 {
 	return plaintextSize
 }
 
-// checkUploadSize returns an ErrFileTooLarge-wrapped error (with a human-readable
-// message) when the file would exceed the active per-file limit once uploaded.
-func (s *Service) checkUploadSize(name string, plaintextSize int64, encrypt bool) error {
-	limit := s.maxUploadBytes()
-	if uploadByteSize(plaintextSize, encrypt) <= limit {
-		return nil
+// planUpload decides how a file is stored. It returns the stored (on-Telegram)
+// size, whether the file must be split into multiple parts, and an
+// ErrFileTooLarge-wrapped error when the file is beyond the hard cap.
+func (s *Service) planUpload(name string, plaintextSize int64, encrypt bool) (storedSize int64, multipart bool, err error) {
+	storedSize = uploadByteSize(plaintextSize, encrypt)
+	if storedSize > s.largeFileMaxBytes() {
+		return 0, false, fmt.Errorf("%s (%s) exceeds the %s maximum upload size: %w",
+			name, humanByteSize(plaintextSize), humanByteSize(s.largeFileMaxBytes()), ErrFileTooLarge)
 	}
-	return fmt.Errorf("%s (%s) exceeds the %s per-file limit: %w",
-		name, humanByteSize(plaintextSize), humanByteSize(limit), ErrFileTooLarge)
+	return storedSize, storedSize > s.maxPartBytes(), nil
 }
 
 // humanByteSize renders a byte count as a short human-readable string (e.g.

--- a/backend/services/file/limits_test.go
+++ b/backend/services/file/limits_test.go
@@ -16,28 +16,39 @@ func TestUploadByteSize(t *testing.T) {
 	}
 }
 
-func TestCheckUploadSize(t *testing.T) {
+func TestPlanUpload(t *testing.T) {
+	// MaxUploadBytes overrides the part size: 1000 here, hard cap = 1000*MaxParts.
 	s := &Service{MaxUploadBytes: 1000}
+	hardCap := int64(1000) * int64(MaxParts)
 
-	if err := s.checkUploadSize("ok.bin", 900, false); err != nil {
-		t.Errorf("900 under 1000 cap should pass, got %v", err)
+	// At or under the part size: a single upload, no split, no error.
+	if stored, multi, err := s.planUpload("ok.bin", 900, false); err != nil || multi || stored != 900 {
+		t.Errorf("900 plain: stored=%d multi=%v err=%v, want 900,false,nil", stored, multi, err)
 	}
-	if err := s.checkUploadSize("edge.bin", 1000, false); err != nil {
-		t.Errorf("exactly at the cap should pass, got %v", err)
-	}
-
-	err := s.checkUploadSize("big.bin", 1001, false)
-	if err == nil || !errors.Is(err, ErrFileTooLarge) {
-		t.Errorf("1001 over 1000 cap should be ErrFileTooLarge, got %v", err)
+	if _, multi, err := s.planUpload("edge.bin", 1000, false); err != nil || multi {
+		t.Errorf("1000 plain should be single, got multi=%v err=%v", multi, err)
 	}
 
-	// Encryption overhead pushes a file that fits in plaintext over the cap.
-	if err := s.checkUploadSize("enc.bin", 1000, true); err == nil || !errors.Is(err, ErrFileTooLarge) {
-		t.Errorf("encrypted 1000 should exceed a 1000 cap, got %v", err)
+	// Over the part size but under the hard cap: multipart, not an error.
+	if stored, multi, err := s.planUpload("big.bin", 1001, false); err != nil || !multi || stored != 1001 {
+		t.Errorf("1001 plain: stored=%d multi=%v err=%v, want 1001,true,nil", stored, multi, err)
 	}
 
-	// With no override, the standard 2 GiB cap applies: 1 GiB is fine.
-	if err := (&Service{}).checkUploadSize("g.bin", 1<<30, false); err != nil {
-		t.Errorf("1 GiB under the default cap should pass, got %v", err)
+	// Encryption overhead pushes a part-sized file into multipart.
+	if _, multi, err := s.planUpload("enc.bin", 1000, true); err != nil || !multi {
+		t.Errorf("encrypted 1000 should be multipart, got multi=%v err=%v", multi, err)
+	}
+
+	// Exactly at the hard cap is allowed (multipart); beyond it is rejected.
+	if _, multi, err := s.planUpload("max.bin", hardCap, false); err != nil || !multi {
+		t.Errorf("at hard cap: multi=%v err=%v, want true,nil", multi, err)
+	}
+	if _, _, err := s.planUpload("huge.bin", hardCap+1, false); err == nil || !errors.Is(err, ErrFileTooLarge) {
+		t.Errorf("over hard cap should be ErrFileTooLarge, got %v", err)
+	}
+
+	// With no override, a 1 GiB file is well under the part size: single upload.
+	if _, multi, err := (&Service{}).planUpload("g.bin", 1<<30, false); err != nil || multi {
+		t.Errorf("1 GiB default should be single, got multi=%v err=%v", multi, err)
 	}
 }

--- a/backend/services/file/multipart_test.go
+++ b/backend/services/file/multipart_test.go
@@ -1,0 +1,128 @@
+package file
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"TDrive/backend/projection"
+)
+
+// bigBody returns deterministic, non-repeating-ish bytes of length n so a
+// reassembly mistake (wrong order, dropped/duplicated part) shows up.
+func bigBody(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte((i*31 + 7) % 251)
+	}
+	return b
+}
+
+func TestMultipartRoundTripPlain(t *testing.T) {
+	svc, db, _, _ := newTestService(t)
+	svc.MaxUploadBytes = 1000 // force splitting above 1000 stored bytes
+
+	body := bigBody(3500) // -> 4 parts (1000,1000,1000,500)
+	path := writeTempNamedFile(t, "movie.bin", body)
+	files, err := svc.Upload(context.Background(), personalChannelID, []string{path}, []string{""}, false)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("uploaded files = %d, want 1", len(files))
+	}
+
+	parts, err := projection.MultipartParts(db, personalChannelID, int64(files[0].MsgID))
+	if err != nil {
+		t.Fatalf("MultipartParts: %v", err)
+	}
+	if len(parts) != 4 {
+		t.Fatalf("parts = %d, want 4", len(parts))
+	}
+
+	savePath := filepath.Join(t.TempDir(), "out.bin")
+	result := svc.Download(context.Background(), personalChannelID, files[0].MsgID, files[0].MsgID, func(string) (string, error) {
+		return savePath, nil
+	})
+	if result.Status != "success" {
+		t.Fatalf("download = %+v", result)
+	}
+	got, err := os.ReadFile(savePath)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("round-trip mismatch: got %d bytes, want %d", len(got), len(body))
+	}
+}
+
+func TestMultipartRoundTripEncrypted(t *testing.T) {
+	svc, db, _, _ := newTestService(t)
+	svc.MaxUploadBytes = 1000
+	wireEncryption(svc, bytes.Repeat([]byte{5}, 32))
+
+	body := bigBody(5000) // ciphertext ~5066 -> 6 parts
+	path := writeTempNamedFile(t, "secret.bin", body)
+	files, err := svc.Upload(context.Background(), personalChannelID, []string{path}, []string{""}, true)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	parts, err := projection.MultipartParts(db, personalChannelID, int64(files[0].MsgID))
+	if err != nil {
+		t.Fatalf("MultipartParts: %v", err)
+	}
+	if len(parts) < 2 {
+		t.Fatalf("encrypted parts = %d, want >= 2", len(parts))
+	}
+
+	savePath := filepath.Join(t.TempDir(), "secret.out")
+	result := svc.Download(context.Background(), personalChannelID, files[0].MsgID, files[0].MsgID, func(string) (string, error) {
+		return savePath, nil
+	})
+	if result.Status != "success" {
+		t.Fatalf("download = %+v", result)
+	}
+	got, err := os.ReadFile(savePath)
+	if err != nil {
+		t.Fatalf("read downloaded file: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("encrypted round-trip mismatch: got %d bytes, want %d", len(got), len(body))
+	}
+}
+
+func TestMultipartDeleteDropsParts(t *testing.T) {
+	svc, db, _, _ := newTestService(t)
+	svc.MaxUploadBytes = 1000
+
+	body := bigBody(2500) // 3 parts
+	path := writeTempNamedFile(t, "a.bin", body)
+	files, err := svc.Upload(context.Background(), personalChannelID, []string{path}, []string{""}, false)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	manifestMsgID := int64(files[0].MsgID)
+	if parts, _ := projection.MultipartParts(db, personalChannelID, manifestMsgID); len(parts) != 3 {
+		t.Fatalf("parts = %d, want 3", len(parts))
+	}
+
+	if err := svc.Delete(context.Background(), personalChannelID, files[0].MsgID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// The file_parts rows are dropped...
+	if left, _ := projection.MultipartParts(db, personalChannelID, manifestMsgID); len(left) != 0 {
+		t.Fatalf("file_parts after delete = %d, want 0", len(left))
+	}
+	// ...and the file is tombstoned (no longer visible).
+	var tombstoned int
+	if err := db.QueryRow(`SELECT tombstoned FROM files WHERE channel_id = ? AND msg_id = ?`, personalChannelID, manifestMsgID).Scan(&tombstoned); err != nil {
+		t.Fatalf("read file row: %v", err)
+	}
+	if tombstoned != 1 {
+		t.Fatalf("tombstoned = %d, want 1", tombstoned)
+	}
+}

--- a/backend/services/file/service.go
+++ b/backend/services/file/service.go
@@ -209,6 +209,12 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 	}
 
 	for _, item := range uploaded {
+		// Multipart uploads project their own parts + manifest inside
+		// uploadMultipart and return an empty op, so there's nothing to project
+		// here for them.
+		if item.Op.Type == "" {
+			continue
+		}
 		if _, err := projection.ProjectFromOp(
 			s.DB,
 			channelID,
@@ -256,10 +262,11 @@ func (s *Service) uploadSingle(ctx context.Context, uploadID int, filePath strin
 		return Metadata{}, projection.Op{}, "", err
 	}
 
-	// Fail fast on oversize files: Telegram rejects them mid-stream otherwise.
-	// The check uses the ciphertext size when encrypting, since the encryption
-	// overhead can push a file that is just under the limit over it.
-	if err := s.checkUploadSize(filename, plaintextSize, wantEncrypted); err != nil {
+	// Decide single vs multipart, rejecting only files beyond the hard cap.
+	// The ciphertext size is used when encrypting, since the overhead can push
+	// a file that is just under a part boundary over it.
+	storedSize, multipart, err := s.planUpload(filename, plaintextSize, wantEncrypted)
+	if err != nil {
 		return Metadata{}, projection.Op{}, "", err
 	}
 
@@ -267,8 +274,21 @@ func (s *Service) uploadSingle(ctx context.Context, uploadID int, filePath strin
 	if err != nil {
 		return Metadata{}, projection.Op{}, "", err
 	}
-	encrypted := wantEncrypted
 
+	peer, err := s.Peers.ResolvePeer(ctx, channelID)
+	if err != nil {
+		return Metadata{}, projection.Op{}, "", err
+	}
+
+	if multipart {
+		// uploadMultipart sends the parts, projects them, and emits the manifest
+		// (the commit point) itself. Returning an empty op tells the caller not
+		// to re-project this upload.
+		meta, err := s.uploadMultipart(ctx, uploadID, plainFile, filename, plaintextSize, parent, channelID, wantEncrypted, masterKey, peer, storedSize)
+		return meta, projection.Op{}, "", err
+	}
+
+	encrypted := wantEncrypted
 	var uploadSource *os.File = plainFile
 	uploadSize := plaintextSize
 	if encrypted {
@@ -303,11 +323,6 @@ func (s *Service) uploadSingle(ctx context.Context, uploadID int, filePath strin
 	}
 	header := projection.Format(op)
 	caption := header + "\nTDrive: " + filename
-
-	peer, err := s.Peers.ResolvePeer(ctx, channelID)
-	if err != nil {
-		return Metadata{}, projection.Op{}, "", err
-	}
 
 	s.warnf("Starting upload: %s\n", filename)
 	s.emitEvent("upload_start", uploadID, filename, uploadSize, parent)
@@ -351,6 +366,191 @@ func (s *Service) uploadSingle(ctx context.Context, uploadID int, filePath strin
 	}, op, header, nil
 }
 
+// uploadMultipart stores a file too big for one Telegram message as N part
+// documents plus a manifest. The stored byte stream (ciphertext when encrypting,
+// else the plaintext file) is produced once and sliced into <= MaxPartBytes
+// parts; each part is sent and projected, then a manifest op commits the logical
+// file (its msg_id becomes the file id). On any failure the already-sent parts
+// are deleted and no manifest is emitted, so a failed upload leaves nothing
+// visible. Disk use stays bounded — the ciphertext is streamed through a pipe,
+// never materialized whole.
+func (s *Service) uploadMultipart(ctx context.Context, uploadID int, plainFile *os.File, filename string, plaintextSize int64, parent string, channelID int64, encrypt bool, masterKey []byte, peer tgclient.InputPeer, storedSize int64) (Metadata, error) {
+	if s.ActorID == nil {
+		return Metadata{}, fmt.Errorf("actor resolver not ready")
+	}
+	actorID, err := s.ActorID(ctx)
+	if err != nil {
+		return Metadata{}, err
+	}
+
+	partSize := s.maxPartBytes()
+	numParts := int((storedSize + partSize - 1) / partSize)
+	if numParts < 1 {
+		numParts = 1
+	}
+	if numParts > MaxParts {
+		return Metadata{}, fmt.Errorf("%s would split into %d parts (max %d): %w", filename, numParts, MaxParts, ErrFileTooLarge)
+	}
+
+	uploadUUID := projection.NewUploadUUID()
+	s.warnf("Starting multipart upload: %s (%d parts)\n", filename, numParts)
+	s.emitEvent("upload_start", uploadID, filename, storedSize, parent)
+
+	// Produce the stored byte stream. Encrypting streams the ciphertext through
+	// a pipe so the whole ciphertext is never written to disk; plaintext reads
+	// straight from the seekable source file.
+	var storedReader io.Reader = plainFile
+	var closeReader func()
+	if encrypt {
+		pr, pw := io.Pipe()
+		go func() {
+			_ = pw.CloseWithError(tdcrypto.EncryptStream(plainFile, pw, masterKey, plaintextSize))
+		}()
+		storedReader = pr
+		closeReader = func() { _ = pr.Close() }
+	}
+	if closeReader != nil {
+		defer closeReader()
+	}
+
+	partMsgIDs := make([]int64, 0, numParts)
+	abort := func() {
+		// Clean-up-and-fail: drop the parts already sent + their rows, using a
+		// fresh context since ctx may itself be canceled.
+		if len(partMsgIDs) > 0 {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if err := s.deleteMessagesChunked(cleanupCtx, peer, partMsgIDs); err != nil {
+				// Couldn't delete the bodies now; queue them so a later sweep
+				// retries rather than leaking them. These parts have no manifest,
+				// so the tombstone-scoped sweep wouldn't otherwise see them.
+				_ = projection.QueuePartCleanup(s.DB, channelID, partMsgIDs)
+			}
+		}
+		_ = projection.DeleteFileParts(s.DB, channelID, uploadUUID)
+	}
+
+	var (
+		sentBytes    int64
+		progressMu   sync.Mutex
+		lastProgress = time.Now()
+	)
+	for i := 0; i < numParts; i++ {
+		if err := ctx.Err(); err != nil {
+			abort()
+			return Metadata{}, err
+		}
+		partLen := partSize
+		if remaining := storedSize - sentBytes; remaining < partLen {
+			partLen = remaining
+		}
+		partOp := projection.Op{
+			Type:       projection.OpFilePart,
+			UploadUUID: uploadUUID,
+			PartIndex:  i,
+			FileSize:   partLen,
+		}
+		partCaption := projection.Format(partOp)
+		partBase := sentBytes
+		result, err := s.TG.SendFile(ctx, peer, io.LimitReader(storedReader, partLen), fmt.Sprintf("part-%05d", i), partCaption, partLen, func(sent, total int64) {
+			progressMu.Lock()
+			defer progressMu.Unlock()
+			if time.Since(lastProgress) <= 100*time.Millisecond {
+				return
+			}
+			percent := 0.0
+			if storedSize > 0 {
+				percent = float64(partBase+sent) / float64(storedSize) * 100
+				if percent > 100 {
+					percent = 100
+				}
+			}
+			s.emitEvent("upload_progress", uploadID, percent)
+			lastProgress = time.Now()
+		})
+		if err != nil {
+			abort()
+			return Metadata{}, err
+		}
+		if result.MsgID == 0 {
+			abort()
+			return Metadata{}, fmt.Errorf("upload part %d: no msg id", i)
+		}
+		// Track the sent part for cleanup before projecting it, so a projection
+		// failure here still deletes this part's body in abort().
+		partMsgIDs = append(partMsgIDs, result.MsgID)
+		if _, err := projection.ProjectFromOp(s.DB, channelID, result.MsgID, partOp, actorID, partCaption); err != nil {
+			abort()
+			return Metadata{}, err
+		}
+		sentBytes += partLen
+	}
+
+	// Commit: the manifest is a text op whose own msg_id becomes the file id.
+	uploadTime := s.now().Unix()
+	manifestOp := projection.Op{
+		Type:           projection.OpFileManifest,
+		UploadUUID:     uploadUUID,
+		Parent:         parent,
+		Name:           filename,
+		FileSize:       storedSize,
+		FileUploadTime: uploadTime,
+		PartCount:      numParts,
+	}
+	if encrypt {
+		manifestOp.Encrypted = true
+		manifestOp.PlaintextSize = plaintextSize
+		manifestOp.EncryptionVersion = 1
+	}
+	manifestMsgID, err := s.emit(channelID, manifestOp)
+	if err != nil {
+		if manifestMsgID == 0 {
+			// The manifest never reached Telegram: nothing is committed, so clean
+			// up the parts and fail.
+			abort()
+			return Metadata{}, err
+		}
+		// The manifest IS in Telegram (only the local projection failed): the file
+		// is committed and the next sync will project it. Deleting the parts now
+		// would corrupt that committed file, so leave Telegram intact and surface
+		// the error.
+		return Metadata{}, err
+	}
+
+	s.emitEvent("upload_progress", uploadID, 100.0)
+	return Metadata{
+		Name:          filename,
+		Size:          storedSize,
+		MsgID:         int(manifestMsgID),
+		ParentID:      parent,
+		UploadTime:    uploadTime,
+		Encrypted:     encrypt,
+		PlaintextSize: plaintextSize,
+	}, nil
+}
+
+// deleteMessagesChunked deletes Telegram messages in batches of 100 so a large
+// part set stays under the deleteMessages API limit. It returns the first error
+// encountered (nil if every chunk succeeded) so callers can decide whether to
+// drop the local file_parts pointers or keep them for a later retry.
+func (s *Service) deleteMessagesChunked(ctx context.Context, peer tgclient.InputPeer, msgIDs []int64) error {
+	if s.TG == nil || len(msgIDs) == 0 {
+		return nil
+	}
+	const chunk = 100
+	var firstErr error
+	for start := 0; start < len(msgIDs); start += chunk {
+		end := min(start+chunk, len(msgIDs))
+		if err := s.TG.DeleteMessages(ctx, peer, msgIDs[start:end]); err != nil {
+			s.warnf("warn: delete %d message bodies failed: %v\n", end-start, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
 func (s *Service) Download(ctx context.Context, channelID int64, msgID int, lookupID int, chooseSavePath ChooseSavePathFunc) DownloadResult {
 	if err := s.ready(); err != nil {
 		return DownloadResult{Status: "error", Message: err.Error()}
@@ -372,6 +572,19 @@ func (s *Service) Download(ctx context.Context, channelID int64, msgID int, look
 	if err != nil {
 		return DownloadResult{Status: "error", Message: "Error: " + err.Error()}
 	}
+
+	// A multipart file's identity is its manifest (a text op, not a document),
+	// so GetFileDocument would fail. Detect it first and reassemble from parts.
+	fileID := int64(lookupID)
+	if fileID == 0 {
+		fileID = int64(msgID)
+	}
+	if parts, err := projection.MultipartParts(s.DB, channelID, fileID); err != nil {
+		return DownloadResult{Status: "error", Message: "System Error: " + err.Error()}
+	} else if len(parts) > 0 {
+		return s.downloadMultipart(ctx, channelID, fileID, parts, peer, chooseSavePath)
+	}
+
 	doc, err := s.TG.GetFileDocument(ctx, peer, int64(msgID))
 	if err != nil {
 		return downloadResolveError(err)
@@ -440,6 +653,107 @@ func (s *Service) Download(ctx context.Context, channelID int64, msgID int, look
 			return DownloadResult{Status: "error", Message: "Decrypt failed: " + err.Error()}
 		}
 	}
+	if err := finalTmp.Close(); err != nil {
+		return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
+	}
+	if err := replaceDownloadedFile(finalTmpPath, savePath); err != nil {
+		return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
+	}
+	committed = true
+
+	s.emitEvent("download_progress", 100.0)
+	return DownloadResult{
+		Status:    "success",
+		Message:   "Download complete",
+		SavedPath: savePath,
+	}
+}
+
+// downloadMultipart reassembles a multipart file by streaming its parts in
+// order. Plain files append each part to the output; encrypted files stream the
+// concatenated ciphertext through a pipe into DecryptStream, so the only disk
+// use is the final output (never a full ciphertext temp). Progress is aggregate
+// across all parts.
+func (s *Service) downloadMultipart(ctx context.Context, channelID int64, fileID int64, parts []projection.FilePart, peer tgclient.InputPeer, chooseSavePath ChooseSavePathFunc) DownloadResult {
+	// Refuse to reassemble an incomplete part set: a missing part would otherwise
+	// produce a silently-truncated file (plain downloads especially, since
+	// there's no AEAD tag to catch it).
+	if err := projection.MultipartComplete(s.DB, channelID, fileID, parts); err != nil {
+		return DownloadResult{Status: "error", Message: err.Error()}
+	}
+
+	originalName := "tdrive_download"
+	if name := projection.LookupFileName(s.DB, channelID, fileID); name != "" {
+		originalName = name
+	}
+
+	encrypted := false
+	if enc, _, _, err := projection.FileEncryptionMeta(s.DB, channelID, fileID); err == nil {
+		encrypted = enc
+	}
+	masterKey, err := s.requireEncryptionKey(encrypted)
+	if err != nil {
+		return DownloadResult{Status: "error", Message: err.Error()}
+	}
+
+	savePath, err := chooseSavePath(originalName)
+	if err != nil {
+		return DownloadResult{Status: "error", Message: "Failed to choose download location: " + err.Error()}
+	}
+	if savePath == "" {
+		return DownloadResult{Status: "canceled", Message: "Download canceled"}
+	}
+
+	finalTmp, err := os.CreateTemp(filepath.Dir(savePath), ".tdrive-download-*")
+	if err != nil {
+		return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
+	}
+	finalTmpPath := finalTmp.Name()
+	committed := false
+	defer func() {
+		_ = finalTmp.Close()
+		if !committed {
+			_ = os.Remove(finalTmpPath)
+		}
+	}()
+
+	var totalStored int64
+	for _, p := range parts {
+		totalStored += p.Size
+	}
+	progress := s.downloadProgress(totalStored)
+
+	// downloadParts streams every part in order into dst, reporting aggregate
+	// progress by offsetting each part's bytes by the bytes already written.
+	downloadParts := func(dst io.Writer) error {
+		var base int64
+		for _, p := range parts {
+			startBase := base
+			if err := s.TG.DownloadFile(ctx, peer, p.MsgID, dst, func(partDone, _ int64) {
+				progress(startBase+partDone, totalStored)
+			}); err != nil {
+				return err
+			}
+			base += p.Size
+		}
+		return nil
+	}
+
+	if !encrypted {
+		if err := downloadParts(finalTmp); err != nil {
+			return DownloadResult{Status: "error", Message: "Network Error: " + err.Error()}
+		}
+	} else {
+		pr, pw := io.Pipe()
+		go func() {
+			_ = pw.CloseWithError(downloadParts(pw))
+		}()
+		if _, err := tdcrypto.DecryptStream(pr, finalTmp, masterKey); err != nil {
+			_ = pr.CloseWithError(err)
+			return DownloadResult{Status: "error", Message: "Download/decrypt failed: " + err.Error()}
+		}
+	}
+
 	if err := finalTmp.Close(); err != nil {
 		return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
 	}
@@ -723,6 +1037,17 @@ func (s *Service) Delete(ctx context.Context, channelID int64, msgID int) error 
 		return err
 	}
 
+	// Gather the bodies to drop: the file/manifest message plus any multipart
+	// parts. Captured before the tomb while file_parts is intact.
+	bodyMsgIDs := []int64{int64(msgID)}
+	var partMsgIDs []int64
+	if parts, err := projection.MultipartParts(s.DB, channelID, int64(msgID)); err == nil {
+		for _, p := range parts {
+			bodyMsgIDs = append(bodyMsgIDs, p.MsgID)
+			partMsgIDs = append(partMsgIDs, p.MsgID)
+		}
+	}
+
 	// Tomb first: visibility convergence is the contract; body delete is
 	// best-effort. If body cleanup fails, the visible state is still correct.
 	tombOp := projection.Op{
@@ -741,8 +1066,64 @@ func (s *Service) Delete(ctx context.Context, channelID int64, msgID int) error 
 		s.warnf("warn: tomb succeeded but peer resolve failed for msg=%d: %v\n", msgID, err)
 		return nil
 	}
-	if err := s.TG.DeleteMessages(ctx, peer, []int64{int64(msgID)}); err != nil {
-		s.warnf("warn: tomb succeeded but body delete failed for msg=%d: %v\n", msgID, err)
+	if err := s.deleteMessagesChunked(ctx, peer, bodyMsgIDs); err != nil {
+		// Body cleanup failed; keep the file_parts rows so the orphan sweep can
+		// retry the part-body delete later. The file is already tombstoned, so it
+		// stays hidden in the meantime.
+		return nil
+	}
+	if len(partMsgIDs) > 0 {
+		if err := projection.DeleteFilePartsByMsgIDs(s.DB, channelID, partMsgIDs); err != nil {
+			s.warnf("warn: tomb succeeded but dropping file_parts rows failed for msg=%d: %v\n", msgID, err)
+		}
+	}
+	return nil
+}
+
+// SweepOrphanParts cleans up two safe sets of part bodies and removes their
+// local pointers: parts of a deleted file whose cleanup didn't finish (a
+// tombstoned manifest with surviving file_parts rows), and parts queued by a
+// failed upload whose inline cleanup failed (pending_part_cleanup). It never
+// touches parts that merely lack a manifest row, so it cannot disturb an upload
+// still in flight (this client, another instance, or another user on a shared
+// drive).
+func (s *Service) SweepOrphanParts(ctx context.Context, channelID int64) error {
+	if err := s.ready(); err != nil {
+		return err
+	}
+	if channelID == 0 || s.TG == nil || s.Peers == nil {
+		return nil
+	}
+	tombParts, err := projection.OrphanPartMessages(s.DB, channelID)
+	if err != nil {
+		return err
+	}
+	pending, err := projection.PendingPartCleanup(s.DB, channelID)
+	if err != nil {
+		return err
+	}
+	if len(tombParts) == 0 && len(pending) == 0 {
+		return nil
+	}
+	peer, err := s.Peers.ResolvePeer(ctx, channelID)
+	if err != nil {
+		return err
+	}
+	if len(tombParts) > 0 {
+		if err := s.deleteMessagesChunked(ctx, peer, tombParts); err != nil {
+			return err // keep the rows; retry next sweep
+		}
+		if err := projection.DeleteFilePartsByMsgIDs(s.DB, channelID, tombParts); err != nil {
+			return err
+		}
+	}
+	if len(pending) > 0 {
+		if err := s.deleteMessagesChunked(ctx, peer, pending); err != nil {
+			return err // keep the queue; retry next sweep
+		}
+		if err := projection.ClearPartCleanup(s.DB, channelID, pending); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/backend/services/folder/service.go
+++ b/backend/services/folder/service.go
@@ -284,18 +284,52 @@ func (s *Service) deleteBodiesBestEffort(ctx context.Context, channelID int64, f
 	if len(files) == 0 || s.TG == nil || s.Peers == nil {
 		return
 	}
+	// Each file's body is its own message; a multipart file also has N part
+	// document bodies that must be deleted too (and their file_parts rows).
 	ids := make([]int64, 0, len(files))
+	var partIDs []int64
 	for _, file := range files {
 		ids = append(ids, file.MsgID)
+		if parts, err := projection.MultipartParts(s.DB, channelID, file.MsgID); err == nil {
+			for _, p := range parts {
+				ids = append(ids, p.MsgID)
+				partIDs = append(partIDs, p.MsgID)
+			}
+		}
 	}
 	peer, err := s.Peers.ResolvePeer(ctx, channelID)
 	if err != nil {
 		s.warnf("warn: folder tomb succeeded but peer resolve failed for %d file bodies: %v\n", len(ids), err)
 		return
 	}
-	if err := s.TG.DeleteMessages(ctx, peer, ids); err != nil {
-		s.warnf("warn: folder tomb succeeded but body delete failed for %d file bodies: %v\n", len(ids), err)
+	if err := s.deleteMessagesChunked(ctx, peer, ids); err != nil {
+		// Keep the file_parts rows so the orphan sweep can retry the part bodies.
+		s.warnf("warn: folder tomb succeeded but body delete failed for %d bodies: %v\n", len(ids), err)
+		return
 	}
+	if len(partIDs) > 0 {
+		if err := projection.DeleteFilePartsByMsgIDs(s.DB, channelID, partIDs); err != nil {
+			s.warnf("warn: folder tomb succeeded but dropping file_parts rows failed: %v\n", err)
+		}
+	}
+}
+
+// deleteMessagesChunked deletes Telegram messages in batches of 100 (a folder
+// subtree plus multipart parts can exceed the deleteMessages limit), returning
+// the first error encountered, nil if every chunk succeeded.
+func (s *Service) deleteMessagesChunked(ctx context.Context, peer tgclient.InputPeer, msgIDs []int64) error {
+	if s.TG == nil || len(msgIDs) == 0 {
+		return nil
+	}
+	const chunk = 100
+	var firstErr error
+	for start := 0; start < len(msgIDs); start += chunk {
+		end := min(start+chunk, len(msgIDs))
+		if err := s.TG.DeleteMessages(ctx, peer, msgIDs[start:end]); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func (s *Service) warnf(format string, args ...any) {

--- a/backend/services/folder/service_test.go
+++ b/backend/services/folder/service_test.go
@@ -155,6 +155,61 @@ func TestRenameMoveAndDeleteFolder(t *testing.T) {
 	}
 }
 
+func TestDeleteFolderCascadesToMultipartParts(t *testing.T) {
+	svc, db, fakeTG, _ := newTestService(t)
+
+	folder, err := svc.Create(testChannelID, "Big", "")
+	if err != nil {
+		t.Fatalf("create folder: %v", err)
+	}
+
+	// Seed a multipart file inside the folder: 3 part ops + a manifest op.
+	const uuid = "uft-1"
+	for i := 0; i < 3; i++ {
+		if err := svc.EmitOp(testChannelID, projection.Op{
+			Type: projection.OpFilePart, UploadUUID: uuid, PartIndex: i, FileSize: 100,
+		}); err != nil {
+			t.Fatalf("emit part %d: %v", i, err)
+		}
+	}
+	if err := svc.EmitOp(testChannelID, projection.Op{
+		Type: projection.OpFileManifest, UploadUUID: uuid, Parent: folder.ID,
+		Name: "big.bin", FileSize: 300, PartCount: 3, FileUploadTime: time.Unix(123, 0).Unix(),
+	}); err != nil {
+		t.Fatalf("emit manifest: %v", err)
+	}
+
+	var manifestID int64
+	if err := db.QueryRow(`SELECT msg_id FROM files WHERE channel_id = ? AND upload_uuid = ?`, testChannelID, uuid).Scan(&manifestID); err != nil {
+		t.Fatalf("scan manifest id: %v", err)
+	}
+	parts, err := projection.MultipartParts(db, testChannelID, manifestID)
+	if err != nil || len(parts) != 3 {
+		t.Fatalf("parts = %+v (err %v), want 3", parts, err)
+	}
+
+	if err := svc.Delete(context.Background(), testChannelID, folder.ID); err != nil {
+		t.Fatalf("delete folder: %v", err)
+	}
+
+	// The file_parts rows are dropped...
+	if left, _ := projection.MultipartParts(db, testChannelID, manifestID); len(left) != 0 {
+		t.Fatalf("file_parts after delete = %d, want 0", len(left))
+	}
+	// ...and the manifest + every part body were deleted from Telegram.
+	deleted := map[int64]bool{}
+	for _, batch := range fakeTG.DeletedBatches() {
+		for _, id := range batch {
+			deleted[id] = true
+		}
+	}
+	for _, id := range []int64{manifestID, parts[0].MsgID, parts[1].MsgID, parts[2].MsgID} {
+		if !deleted[id] {
+			t.Fatalf("msg %d was not deleted from Telegram; deleted=%v", id, deleted)
+		}
+	}
+}
+
 func TestDeleteFolderRequiresOwnershipForSharedDescendantFiles(t *testing.T) {
 	svc, db, fakeTG, actor := newTestService(t)
 	const sharedChannelID int64 = 717171

--- a/backend/services/read/service.go
+++ b/backend/services/read/service.go
@@ -191,9 +191,15 @@ func (s *Service) MediaFiles(channelID int64) ([]File, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Multipart files have no single document (their id is a text manifest), so
+	// they can't thumbnail or preview — keep them out of the gallery.
+	multipart, err := projection.MultipartFileMsgIDs(s.DB, channelID)
+	if err != nil {
+		return nil, err
+	}
 	out := make([]File, 0, len(all))
 	for _, f := range all {
-		if thumbnail.IsImage(f.Name) {
+		if thumbnail.IsImage(f.Name) && !multipart[f.MsgID] {
 			out = append(out, fileFromProjection(f))
 		}
 	}
@@ -250,6 +256,13 @@ func (s *Service) TelegramRootFiles(ctx context.Context, channelID int64) ([]Tel
 	files := make([]TelegramFile, 0, len(messages))
 	for _, msg := range messages {
 		if !msg.HasMedia {
+			continue
+		}
+		// Multipart part documents are internal artifacts, not user files. They
+		// carry a TDX1 t=part header; skip them so they never surface at root.
+		// Their msg_ids live in file_parts, not files, so the frontend's
+		// unmanaged-file filter wouldn't otherwise exclude them.
+		if op, err := projection.Parse(projection.ExtractHeaderLine(msg.Text)); err == nil && op.Type == projection.OpFilePart {
 			continue
 		}
 		name := strings.TrimSpace(msg.DocumentName)

--- a/backend/services/read/service_test.go
+++ b/backend/services/read/service_test.go
@@ -188,3 +188,30 @@ func TestTelegramRootFilesUsesTGHistory(t *testing.T) {
 		t.Fatalf("bad file: %+v", files[0])
 	}
 }
+
+func TestTelegramRootFilesSkipsMultipartParts(t *testing.T) {
+	svc, _, fakeTG := newTestService(t)
+	partCaption := projection.Format(projection.Op{
+		Type: projection.OpFilePart, UploadUUID: "u1", PartIndex: 0, FileSize: 1024,
+	})
+	fakeTG.SeedHistory(
+		// A multipart part document: has media, but a t=part header.
+		tgclient.HistoryMessage{
+			MsgID: 60, Date: 600, HasMedia: true, MediaSize: 1024,
+			DocumentName: "part-00000", Text: partCaption,
+		},
+		// A genuine loose document with no TDrive header stays visible.
+		tgclient.HistoryMessage{
+			MsgID: 61, Date: 601, HasMedia: true, MediaSize: 50,
+			DocumentName: "real.bin",
+		},
+	)
+
+	files, err := svc.TelegramRootFiles(context.Background(), testChannelID)
+	if err != nil {
+		t.Fatalf("telegram root files: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "real.bin" {
+		t.Fatalf("files = %+v, want only real.bin (multipart parts skipped)", files)
+	}
+}


### PR DESCRIPTION
Files over Telegram's ~2GB per-message limit now upload as N part documents plus a manifest, shown as one file in the drive. No Premium tiers: uniform ~1.9GiB part size, ~40GB cap.

Design:
- Encrypt-whole-then-slice, streamed through a pipe (no full-ciphertext temp). Download reassembles the parts in order and decrypts streaming (output-only disk). Cutting ciphertext at arbitrary offsets is safe because reassembly restores the exact byte stream before decrypt.
- Manifest is the commit point; its msg_id is the logical file id. Parts live in a separate file_parts table, never in files, so they never surface as files, listings, or orphans (TelegramRootFiles also skips t=part docs).
- Delete cascades to all part bodies (chunked); a failed body-delete keeps the rows so a tombstone-scoped GC can retry. The GC never touches parts that have no manifest, so it can't disturb an upload still in flight (shared drives / other clients).

Tests: projection (parts hidden, rebuild order, orphan GC, wire round-trip), upload to download byte-identical for plain and encrypted, file + folder delete cascade.