### PR TITLE
macOS arm64 native media playback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
             platform: linux/amd64
           - os: windows-latest
             platform: windows/amd64
-          - os: macos-latest
-            platform: darwin/universal
+          - os: macos-15
+            platform: darwin/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,6 +101,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+
+      - name: Install macOS media dependencies
+        if: runner.os == 'macOS'
+        run: brew install mpv
 
       - name: Install Wails
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
             output_name: TDrive-windows-amd64.exe
             asset_name: TDrive-${{ github.ref_name }}-windows-amd64.zip
 
-          - os: macos-latest
-            platform: darwin/universal
-            output_name: TDrive-macos-universal
-            asset_name: TDrive-${{ github.ref_name }}-macos-universal.zip
+          - os: macos-15
+            platform: darwin/arm64
+            output_name: TDrive-macos-arm64
+            asset_name: TDrive-${{ github.ref_name }}-macos-arm64.zip
 
     steps:
       - name: Checkout
@@ -59,6 +59,10 @@ jobs:
           sudo apt-get update
           # FIX 1: Explicitly install the 4.0 version which Wails expects
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+
+      - name: Install macOS media dependencies
+        if: runner.os == 'macOS'
+        run: brew install mpv
 
       - name: Install Wails
         run: |
@@ -133,6 +137,7 @@ jobs:
           fi
           
           echo "Packaging application from: $APP_PATH"
+          ./scripts/package-mpv-darwin.sh "$APP_PATH"
           ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "dist/${{ matrix.asset_name }}"
 
       - name: Package CLI (macOS/Linux)

--- a/app.go
+++ b/app.go
@@ -38,6 +38,12 @@ type App struct {
 	transferMu     sync.Mutex
 	uploadCancel   context.CancelFunc
 	downloadCancel context.CancelFunc
+
+	// nativeMedia owns out-of-webview player processes tied to media loopback
+	// sessions. Each token must be closed before the backend shuts down so the
+	// range reader and native surface do not outlive the app.
+	nativeMediaMu sync.Mutex
+	nativeMedia   map[string]*nativeMediaSession
 }
 
 type runtimeEventSink struct {
@@ -444,6 +450,7 @@ func (a *App) CreateFolder(foldername string, parentID string) (backend.Folder, 
 // shutdown runs on app exit. Tear down the shared Telegram connection so the
 // background Run scope's goroutine exits cleanly.
 func (a *App) shutdown(ctx context.Context) {
+	a.closeAllNativeMedia()
 	if a.engine != nil {
 		a.engine.Close()
 	}

--- a/app_native_media.go
+++ b/app_native_media.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"TDrive/backend/media"
+	"TDrive/backend/nativeplayer"
+)
+
+type NativeMediaResult struct {
+	Token string            `json:"token"`
+	Name  string            `json:"name"`
+	Info  media.LogicalFile `json:"info"`
+}
+
+type nativeMediaSession struct {
+	player *nativeplayer.Player
+}
+
+// OpenNativeMedia opens the same tokenized loopback stream as OpenMedia, then
+// hands it to the native player. The returned token owns both resources.
+func (a *App) OpenNativeMedia(msgID int, rect nativeplayer.Rect) (NativeMediaResult, error) {
+	if a.engine == nil {
+		return NativeMediaResult{}, fmt.Errorf("backend not ready")
+	}
+	if !rect.Valid() {
+		return NativeMediaResult{}, fmt.Errorf("invalid video viewport")
+	}
+
+	opened, err := a.engine.MediaService().Open(a.ctx, a.ActiveChannelID(), int64(msgID))
+	if err != nil {
+		return NativeMediaResult{}, err
+	}
+
+	if err := nativeplayer.PreflightDecode(a.ctx, opened.URL); err != nil {
+		_ = a.engine.MediaService().CloseSession(opened.Token)
+		if errors.Is(err, nativeplayer.ErrDecoderUnsafe) {
+			return NativeMediaResult{}, fmt.Errorf("this file crashes the local native decoder; bundled all-format playback is required for this format")
+		}
+		return NativeMediaResult{}, err
+	}
+
+	player, err := nativeplayer.Start(a.ctx, opened.URL, rect)
+	if err != nil {
+		_ = a.engine.MediaService().CloseSession(opened.Token)
+		if errors.Is(err, nativeplayer.ErrUnsupported) {
+			return NativeMediaResult{}, fmt.Errorf("native playback is not available on this platform yet")
+		}
+		return NativeMediaResult{}, err
+	}
+
+	a.nativeMediaMu.Lock()
+	if a.nativeMedia == nil {
+		a.nativeMedia = make(map[string]*nativeMediaSession)
+	}
+	a.nativeMedia[opened.Token] = &nativeMediaSession{player: player}
+	a.nativeMediaMu.Unlock()
+
+	return NativeMediaResult{
+		Token: opened.Token,
+		Name:  opened.Name,
+		Info:  opened.Info,
+	}, nil
+}
+
+func (a *App) ResizeNativeMedia(token string, rect nativeplayer.Rect) error {
+	session := a.nativeMediaSession(token)
+	if session == nil || session.player == nil {
+		return nil
+	}
+	return session.player.Resize(rect)
+}
+
+func (a *App) NativeMediaCommand(token string, command []string) error {
+	if err := validateNativeMediaCommand(command); err != nil {
+		return err
+	}
+	session := a.nativeMediaSession(token)
+	if session == nil || session.player == nil {
+		return nil
+	}
+	return session.player.Command(command...)
+}
+
+func (a *App) CloseNativeMedia(token string) error {
+	if token == "" {
+		return nil
+	}
+	session := a.takeNativeMediaSession(token)
+	if session != nil && session.player != nil {
+		_ = session.player.Close()
+	}
+	if a.engine != nil {
+		return a.engine.MediaService().CloseSession(token)
+	}
+	return nil
+}
+
+func (a *App) closeAllNativeMedia() {
+	a.nativeMediaMu.Lock()
+	sessions := a.nativeMedia
+	a.nativeMedia = nil
+	a.nativeMediaMu.Unlock()
+
+	for token, session := range sessions {
+		if session != nil && session.player != nil {
+			_ = session.player.Close()
+		}
+		if a.engine != nil {
+			_ = a.engine.MediaService().CloseSession(token)
+		}
+	}
+}
+
+func (a *App) nativeMediaSession(token string) *nativeMediaSession {
+	if token == "" {
+		return nil
+	}
+	a.nativeMediaMu.Lock()
+	defer a.nativeMediaMu.Unlock()
+	return a.nativeMedia[token]
+}
+
+func (a *App) takeNativeMediaSession(token string) *nativeMediaSession {
+	if token == "" {
+		return nil
+	}
+	a.nativeMediaMu.Lock()
+	defer a.nativeMediaMu.Unlock()
+	session := a.nativeMedia[token]
+	delete(a.nativeMedia, token)
+	return session
+}
+
+func validateNativeMediaCommand(command []string) error {
+	if len(command) == 0 {
+		return fmt.Errorf("native media command is empty")
+	}
+
+	switch command[0] {
+	case "cycle":
+		if len(command) != 2 {
+			return fmt.Errorf("invalid native media cycle command")
+		}
+		switch command[1] {
+		case "pause", "mute":
+			return nil
+		default:
+			return fmt.Errorf("unsupported native media cycle target")
+		}
+	case "seek":
+		if len(command) != 3 || command[2] != "relative" {
+			return fmt.Errorf("invalid native media seek command")
+		}
+		if _, err := strconv.ParseFloat(command[1], 64); err != nil {
+			return fmt.Errorf("invalid native media seek offset")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported native media command")
+	}
+}

--- a/app_native_media_test.go
+++ b/app_native_media_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestValidateNativeMediaCommandAcceptsSupportedCommands(t *testing.T) {
+	tests := [][]string{
+		{"cycle", "pause"},
+		{"cycle", "mute"},
+		{"seek", "10", "relative"},
+		{"seek", "-5.5", "relative"},
+	}
+
+	for _, command := range tests {
+		if err := validateNativeMediaCommand(command); err != nil {
+			t.Fatalf("validateNativeMediaCommand(%v) returned error: %v", command, err)
+		}
+	}
+}
+
+func TestValidateNativeMediaCommandRejectsUnsupportedCommands(t *testing.T) {
+	tests := [][]string{
+		nil,
+		{},
+		{"loadfile", "https://example.com/video.mkv"},
+		{"screenshot-to-file", "/tmp/frame.png"},
+		{"cycle", "fullscreen"},
+		{"cycle", "pause", "extra"},
+		{"seek", "10", "absolute"},
+		{"seek", "soon", "relative"},
+	}
+
+	for _, command := range tests {
+		if err := validateNativeMediaCommand(command); err == nil {
+			t.Fatalf("validateNativeMediaCommand(%v) returned nil error", command)
+		}
+	}
+}

--- a/backend/media/service.go
+++ b/backend/media/service.go
@@ -18,8 +18,8 @@ type Config struct {
 	Ranges tgclient.RangeClient
 }
 
-// Service is the app-facing media entry point. Later slices will attach the
-// loopback server, native player sessions, and byte-range reader here.
+// Service is the app-facing media entry point. It owns logical file resolution
+// and loopback sessions; UI-specific players sit above it.
 type Service struct {
 	peers    PeerResolver
 	ranges   tgclient.RangeClient

--- a/backend/nativeplayer/player_darwin.go
+++ b/backend/nativeplayer/player_darwin.go
@@ -1,0 +1,371 @@
+//go:build darwin
+
+package nativeplayer
+
+/*
+#cgo darwin CFLAGS: -x objective-c -fblocks -DGL_SILENCE_DEPRECATION
+#cgo darwin LDFLAGS: -framework Cocoa -framework QuartzCore -framework OpenGL
+#cgo darwin pkg-config: mpv
+
+#import <Cocoa/Cocoa.h>
+#import <OpenGL/gl3.h>
+#import <QuartzCore/QuartzCore.h>
+#import <dispatch/dispatch.h>
+#import <mpv/client.h>
+#import <mpv/render.h>
+#import <mpv/render_gl.h>
+
+static void *tdrive_gl_get_proc_address(void *ctx, const char *name) {
+    CFStringRef symbol = CFStringCreateWithCString(kCFAllocatorDefault, name, kCFStringEncodingASCII);
+    void *addr = CFBundleGetFunctionPointerForName(CFBundleGetBundleWithIdentifier(CFSTR("com.apple.opengl")), symbol);
+    CFRelease(symbol);
+    return addr;
+}
+
+@interface TDriveMPVView : NSOpenGLView {
+    mpv_handle *_mpv;
+    mpv_render_context *_render;
+    BOOL _closed;
+}
+- (BOOL)startWithURL:(NSString *)url;
+- (void)shutdown;
+- (int)sendCommand:(int)argc argv:(const char **)argv;
+@end
+
+static void tdrive_mpv_render_update(void *ctx) {
+    TDriveMPVView *view = (TDriveMPVView *)ctx;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [view setNeedsDisplay:YES];
+    });
+}
+
+@implementation TDriveMPVView
+
++ (NSOpenGLPixelFormat *)tdrivePixelFormat {
+    NSOpenGLPixelFormatAttribute attrs[] = {
+        NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core,
+        NSOpenGLPFAColorSize, 24,
+        NSOpenGLPFAAlphaSize, 8,
+        NSOpenGLPFADoubleBuffer,
+        NSOpenGLPFAAccelerated,
+        0
+    };
+    return [[[NSOpenGLPixelFormat alloc] initWithAttributes:attrs] autorelease];
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+    self = [super initWithFrame:frameRect pixelFormat:[TDriveMPVView tdrivePixelFormat]];
+    if (self) {
+        [self setWantsBestResolutionOpenGLSurface:YES];
+        [self setWantsLayer:YES];
+        [[self layer] setBackgroundColor:[[NSColor blackColor] CGColor]];
+    }
+    return self;
+}
+
+- (BOOL)startWithURL:(NSString *)url {
+    _mpv = mpv_create();
+    if (_mpv == NULL) {
+        return NO;
+    }
+
+	mpv_set_option_string(_mpv, "config", "no");
+	mpv_set_option_string(_mpv, "terminal", "no");
+	mpv_set_option_string(_mpv, "msg-level", "all=warn");
+	mpv_set_option_string(_mpv, "vo", "libmpv");
+	mpv_set_option_string(_mpv, "ytdl", "no");
+	mpv_set_option_string(_mpv, "hwdec", "auto-safe");
+	mpv_set_option_string(_mpv, "osc", "yes");
+	mpv_set_option_string(_mpv, "osd-bar", "yes");
+
+    if (mpv_initialize(_mpv) < 0) {
+        return NO;
+    }
+
+    [[self openGLContext] makeCurrentContext];
+    mpv_opengl_init_params glInit = {
+        .get_proc_address = tdrive_gl_get_proc_address,
+        .get_proc_address_ctx = NULL,
+    };
+    mpv_render_param params[] = {
+        { MPV_RENDER_PARAM_API_TYPE, (void *)MPV_RENDER_API_TYPE_OPENGL },
+        { MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &glInit },
+        { MPV_RENDER_PARAM_INVALID, NULL },
+    };
+    if (mpv_render_context_create(&_render, _mpv, params) < 0) {
+        return NO;
+    }
+    mpv_render_context_set_update_callback(_render, tdrive_mpv_render_update, self);
+
+    const char *cmd[] = { "loadfile", [url UTF8String], NULL };
+    if (mpv_command_async(_mpv, 0, cmd) < 0) {
+        return NO;
+    }
+    return YES;
+}
+
+- (void)drawRect:(NSRect)dirtyRect {
+    if (_closed || _render == NULL) {
+        [[NSColor blackColor] setFill];
+        NSRectFill([self bounds]);
+        return;
+    }
+
+    [[self openGLContext] makeCurrentContext];
+    NSRect backing = [self convertRectToBacking:[self bounds]];
+    int width = (int)MAX(1, backing.size.width);
+    int height = (int)MAX(1, backing.size.height);
+    glViewport(0, 0, width, height);
+    glClearColor(0.0, 0.0, 0.0, 1.0);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    mpv_opengl_fbo fbo = { .fbo = 0, .w = width, .h = height, .internal_format = GL_RGBA8 };
+    int flipY = 1;
+    mpv_render_param params[] = {
+        { MPV_RENDER_PARAM_OPENGL_FBO, &fbo },
+        { MPV_RENDER_PARAM_FLIP_Y, &flipY },
+        { MPV_RENDER_PARAM_INVALID, NULL },
+    };
+    mpv_render_context_render(_render, params);
+    [[self openGLContext] flushBuffer];
+}
+
+- (void)reshape {
+    [super reshape];
+    [self setNeedsDisplay:YES];
+}
+
+- (int)sendCommand:(int)argc argv:(const char **)argv {
+    if (_closed || _mpv == NULL || argc <= 0 || argv == NULL) {
+        return 0;
+    }
+    return mpv_command_async(_mpv, 0, argv);
+}
+
+- (void)shutdown {
+    if (_closed) {
+        return;
+    }
+    _closed = YES;
+    mpv_handle *mpv = _mpv;
+    _mpv = NULL;
+    if (_render != NULL) {
+        [[self openGLContext] makeCurrentContext];
+        mpv_render_context_set_update_callback(_render, NULL, NULL);
+        mpv_render_context_free(_render);
+        _render = NULL;
+        [NSOpenGLContext clearCurrentContext];
+    }
+    if (mpv != NULL) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            mpv_terminate_destroy(mpv);
+        });
+    }
+}
+
+- (void)dealloc {
+    [self shutdown];
+    [super dealloc];
+}
+
+@end
+
+static NSWindow* tdrive_player_window(void) {
+    NSWindow *window = [NSApp keyWindow];
+    if (window != nil) {
+        return window;
+    }
+    for (NSWindow *candidate in [NSApp windows]) {
+        if ([candidate isVisible]) {
+            return candidate;
+        }
+    }
+    return nil;
+}
+
+static NSRect tdrive_player_frame(NSView *content, double x, double y, double w, double h) {
+    NSRect bounds = [content bounds];
+    double bottomY = bounds.size.height - y - h;
+    return NSMakeRect(x, bottomY, w, h);
+}
+
+static void* tdrive_player_create_view(const char *rawURL, double x, double y, double w, double h) {
+    if (rawURL == NULL) {
+        return nil;
+    }
+    __block TDriveMPVView *view = nil;
+    NSString *url = [NSString stringWithUTF8String:rawURL];
+    void (^create)(void) = ^{
+        NSWindow *window = tdrive_player_window();
+        if (window == nil) {
+            return;
+        }
+        NSView *content = [window contentView];
+        if (content == nil) {
+            return;
+        }
+        NSRect frame = tdrive_player_frame(content, x, y, w, h);
+        view = [[TDriveMPVView alloc] initWithFrame:frame];
+        if (view == nil || ![view startWithURL:url]) {
+            [view release];
+            view = nil;
+            return;
+        }
+        [view setAutoresizingMask:0];
+        [content addSubview:view positioned:NSWindowAbove relativeTo:nil];
+    };
+    if ([NSThread isMainThread]) {
+        create();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), create);
+    }
+    return view;
+}
+
+static void tdrive_player_set_frame(void *ptr, double x, double y, double w, double h) {
+    if (ptr == nil) {
+        return;
+    }
+    TDriveMPVView *view = (TDriveMPVView *)ptr;
+    void (^resize)(void) = ^{
+        NSView *content = [view superview];
+        if (content == nil) {
+            return;
+        }
+        [view setFrame:tdrive_player_frame(content, x, y, w, h)];
+        [view setNeedsDisplay:YES];
+    };
+    if ([NSThread isMainThread]) {
+        resize();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), resize);
+    }
+}
+
+static int tdrive_player_command(void *ptr, int argc, const char **argv) {
+    if (ptr == nil) {
+        return 0;
+    }
+    __block int result = 0;
+    TDriveMPVView *view = (TDriveMPVView *)ptr;
+    void (^send)(void) = ^{
+        result = [view sendCommand:argc argv:argv];
+    };
+    if ([NSThread isMainThread]) {
+        send();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), send);
+    }
+    return result;
+}
+
+static void tdrive_player_destroy_view(void *ptr) {
+    if (ptr == nil) {
+        return;
+    }
+    TDriveMPVView *view = (TDriveMPVView *)ptr;
+    void (^destroy)(void) = ^{
+        [view shutdown];
+        [view removeFromSuperview];
+        [view release];
+    };
+    if ([NSThread isMainThread]) {
+        destroy();
+    } else {
+        dispatch_sync(dispatch_get_main_queue(), destroy);
+    }
+}
+*/
+import "C"
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"unsafe"
+)
+
+type Player struct {
+	mu     sync.Mutex
+	view   unsafe.Pointer
+	closed bool
+}
+
+func Start(ctx context.Context, url string, rect Rect) (*Player, error) {
+	if !rect.Valid() {
+		return nil, fmt.Errorf("native player: invalid view rect")
+	}
+	rawURL := C.CString(url)
+	defer C.free(unsafe.Pointer(rawURL))
+	view := C.tdrive_player_create_view(rawURL, C.double(rect.X), C.double(rect.Y), C.double(rect.Width), C.double(rect.Height))
+	if view == nil {
+		return nil, fmt.Errorf("native player: could not start libmpv view")
+	}
+	return &Player{view: view}, nil
+}
+
+func (p *Player) Resize(rect Rect) error {
+	if p == nil {
+		return nil
+	}
+	if !rect.Valid() {
+		return fmt.Errorf("native player: invalid view rect")
+	}
+	p.mu.Lock()
+	view := p.view
+	closed := p.closed
+	p.mu.Unlock()
+	if closed || view == nil {
+		return nil
+	}
+	C.tdrive_player_set_frame(view, C.double(rect.X), C.double(rect.Y), C.double(rect.Width), C.double(rect.Height))
+	return nil
+}
+
+func (p *Player) Command(command ...string) error {
+	if p == nil || len(command) == 0 {
+		return nil
+	}
+	p.mu.Lock()
+	view := p.view
+	closed := p.closed
+	p.mu.Unlock()
+	if closed || view == nil {
+		return nil
+	}
+
+	cStrings := make([]*C.char, len(command)+1)
+	for i, part := range command {
+		cStrings[i] = C.CString(part)
+	}
+	defer func() {
+		for _, cstr := range cStrings {
+			if cstr != nil {
+				C.free(unsafe.Pointer(cstr))
+			}
+		}
+	}()
+	if rc := C.tdrive_player_command(view, C.int(len(command)), (**C.char)(unsafe.Pointer(&cStrings[0]))); rc < 0 {
+		return fmt.Errorf("native player: libmpv command failed: %d", int(rc))
+	}
+	return nil
+}
+
+func (p *Player) Close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	view := p.view
+	p.view = nil
+	p.mu.Unlock()
+	if view != nil {
+		C.tdrive_player_destroy_view(view)
+	}
+	return nil
+}

--- a/backend/nativeplayer/player_unsupported.go
+++ b/backend/nativeplayer/player_unsupported.go
@@ -1,0 +1,25 @@
+//go:build !darwin
+
+package nativeplayer
+
+import (
+	"context"
+)
+
+type Player struct{}
+
+func Start(ctx context.Context, url string, rect Rect) (*Player, error) {
+	return nil, ErrUnsupported
+}
+
+func (p *Player) Resize(rect Rect) error {
+	return nil
+}
+
+func (p *Player) Command(command ...string) error {
+	return nil
+}
+
+func (p *Player) Close() error {
+	return nil
+}

--- a/backend/nativeplayer/preflight_darwin.go
+++ b/backend/nativeplayer/preflight_darwin.go
@@ -1,0 +1,88 @@
+//go:build darwin
+
+package nativeplayer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+const preflightTimeout = 6 * time.Second
+
+// PreflightDecode decodes a tiny prefix in a separate process before libmpv is
+// loaded in-process. A bad system decoder can segfault; doing the first probe
+// out-of-process keeps TDrive alive and turns that class of failure into a
+// normal playback error.
+func PreflightDecode(ctx context.Context, url string) error {
+	if os.Getenv("TDRIVE_SKIP_MPV_PREFLIGHT") == "1" {
+		return nil
+	}
+	mpvPath, err := findPreflightMPV()
+	if err != nil {
+		// Future bundled libmpv builds may not ship a separate mpv executable.
+		// In that case the app still attempts playback; packaging owns safety.
+		return nil
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, preflightTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, mpvPath,
+		"--no-config",
+		"--really-quiet",
+		"--terminal=no",
+		"--force-window=no",
+		"--vo=null",
+		"--ao=null",
+		"--frames=1",
+		"--demuxer-readahead-secs=0.5",
+		"--demuxer-max-bytes=2097152",
+		"--",
+		url,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		if runCtx.Err() != nil {
+			return fmt.Errorf("%w: timed out", ErrDecoderUnsafe)
+		}
+		if len(output) > 0 {
+			return fmt.Errorf("%w: %v: %s", ErrDecoderUnsafe, err, string(output))
+		}
+		return fmt.Errorf("%w: %v", ErrDecoderUnsafe, err)
+	}
+	return nil
+}
+
+func findPreflightMPV() (string, error) {
+	if override := os.Getenv("TDRIVE_MPV_BIN"); override != "" {
+		st, err := os.Stat(override)
+		if err != nil || st.IsDir() {
+			return "", fmt.Errorf("TDRIVE_MPV_BIN is not executable")
+		}
+		return override, nil
+	}
+	if bundled, err := bundledMPVPath(); err == nil {
+		return bundled, nil
+	}
+	return exec.LookPath("mpv")
+}
+
+func bundledMPVPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	candidates := []string{
+		filepath.Join(filepath.Dir(exe), "mpv"),
+		filepath.Join(filepath.Dir(exe), "..", "Resources", "media", "mpv"),
+	}
+	for _, candidate := range candidates {
+		st, err := os.Stat(candidate)
+		if err == nil && !st.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", os.ErrNotExist
+}

--- a/backend/nativeplayer/preflight_unsupported.go
+++ b/backend/nativeplayer/preflight_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package nativeplayer
+
+import "context"
+
+func PreflightDecode(ctx context.Context, url string) error {
+	return nil
+}

--- a/backend/nativeplayer/types.go
+++ b/backend/nativeplayer/types.go
@@ -1,0 +1,17 @@
+package nativeplayer
+
+import "errors"
+
+var ErrUnsupported = errors.New("native player is not supported on this platform")
+var ErrDecoderUnsafe = errors.New("native player decoder preflight failed")
+
+type Rect struct {
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+	Width  float64 `json:"width"`
+	Height float64 `json:"height"`
+}
+
+func (r Rect) Valid() bool {
+	return r.Width > 0 && r.Height > 0
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -356,6 +356,7 @@
                     <button id="video-close" class="video-icon-btn video-close-btn" type="button" aria-label="Close video" title="Close">×</button>
                 </div>
                 <div id="video-stage" class="video-stage">
+                    <div id="video-native-viewport" class="video-native-viewport" aria-hidden="true"></div>
                     <video id="video-player" class="video-player" playsinline preload="metadata"></video>
                     <div id="video-loading" class="video-loading" aria-hidden="true" style="display: none;">
                         <div class="video-spinner"></div>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,10 +7,14 @@
 
 import {
     CloseMedia as rawCloseMedia,
+    CloseNativeMedia as rawCloseNativeMedia,
     GetFolderContents as rawGetFolderContents,
     GetFileList as rawGetFileList,
     ListMedia as rawListMedia,
+    NativeMediaCommand as rawNativeMediaCommand,
     OpenMedia as rawOpenMedia,
+    OpenNativeMedia as rawOpenNativeMedia,
+    ResizeNativeMedia as rawResizeNativeMedia,
     Search as rawSearch,
     Thumbnail as rawThumbnail,
 } from "../wailsjs/go/main/App";
@@ -37,6 +41,19 @@ export interface MediaOpenInfo {
 export interface MediaOpenResult {
     token: string;
     url: string;
+    name: string;
+    info: MediaOpenInfo;
+}
+
+export interface NativeMediaRect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface NativeMediaOpenResult {
+    token: string;
     name: string;
     info: MediaOpenInfo;
 }
@@ -150,4 +167,38 @@ export async function openMedia(msgId: number): Promise<MediaOpenResult> {
 export async function closeMedia(token: string): Promise<void> {
     if (!token) return;
     await rawCloseMedia(token);
+}
+
+/** Open a native all-format player for one projected file. */
+export async function openNativeMedia(msgId: number, rect: NativeMediaRect): Promise<NativeMediaOpenResult> {
+    const opened = await rawOpenNativeMedia(msgId, rect as any);
+    const info: media.LogicalFile | undefined = opened?.info;
+    return {
+        token: String(opened?.token ?? ""),
+        name: String(opened?.name ?? ""),
+        info: {
+            channelId: Number(info?.channel_id ?? 0),
+            fileId: Number(info?.file_id ?? 0),
+            name: String(info?.name ?? opened?.name ?? ""),
+            storedSize: Number(info?.stored_size ?? 0),
+            plaintextSize: Number(info?.plaintext_size ?? 0),
+            encrypted: Boolean(info?.encrypted),
+            multipart: Boolean(info?.multipart),
+        },
+    };
+}
+
+export async function resizeNativeMedia(token: string, rect: NativeMediaRect): Promise<void> {
+    if (!token) return;
+    await rawResizeNativeMedia(token, rect as any);
+}
+
+export async function nativeMediaCommand(token: string, command: string[]): Promise<void> {
+    if (!token || command.length === 0) return;
+    await rawNativeMediaCommand(token, command);
+}
+
+export async function closeNativeMedia(token: string): Promise<void> {
+    if (!token) return;
+    await rawCloseNativeMedia(token);
 }

--- a/frontend/src/modules/modals/video.ts
+++ b/frontend/src/modules/modals/video.ts
@@ -1,4 +1,14 @@
-import { closeMedia, openMedia, type MediaOpenResult } from "../../api";
+import {
+    closeMedia,
+    closeNativeMedia,
+    nativeMediaCommand,
+    openMedia,
+    openNativeMedia,
+    resizeNativeMedia,
+    type MediaOpenResult,
+    type NativeMediaOpenResult,
+    type NativeMediaRect,
+} from "../../api";
 import { formatBytes } from "../../utils";
 import { isWebviewDirectVideo, videoFormatLabel } from "../media-types";
 import { installModalA11y } from "./modal-a11y";
@@ -19,6 +29,7 @@ let shellEl: HTMLElement | null = null;
 let filenameEl: HTMLElement | null = null;
 let metaEl: HTMLElement | null = null;
 let closeBtnEl: HTMLButtonElement | null = null;
+let nativeViewportEl: HTMLElement | null = null;
 let videoEl: HTMLVideoElement | null = null;
 let loadingEl: HTMLElement | null = null;
 let errorEl: HTMLElement | null = null;
@@ -31,8 +42,10 @@ let durationEl: HTMLElement | null = null;
 let speedEl: HTMLSelectElement | null = null;
 
 let active: MediaOpenResult | null = null;
+let activeNative: NativeMediaOpenResult | null = null;
 let openSeq = 0;
 let chromeHideTimer: ReturnType<typeof setTimeout> | null = null;
+let nativeResizeFrame = 0;
 let seekingWithPointer = false;
 let hasError = false;
 let a11y: ReturnType<typeof installModalA11y> | null = null;
@@ -47,6 +60,40 @@ function isOpen() {
 
 function setChromeVisible(visible: boolean) {
     modalEl?.classList.toggle("is-video-chrome-visible", visible);
+}
+
+function setNativeMode(visible: boolean) {
+    modalEl?.classList.toggle("is-video-native", visible);
+}
+
+function nextFrame(): Promise<void> {
+    return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+function currentNativeRect(): NativeMediaRect | null {
+    if (!nativeViewportEl) return null;
+    const rect = nativeViewportEl.getBoundingClientRect();
+    if (rect.width < 2 || rect.height < 2) return null;
+    return {
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+    };
+}
+
+function scheduleNativeResize() {
+    if (!activeNative) return;
+    if (nativeResizeFrame) cancelAnimationFrame(nativeResizeFrame);
+    nativeResizeFrame = requestAnimationFrame(() => {
+        nativeResizeFrame = 0;
+        const token = activeNative?.token || "";
+        const rect = currentNativeRect();
+        if (!token || !rect) return;
+        void resizeNativeMedia(token, rect).catch((err) => {
+            console.warn("ResizeNativeMedia failed:", err);
+        });
+    });
 }
 
 function clearChromeTimer() {
@@ -162,7 +209,10 @@ function loadIntoVideo(opened: MediaOpenResult, target: VideoOpenTarget) {
 
 async function releaseActive() {
     const token = active?.token || "";
+    const nativeToken = activeNative?.token || "";
     active = null;
+    activeNative = null;
+    setNativeMode(false);
     if (videoEl) {
         videoEl.pause();
         videoEl.removeAttribute("src");
@@ -175,11 +225,21 @@ async function releaseActive() {
             console.warn("CloseMedia failed:", err);
         }
     }
+    if (nativeToken) {
+        try {
+            await closeNativeMedia(nativeToken);
+        } catch (err) {
+            console.warn("CloseNativeMedia failed:", err);
+        }
+    }
 }
 
 function releaseActiveSoon() {
     const token = active?.token || "";
+    const nativeToken = activeNative?.token || "";
     active = null;
+    activeNative = null;
+    setNativeMode(false);
     if (videoEl) {
         videoEl.pause();
         videoEl.removeAttribute("src");
@@ -188,6 +248,11 @@ function releaseActiveSoon() {
     if (token) {
         void closeMedia(token).catch((err) => {
             console.warn("CloseMedia failed:", err);
+        });
+    }
+    if (nativeToken) {
+        void closeNativeMedia(nativeToken).catch((err) => {
+            console.warn("CloseNativeMedia failed:", err);
         });
     }
 }
@@ -215,9 +280,38 @@ export async function openVideoModal(target: VideoOpenTarget) {
         return;
     }
     if (!isWebviewDirectVideo(target.name)) {
-        setError(`${videoFormatLabel(target.name)} playback is not supported in this preview yet. MP4, MOV, and WebM can play now.`);
+        setNativeMode(true);
+        await nextFrame();
+        const rect = currentNativeRect();
+        if (seq !== openSeq || !isOpen()) return;
+        if (!rect) {
+            setNativeMode(false);
+            setError("Could not prepare the native video surface.");
+            return;
+        }
+        try {
+            const opened = await openNativeMedia(id, rect);
+            if (seq !== openSeq || !isOpen()) {
+                await closeNativeMedia(opened.token);
+                return;
+            }
+            if (!opened.token) {
+                throw new Error("native media session did not return a token");
+            }
+            activeNative = opened;
+            filenameEl.textContent = opened.info.name || opened.name || target.name || "Video";
+            const displaySize = opened.info.plaintextSize || opened.info.storedSize || target.size || 0;
+            metaEl.textContent = `${videoFormatLabel(opened.info.name || opened.name || target.name)}${displaySize ? ` · ${formatBytes(displaySize)}` : ""}`;
+            setLoading(false);
+            scheduleNativeResize();
+        } catch (err: any) {
+            console.error("OpenNativeMedia failed:", err);
+            setNativeMode(false);
+            setError(String(err?.message || err || "Could not open this video."));
+        }
         return;
     }
+    setNativeMode(false);
 
     try {
         const opened = await openMedia(id);
@@ -253,6 +347,13 @@ export async function closeVideoModal() {
 }
 
 function togglePlayback() {
+    if (activeNative?.token) {
+        void nativeMediaCommand(activeNative.token, ["cycle", "pause"]).catch((err) => {
+            console.warn("NativeMediaCommand failed:", err);
+        });
+        revealChrome();
+        return;
+    }
     if (!videoEl || hasError) return;
     if (videoEl.paused) {
         videoEl.play().catch((err) => setError(String(err?.message || err || "Playback failed.")));
@@ -263,6 +364,13 @@ function togglePlayback() {
 }
 
 function seekBy(delta: number) {
+    if (activeNative?.token) {
+        void nativeMediaCommand(activeNative.token, ["seek", String(delta), "relative"]).catch((err) => {
+            console.warn("NativeMediaCommand failed:", err);
+        });
+        revealChrome();
+        return;
+    }
     if (!videoEl || !Number.isFinite(videoEl.duration)) return;
     videoEl.currentTime = Math.max(0, Math.min(videoEl.duration, videoEl.currentTime + delta));
     syncTimeline();
@@ -350,9 +458,16 @@ function bindControls() {
             seekBy(SEEK_STEP_SECONDS);
         } else if (event.key.toLowerCase() === "m") {
             event.preventDefault();
-            muteBtnEl?.click();
+            if (activeNative?.token) {
+                void nativeMediaCommand(activeNative.token, ["cycle", "mute"]).catch((err) => {
+                    console.warn("NativeMediaCommand failed:", err);
+                });
+            } else {
+                muteBtnEl?.click();
+            }
         }
     });
+    window.addEventListener("resize", scheduleNativeResize);
 }
 
 function renderSpeedOptions() {
@@ -368,6 +483,7 @@ export function setupVideoModal() {
     filenameEl = byID("video-filename");
     metaEl = byID("video-meta");
     closeBtnEl = byID("video-close");
+    nativeViewportEl = byID("video-native-viewport");
     videoEl = byID("video-player");
     loadingEl = byID("video-loading");
     errorEl = byID("video-error");

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2003,6 +2003,31 @@ header {
     background: #000;
 }
 
+.video-native-viewport {
+    position: absolute;
+    left: 18px;
+    right: 18px;
+    top: 78px;
+    bottom: 18px;
+    display: none;
+    background: #000;
+}
+
+.video-overlay.is-video-native .video-native-viewport {
+    display: block;
+}
+
+.video-overlay.is-video-native .video-player,
+.video-overlay.is-video-native .video-controls {
+    display: none;
+}
+
+.video-overlay.is-video-native .video-topbar {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+
 .video-topbar,
 .video-controls {
     position: absolute;
@@ -2186,6 +2211,13 @@ header {
     .video-topbar {
         min-height: 60px;
         padding: 12px 14px;
+    }
+
+    .video-native-viewport {
+        left: 10px;
+        right: 10px;
+        top: 64px;
+        bottom: 10px;
     }
 
     .video-filename {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -3,6 +3,7 @@
 import {main} from '../models';
 import {backend} from '../models';
 import {media} from '../models';
+import {nativeplayer} from '../models';
 import {file} from '../models';
 
 export function ActiveChannelID():Promise<number>;
@@ -22,6 +23,8 @@ export function CheckPendingJoin(arg1:string):Promise<main.JoinDriveResult>;
 export function CheckSystemStatus():Promise<string>;
 
 export function CloseMedia(arg1:string):Promise<void>;
+
+export function CloseNativeMedia(arg1:string):Promise<void>;
 
 export function CreateEncryptionPassword(arg1:string,arg2:string):Promise<void>;
 
@@ -85,7 +88,11 @@ export function MsgToTdriveSystem(arg1:number,arg2:string,arg3:number,arg4:strin
 
 export function MyUserID():Promise<number>;
 
+export function NativeMediaCommand(arg1:string,arg2:Array<string>):Promise<void>;
+
 export function OpenMedia(arg1:number):Promise<media.OpenResult>;
+
+export function OpenNativeMedia(arg1:number,arg2:nativeplayer.Rect):Promise<main.NativeMediaResult>;
 
 export function PlanImport(arg1:Array<string>,arg2:boolean,arg3:boolean):Promise<file.ImportPlan>;
 
@@ -102,6 +109,8 @@ export function RemovePendingJoin(arg1:string):Promise<void>;
 export function RenameFile(arg1:number,arg2:string):Promise<string>;
 
 export function RenameFolder(arg1:string,arg2:string):Promise<string>;
+
+export function ResizeNativeMedia(arg1:string,arg2:nativeplayer.Rect):Promise<void>;
 
 export function ResolveUsernames(arg1:Array<number>):Promise<Record<string, string>>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -38,6 +38,10 @@ export function CloseMedia(arg1) {
   return window['go']['main']['App']['CloseMedia'](arg1);
 }
 
+export function CloseNativeMedia(arg1) {
+  return window['go']['main']['App']['CloseNativeMedia'](arg1);
+}
+
 export function CreateEncryptionPassword(arg1, arg2) {
   return window['go']['main']['App']['CreateEncryptionPassword'](arg1, arg2);
 }
@@ -162,8 +166,16 @@ export function MyUserID() {
   return window['go']['main']['App']['MyUserID']();
 }
 
+export function NativeMediaCommand(arg1, arg2) {
+  return window['go']['main']['App']['NativeMediaCommand'](arg1, arg2);
+}
+
 export function OpenMedia(arg1) {
   return window['go']['main']['App']['OpenMedia'](arg1);
+}
+
+export function OpenNativeMedia(arg1, arg2) {
+  return window['go']['main']['App']['OpenNativeMedia'](arg1, arg2);
 }
 
 export function PlanImport(arg1, arg2, arg3) {
@@ -196,6 +208,10 @@ export function RenameFile(arg1, arg2) {
 
 export function RenameFolder(arg1, arg2) {
   return window['go']['main']['App']['RenameFolder'](arg1, arg2);
+}
+
+export function ResizeNativeMedia(arg1, arg2) {
+  return window['go']['main']['App']['ResizeNativeMedia'](arg1, arg2);
 }
 
 export function ResolveUsernames(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1,5 +1,5 @@
 export namespace backend {
-	
+
 	export class FileMetaData {
 	    name: string;
 	    size: number;
@@ -9,11 +9,11 @@ export namespace backend {
 	    uploader_id: number;
 	    encrypted?: boolean;
 	    plaintext_size?: number;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new FileMetaData(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
@@ -30,11 +30,11 @@ export namespace backend {
 	    name: string;
 	    id: string;
 	    parent_id: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Folder(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
@@ -45,17 +45,17 @@ export namespace backend {
 	export class FileSystem {
 	    folders: Folder[];
 	    files: FileMetaData[];
-	
+
 	    static createFrom(source: any = {}) {
 	        return new FileSystem(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.folders = this.convertValues(source["folders"], Folder);
 	        this.files = this.convertValues(source["files"], FileMetaData);
 	    }
-	
+
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -74,7 +74,7 @@ export namespace backend {
 		    return a;
 		}
 	}
-	
+
 	export class SearchResult {
 	    type: string;
 	    id: string;
@@ -84,11 +84,11 @@ export namespace backend {
 	    upload_time: number;
 	    uploader_id: number;
 	    path: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new SearchResult(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.type = source["type"];
@@ -105,7 +105,7 @@ export namespace backend {
 }
 
 export namespace file {
-	
+
 	export class ImportPlan {
 	    files: number;
 	    folders: number;
@@ -114,11 +114,11 @@ export namespace file {
 	    archives: number;
 	    maxBytes: number;
 	    errors: string[];
-	
+
 	    static createFrom(source: any = {}) {
 	        return new ImportPlan(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.files = source["files"];
@@ -134,18 +134,18 @@ export namespace file {
 }
 
 export namespace main {
-	
+
 	export class ChannelInfo {
 	    id: number;
 	    title: string;
 	    kind: string;
 	    is_active: boolean;
 	    invite_link?: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new ChannelInfo(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -159,11 +159,11 @@ export namespace main {
 	    status: string;
 	    message: string;
 	    saved_path?: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new DownloadResult(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.status = source["status"];
@@ -176,11 +176,11 @@ export namespace main {
 	    password_set: boolean;
 	    password_remembered: boolean;
 	    hint: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new EncryptionStatus(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.available = source["available"];
@@ -197,11 +197,11 @@ export namespace main {
 	    last_checked_at: number;
 	    status: string;
 	    last_error: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new PendingJoinInfo(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.invite_hash = source["invite_hash"];
@@ -217,18 +217,18 @@ export namespace main {
 	    status: string;
 	    channel?: ChannelInfo;
 	    pending?: PendingJoinInfo;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new JoinDriveResult(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.status = source["status"];
 	        this.channel = this.convertValues(source["channel"], ChannelInfo);
 	        this.pending = this.convertValues(source["pending"], PendingJoinInfo);
 	    }
-	
+
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -253,11 +253,11 @@ export namespace main {
 	    username?: string;
 	    requested_at: number;
 	    about?: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new JoinRequestInfo(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.user_id = source["user_id"];
@@ -267,15 +267,49 @@ export namespace main {
 	        this.about = source["about"];
 	    }
 	}
-	
+	export class NativeMediaResult {
+	    token: string;
+	    name: string;
+	    info: media.LogicalFile;
+
+	    static createFrom(source: any = {}) {
+	        return new NativeMediaResult(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.token = source["token"];
+	        this.name = source["name"];
+	        this.info = this.convertValues(source["info"], media.LogicalFile);
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+
 	export class PreviewPayload {
 	    data_base64: string;
 	    mime_type: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new PreviewPayload(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.data_base64 = source["data_base64"];
@@ -287,11 +321,11 @@ export namespace main {
 	    display_name: string;
 	    username?: string;
 	    photo_base64?: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new SelfUser(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.user_id = source["user_id"];
@@ -306,11 +340,11 @@ export namespace main {
 	    size: number;
 	    access_hash: number;
 	    date: number;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new TDriveFile(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -324,15 +358,15 @@ export namespace main {
 }
 
 export namespace media {
-	
+
 	export class Segment {
 	    msg_id: number;
 	    size: number;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Segment(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.msg_id = source["msg_id"];
@@ -349,11 +383,11 @@ export namespace media {
 	    encryption_version: number;
 	    multipart: boolean;
 	    segments: Segment[];
-	
+
 	    static createFrom(source: any = {}) {
 	        return new LogicalFile(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.channel_id = source["channel_id"];
@@ -366,7 +400,7 @@ export namespace media {
 	        this.multipart = source["multipart"];
 	        this.segments = this.convertValues(source["segments"], Segment);
 	    }
-	
+
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -390,11 +424,11 @@ export namespace media {
 	    url: string;
 	    name: string;
 	    info: LogicalFile;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new OpenResult(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.token = source["token"];
@@ -402,7 +436,7 @@ export namespace media {
 	        this.name = source["name"];
 	        this.info = this.convertValues(source["info"], LogicalFile);
 	    }
-	
+
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -420,6 +454,29 @@ export namespace media {
 		    }
 		    return a;
 		}
+	}
+
+}
+
+export namespace nativeplayer {
+
+	export class Rect {
+	    x: number;
+	    y: number;
+	    width: number;
+	    height: number;
+
+	    static createFrom(source: any = {}) {
+	        return new Rect(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.x = source["x"];
+	        this.y = source["y"];
+	        this.width = source["width"];
+	        this.height = source["height"];
+	    }
 	}
 
 }

--- a/scripts/package-mpv-darwin.sh
+++ b/scripts/package-mpv-darwin.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH="${1:-build/bin/TDrive.app}"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "package-mpv-darwin: this script only runs on macOS" >&2
+  exit 1
+fi
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "package-mpv-darwin: app bundle not found: $APP_PATH" >&2
+  exit 1
+fi
+
+BIN_PATH="$APP_PATH/Contents/MacOS/TDrive"
+FRAMEWORKS_DIR="$APP_PATH/Contents/Frameworks"
+MEDIA_DIR="$APP_PATH/Contents/Resources/media"
+MPV_SIDECAR="$MEDIA_DIR/mpv"
+
+if [ ! -x "$BIN_PATH" ]; then
+  echo "package-mpv-darwin: app executable not found: $BIN_PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$FRAMEWORKS_DIR" "$MEDIA_DIR"
+
+# This script owns the media runtime files it places in the bundle. Removing
+# them up front keeps repeated local package runs deterministic.
+find "$FRAMEWORKS_DIR" -maxdepth 1 -type f -name '*.dylib' -delete
+rm -f "$MPV_SIDECAR"
+
+log() {
+  printf 'package-mpv-darwin: %s\n' "$*"
+}
+
+die() {
+  echo "package-mpv-darwin: $*" >&2
+  exit 1
+}
+
+otool_deps() {
+  local file="$1"
+  local skip_install_name="${2:-0}"
+  local line_no=0
+
+  otool -L "$file" | while IFS= read -r line; do
+    line_no=$((line_no + 1))
+    if [ "$line_no" -eq 1 ]; then
+      continue
+    fi
+    if [ "$skip_install_name" = "1" ] && [ "$line_no" -eq 2 ]; then
+      continue
+    fi
+    printf '%s\n' "$line" | awk '{print $1}'
+  done
+}
+
+is_system_ref() {
+  case "$1" in
+    @*|/System/*|/usr/lib/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_bundle_ref() {
+  if is_system_ref "$1"; then
+    return 1
+  fi
+  [ -f "$1" ]
+}
+
+find_mpv_lib() {
+  if [ -n "${TDRIVE_MPV_LIB:-}" ]; then
+    [ -f "$TDRIVE_MPV_LIB" ] || die "TDRIVE_MPV_LIB does not exist: $TDRIVE_MPV_LIB"
+    printf '%s\n' "$TDRIVE_MPV_LIB"
+    return
+  fi
+
+  local libdir=""
+  libdir="$(pkg-config --variable=libdir mpv 2>/dev/null || true)"
+  for candidate in \
+    "$libdir/libmpv.2.dylib" \
+    "$libdir/libmpv.dylib" \
+    "/opt/homebrew/opt/mpv/lib/libmpv.2.dylib" \
+    "/usr/local/opt/mpv/lib/libmpv.2.dylib"; do
+    if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  die "could not find libmpv; install mpv or set TDRIVE_MPV_LIB"
+}
+
+find_mpv_bin() {
+  if [ -n "${TDRIVE_MPV_BIN:-}" ]; then
+    [ -f "$TDRIVE_MPV_BIN" ] || die "TDRIVE_MPV_BIN does not exist: $TDRIVE_MPV_BIN"
+    printf '%s\n' "$TDRIVE_MPV_BIN"
+    return
+  fi
+
+  local found=""
+  found="$(command -v mpv || true)"
+  [ -n "$found" ] || die "could not find mpv sidecar; install mpv or set TDRIVE_MPV_BIN"
+  printf '%s\n' "$found"
+}
+
+assert_arch_compatible() {
+  local app_arches lib_arches arch
+  app_arches="$(lipo -archs "$BIN_PATH" 2>/dev/null || true)"
+  lib_arches="$(lipo -archs "$1" 2>/dev/null || true)"
+  [ -n "$app_arches" ] || return 0
+  [ -n "$lib_arches" ] || return 0
+
+  for arch in $app_arches; do
+    case " $lib_arches " in
+      *" $arch "*) ;;
+      *)
+        die "libmpv is missing architecture '$arch' required by the app. App: [$app_arches], libmpv: [$lib_arches]"
+        ;;
+    esac
+  done
+}
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+QUEUE="$TMP_DIR/queue"
+SEEN="$TMP_DIR/seen"
+COPIED="$TMP_DIR/copied"
+: > "$QUEUE"
+: > "$SEEN"
+: > "$COPIED"
+
+seen_path() {
+  grep -Fxq "$1" "$SEEN"
+}
+
+enqueue() {
+  local dep="$1"
+  if ! is_bundle_ref "$dep"; then
+    return
+  fi
+  if seen_path "$dep"; then
+    return
+  fi
+  printf '%s\n' "$dep" >> "$SEEN"
+  printf '%s\n' "$dep" >> "$QUEUE"
+}
+
+enqueue_deps_for() {
+  local file="$1"
+  local skip_install_name="${2:-0}"
+  local dep
+
+  while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    if is_system_ref "$dep"; then
+      continue
+    fi
+    if [ ! -f "$dep" ]; then
+      die "non-system dependency does not exist: $dep (from $file)"
+    fi
+    enqueue "$dep"
+  done < <(otool_deps "$file" "$skip_install_name")
+}
+
+copy_dylib() {
+  local src="$1"
+  local base dest
+  base="$(basename "$src")"
+  dest="$FRAMEWORKS_DIR/$base"
+
+  if [ -e "$dest" ]; then
+    if ! cmp -s "$src" "$dest"; then
+      die "dylib basename collision for $base ($src conflicts with existing bundled file)"
+    fi
+  else
+    cp -pL "$src" "$dest"
+    chmod u+w "$dest"
+    log "bundled $base"
+  fi
+  if ! grep -Fxq "$base" "$COPIED"; then
+    printf '%s\n' "$base" >> "$COPIED"
+  fi
+}
+
+rewrite_executable_refs() {
+  local file="$1"
+  local prefix="$2"
+  local dep base
+
+  while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    if is_bundle_ref "$dep"; then
+      base="$(basename "$dep")"
+      if [ -f "$FRAMEWORKS_DIR/$base" ]; then
+        install_name_tool -change "$dep" "$prefix/$base" "$file"
+      fi
+    fi
+  done < <(otool_deps "$file" 0)
+}
+
+rewrite_dylib_refs() {
+  local base="$1"
+  local dest dep dep_base
+  dest="$FRAMEWORKS_DIR/$base"
+
+  install_name_tool -id "@rpath/$base" "$dest"
+  while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    if is_bundle_ref "$dep"; then
+      dep_base="$(basename "$dep")"
+      if [ -f "$FRAMEWORKS_DIR/$dep_base" ]; then
+        install_name_tool -change "$dep" "@loader_path/$dep_base" "$dest"
+      fi
+    fi
+  done < <(otool_deps "$dest" 1)
+}
+
+verify_no_local_refs() {
+  local files bad
+  files=("$BIN_PATH" "$MPV_SIDECAR")
+  while IFS= read -r base; do
+    [ -n "$base" ] || continue
+    files+=("$FRAMEWORKS_DIR/$base")
+  done < "$COPIED"
+
+  bad="$(
+    for file in "${files[@]}"; do
+      [ -f "$file" ] || continue
+      otool -L "$file"
+    done | grep -E '/opt/homebrew|/usr/local' || true
+  )"
+  if [ -n "$bad" ]; then
+    printf '%s\n' "$bad" >&2
+    die "packaged app still references local Homebrew paths"
+  fi
+}
+
+MPV_LIB="$(find_mpv_lib)"
+MPV_BIN="$(find_mpv_bin)"
+assert_arch_compatible "$MPV_LIB"
+
+log "using libmpv: $MPV_LIB"
+log "using mpv sidecar: $MPV_BIN"
+
+cp -pL "$MPV_BIN" "$MPV_SIDECAR"
+chmod 755 "$MPV_SIDECAR"
+
+enqueue "$MPV_LIB"
+enqueue_deps_for "$MPV_BIN" 0
+
+while [ -s "$QUEUE" ]; do
+  src="$(sed -n '1p' "$QUEUE")"
+  sed -n '2,$p' "$QUEUE" > "$QUEUE.next" || true
+  mv "$QUEUE.next" "$QUEUE"
+
+  copy_dylib "$src"
+  enqueue_deps_for "$src" 1
+done
+
+while IFS= read -r base; do
+  [ -n "$base" ] || continue
+  rewrite_dylib_refs "$base"
+done < "$COPIED"
+
+rewrite_executable_refs "$BIN_PATH" "@executable_path/../Frameworks"
+rewrite_executable_refs "$MPV_SIDECAR" "@executable_path/../../Frameworks"
+verify_no_local_refs
+
+if command -v codesign >/dev/null 2>&1; then
+  log "ad-hoc signing bundled media runtime"
+  while IFS= read -r base; do
+    [ -n "$base" ] || continue
+    codesign --force --sign - "$FRAMEWORKS_DIR/$base" >/dev/null
+  done < "$COPIED"
+  codesign --force --sign - "$MPV_SIDECAR" >/dev/null
+
+  log "ad-hoc signing app bundle"
+  codesign --force --deep --sign - "$APP_PATH" >/dev/null
+fi
+
+"$MPV_SIDECAR" --no-config --version >/dev/null
+
+log "done"


### PR DESCRIPTION
Adds macOS arm64 native playback for formats the webview cannot decode.

- routes MKV/AVI/etc. through an in-app libmpv surface
- bundles mpv/libmpv + dylib closure into the macOS app
- hardens the native command bridge with a small whitelist

Known limits:
- macOS GUI release is arm64 only for this slice, not universal/Intel
- bundled runtime comes from CI Homebrew, not a pinned custom build yet
- native decode is still in-process

