### PR TITLE
experimental windows native playback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,14 @@ jobs:
       - name: Build Wails app
         shell: bash
         run: wails build -clean -platform "${{ matrix.platform }}"
+
+      - name: Verify Windows media bundle
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install mpvio.install --no-progress -y
+          $app = Get-ChildItem -Path build/bin -Filter "*.exe" | Select-Object -First 1
+          if ($null -eq $app) {
+            throw "no Windows executable found in build/bin"
+          }
+          ./scripts/package-mpv-windows.ps1 $app.FullName

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,11 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install mpv
 
+      - name: Install Windows media dependencies
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: choco install mpvio.install --no-progress -y
+
       - name: Install Wails
         run: |
           go install github.com/wailsapp/wails/v2/cmd/wails@v2.11.0
@@ -121,7 +126,8 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path dist | Out-Null
-          Compress-Archive -Force -Path "build/bin/${{ matrix.output_name }}" -DestinationPath "dist/${{ matrix.asset_name }}"
+          ./scripts/package-mpv-windows.ps1 "build/bin/${{ matrix.output_name }}"
+          Compress-Archive -Force -Path "build/bin/${{ matrix.output_name }}", "build/bin/media" -DestinationPath "dist/${{ matrix.asset_name }}"
 
       - name: Package (macOS)
         if: runner.os == 'macOS'

--- a/app_native_media.go
+++ b/app_native_media.go
@@ -49,7 +49,7 @@ func (a *App) OpenNativeMedia(msgID int, rect nativeplayer.Rect) (NativeMediaRes
 	}
 
 	token := opened.Token
-	htmlControls := nativeHTMLControlsEnabled()
+	htmlControls := nativeHTMLControlsEnabled() && nativeplayer.SupportsHTMLControls()
 	opts := nativeplayer.Options{UseHTMLControls: htmlControls}
 	if htmlControls {
 		opts.OnState = func(state nativeplayer.State) {

--- a/backend/nativeplayer/html_controls_darwin.go
+++ b/backend/nativeplayer/html_controls_darwin.go
@@ -1,0 +1,7 @@
+//go:build darwin
+
+package nativeplayer
+
+func SupportsHTMLControls() bool {
+	return true
+}

--- a/backend/nativeplayer/html_controls_unsupported.go
+++ b/backend/nativeplayer/html_controls_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package nativeplayer
+
+func SupportsHTMLControls() bool {
+	return false
+}

--- a/backend/nativeplayer/mpv_windows.go
+++ b/backend/nativeplayer/mpv_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package nativeplayer
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func findWindowsMPV() (string, error) {
+	if override := os.Getenv("TDRIVE_MPV_BIN"); override != "" {
+		if st, err := os.Stat(override); err == nil && !st.IsDir() {
+			return override, nil
+		}
+		return "", fmt.Errorf("TDRIVE_MPV_BIN is not executable")
+	}
+
+	if exe, err := os.Executable(); err == nil {
+		dir := filepath.Dir(exe)
+		for _, candidate := range []string{
+			filepath.Join(dir, "media", "mpv.exe"),
+			filepath.Join(dir, "mpv.exe"),
+		} {
+			if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
+				return candidate, nil
+			}
+		}
+	}
+
+	for _, name := range []string{"mpv.exe", "mpv"} {
+		if path, err := exec.LookPath(name); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("native player: mpv executable not found")
+}

--- a/backend/nativeplayer/player_linux.go
+++ b/backend/nativeplayer/player_linux.go
@@ -305,7 +305,7 @@ type Player struct {
 	closeOnce sync.Once
 }
 
-func Start(ctx context.Context, url string, rect Rect) (*Player, error) {
+func Start(ctx context.Context, url string, rect Rect, opts Options) (*Player, error) {
 	if !linuxNativePlayerEnabled() {
 		return nil, ErrUnsupported
 	}

--- a/backend/nativeplayer/player_unsupported.go
+++ b/backend/nativeplayer/player_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !windows
 
 package nativeplayer
 

--- a/backend/nativeplayer/player_windows.go
+++ b/backend/nativeplayer/player_windows.go
@@ -22,13 +22,22 @@ const (
 	wsClipChildren = 0x02000000
 	wsClipSiblings = 0x04000000
 
-	swHide        = 0
-	swpNoZOrder   = 0x0004
-	swpNoActivate = 0x0010
+	swHide = 0
+
+	jobObjectInfoClassExtendedLimitInformation = 9
+	jobObjectLimitKillOnJobClose               = 0x00002000
+
+	processTerminate = 0x0001
+	processSetQuota  = 0x0100
 )
 
 var (
-	user32 = syscall.NewLazyDLL("user32.dll")
+	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+	user32   = syscall.NewLazyDLL("user32.dll")
+
+	procAssignProcessToJobObject = kernel32.NewProc("AssignProcessToJobObject")
+	procCreateJobObjectW         = kernel32.NewProc("CreateJobObjectW")
+	procSetInformationJobObject  = kernel32.NewProc("SetInformationJobObject")
 
 	procCreateWindowExW        = user32.NewProc("CreateWindowExW")
 	procDestroyWindow          = user32.NewProc("DestroyWindow")
@@ -39,19 +48,27 @@ var (
 	procGetWindowThreadProcess = user32.NewProc("GetWindowThreadProcessId")
 	procIsWindowVisible        = user32.NewProc("IsWindowVisible")
 	procMoveWindow             = user32.NewProc("MoveWindow")
-	procSetWindowPos           = user32.NewProc("SetWindowPos")
 	procShowWindow             = user32.NewProc("ShowWindow")
+
+	enumWindowsMu       sync.Mutex
+	enumWindowsCallback = syscall.NewCallback(enumWindowsProc)
+	enumTargetPID       uint32
+	enumFirstWindow     uintptr
+	enumTitledWindow    uintptr
 )
 
 type Player struct {
 	mu      sync.Mutex
 	closed  bool
+	parent  uintptr
 	child   uintptr
 	ipcPath string
 	cmd     *exec.Cmd
 	done    chan error
+	job     syscall.Handle
 
 	destroyOnce sync.Once
+	jobOnce     sync.Once
 }
 
 func Start(ctx context.Context, url string, rect Rect) (*Player, error) {
@@ -68,7 +85,7 @@ func Start(ctx context.Context, url string, rect Rect) (*Player, error) {
 		return nil, err
 	}
 
-	player := &Player{child: child, done: make(chan error, 1)}
+	player := &Player{parent: parent, child: child, done: make(chan error, 1)}
 	if err := player.startProcess(ctx, url); err != nil {
 		player.destroyChild()
 		return nil, err
@@ -81,6 +98,11 @@ func (p *Player) startProcess(ctx context.Context, url string) error {
 	if err != nil {
 		return err
 	}
+	job, err := createKillOnCloseJob()
+	if err != nil {
+		return err
+	}
+	p.job = job
 
 	p.ipcPath = fmt.Sprintf(`\\.\pipe\tdrive-mpv-%d-%d`, os.Getpid(), time.Now().UnixNano())
 	args := []string{
@@ -102,13 +124,21 @@ func (p *Player) startProcess(ctx context.Context, url string) error {
 	cmd := exec.CommandContext(ctx, mpvPath, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	if err := cmd.Start(); err != nil {
+		p.closeJob()
 		return fmt.Errorf("native player: start mpv: %w", err)
+	}
+	if err := assignProcessToJob(job, cmd.Process.Pid); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		p.closeJob()
+		return err
 	}
 	p.cmd = cmd
 	go func() {
 		err := cmd.Wait()
 		p.done <- err
 		p.destroyChild()
+		p.closeJob()
 	}()
 	return nil
 }
@@ -122,22 +152,18 @@ func (p *Player) Resize(rect Rect) error {
 	}
 
 	p.mu.Lock()
+	parent := p.parent
 	child := p.child
 	closed := p.closed
 	p.mu.Unlock()
 	if closed || child == 0 {
 		return nil
 	}
-	parent := uintptr(0)
-	if hwnd, err := findTDriveWindow(); err == nil {
-		parent = hwnd
-	}
 	x, y, w, h := scaleRect(rect, parent)
 	ret, _, callErr := procMoveWindow.Call(child, uintptr(x), uintptr(y), uintptr(w), uintptr(h), 1)
 	if ret == 0 {
 		return callFailed("MoveWindow", callErr)
 	}
-	procSetWindowPos.Call(child, 0, uintptr(x), uintptr(y), uintptr(w), uintptr(h), swpNoZOrder|swpNoActivate)
 	return nil
 }
 
@@ -195,6 +221,7 @@ func (p *Player) Close() error {
 		}
 	}
 	p.destroyChild()
+	p.closeJob()
 	return nil
 }
 
@@ -210,6 +237,21 @@ func (p *Player) destroyChild() {
 		if child != 0 {
 			procShowWindow.Call(child, swHide)
 			procDestroyWindow.Call(child)
+		}
+	})
+}
+
+func (p *Player) closeJob() {
+	if p == nil {
+		return
+	}
+	p.jobOnce.Do(func() {
+		p.mu.Lock()
+		job := p.job
+		p.job = 0
+		p.mu.Unlock()
+		if job != 0 {
+			_ = syscall.CloseHandle(job)
 		}
 	})
 }
@@ -233,23 +275,19 @@ func writeMPVIPC(path string, payload []byte) error {
 }
 
 func findTDriveWindow() (uintptr, error) {
-	currentPID := uint32(os.Getpid())
-	var first uintptr
-	var titled uintptr
-	cb := syscall.NewCallback(func(hwnd uintptr, lparam uintptr) uintptr {
-		if !windowVisible(hwnd) || windowProcessID(hwnd) != currentPID {
-			return 1
-		}
-		if first == 0 {
-			first = hwnd
-		}
-		if strings.Contains(windowText(hwnd), "TDrive") {
-			titled = hwnd
-			return 0
-		}
-		return 1
-	})
-	ret, _, callErr := procEnumWindows.Call(cb, 0)
+	enumWindowsMu.Lock()
+	defer enumWindowsMu.Unlock()
+
+	enumTargetPID = uint32(os.Getpid())
+	enumFirstWindow = 0
+	enumTitledWindow = 0
+	ret, _, callErr := procEnumWindows.Call(enumWindowsCallback, 0)
+	first := enumFirstWindow
+	titled := enumTitledWindow
+	enumTargetPID = 0
+	enumFirstWindow = 0
+	enumTitledWindow = 0
+
 	if ret == 0 && titled == 0 && first == 0 {
 		return 0, callFailed("EnumWindows", callErr)
 	}
@@ -260,6 +298,20 @@ func findTDriveWindow() (uintptr, error) {
 		return first, nil
 	}
 	return 0, fmt.Errorf("native player: TDrive window not found")
+}
+
+func enumWindowsProc(hwnd uintptr, lparam uintptr) uintptr {
+	if !windowVisible(hwnd) || windowProcessID(hwnd) != enumTargetPID {
+		return 1
+	}
+	if enumFirstWindow == 0 {
+		enumFirstWindow = hwnd
+	}
+	if strings.Contains(windowText(hwnd), "TDrive") {
+		enumTitledWindow = hwnd
+		return 0
+	}
+	return 1
 }
 
 func createVideoChildWindow(parent uintptr, rect Rect) (uintptr, error) {
@@ -285,6 +337,71 @@ func createVideoChildWindow(parent uintptr, rect Rect) (uintptr, error) {
 		return 0, callFailed("CreateWindowExW", callErr)
 	}
 	return child, nil
+}
+
+type jobObjectBasicLimitInformation struct {
+	PerProcessUserTimeLimit int64
+	PerJobUserTimeLimit     int64
+	LimitFlags              uint32
+	MinimumWorkingSetSize   uintptr
+	MaximumWorkingSetSize   uintptr
+	ActiveProcessLimit      uint32
+	Affinity                uintptr
+	PriorityClass           uint32
+	SchedulingClass         uint32
+}
+
+type ioCounters struct {
+	ReadOperationCount  uint64
+	WriteOperationCount uint64
+	OtherOperationCount uint64
+	ReadTransferCount   uint64
+	WriteTransferCount  uint64
+	OtherTransferCount  uint64
+}
+
+type jobObjectExtendedLimitInformation struct {
+	BasicLimitInformation jobObjectBasicLimitInformation
+	IoInfo                ioCounters
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+func createKillOnCloseJob() (syscall.Handle, error) {
+	handle, _, callErr := procCreateJobObjectW.Call(0, 0)
+	if handle == 0 {
+		return 0, callFailed("CreateJobObjectW", callErr)
+	}
+
+	info := jobObjectExtendedLimitInformation{}
+	info.BasicLimitInformation.LimitFlags = jobObjectLimitKillOnJobClose
+	ret, _, callErr := procSetInformationJobObject.Call(
+		handle,
+		jobObjectInfoClassExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		unsafe.Sizeof(info),
+	)
+	if ret == 0 {
+		_ = syscall.CloseHandle(syscall.Handle(handle))
+		return 0, callFailed("SetInformationJobObject", callErr)
+	}
+	return syscall.Handle(handle), nil
+}
+
+func assignProcessToJob(job syscall.Handle, pid int) error {
+	process, err := syscall.OpenProcess(processSetQuota|processTerminate, false, uint32(pid))
+	if err != nil {
+		return fmt.Errorf("native player: open mpv process for job assignment: %w", err)
+	}
+	defer syscall.CloseHandle(process)
+
+	ret, _, callErr := procAssignProcessToJobObject.Call(uintptr(job), uintptr(process))
+	if ret == 0 {
+		return callFailed("AssignProcessToJobObject", callErr)
+	}
+	return nil
 }
 
 func scaleRect(rect Rect, hwnd uintptr) (int, int, int, int) {

--- a/backend/nativeplayer/player_windows.go
+++ b/backend/nativeplayer/player_windows.go
@@ -1,0 +1,339 @@
+//go:build windows
+
+package nativeplayer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+const (
+	wsChild        = 0x40000000
+	wsVisible      = 0x10000000
+	wsClipChildren = 0x02000000
+	wsClipSiblings = 0x04000000
+
+	swHide        = 0
+	swpNoZOrder   = 0x0004
+	swpNoActivate = 0x0010
+)
+
+var (
+	user32 = syscall.NewLazyDLL("user32.dll")
+
+	procCreateWindowExW        = user32.NewProc("CreateWindowExW")
+	procDestroyWindow          = user32.NewProc("DestroyWindow")
+	procEnumWindows            = user32.NewProc("EnumWindows")
+	procGetDpiForWindow        = user32.NewProc("GetDpiForWindow")
+	procGetWindowTextLengthW   = user32.NewProc("GetWindowTextLengthW")
+	procGetWindowTextW         = user32.NewProc("GetWindowTextW")
+	procGetWindowThreadProcess = user32.NewProc("GetWindowThreadProcessId")
+	procIsWindowVisible        = user32.NewProc("IsWindowVisible")
+	procMoveWindow             = user32.NewProc("MoveWindow")
+	procSetWindowPos           = user32.NewProc("SetWindowPos")
+	procShowWindow             = user32.NewProc("ShowWindow")
+)
+
+type Player struct {
+	mu      sync.Mutex
+	closed  bool
+	child   uintptr
+	ipcPath string
+	cmd     *exec.Cmd
+	done    chan error
+
+	destroyOnce sync.Once
+}
+
+func Start(ctx context.Context, url string, rect Rect) (*Player, error) {
+	if !rect.Valid() {
+		return nil, fmt.Errorf("native player: invalid view rect")
+	}
+
+	parent, err := findTDriveWindow()
+	if err != nil {
+		return nil, err
+	}
+	child, err := createVideoChildWindow(parent, rect)
+	if err != nil {
+		return nil, err
+	}
+
+	player := &Player{child: child, done: make(chan error, 1)}
+	if err := player.startProcess(ctx, url); err != nil {
+		player.destroyChild()
+		return nil, err
+	}
+	return player, nil
+}
+
+func (p *Player) startProcess(ctx context.Context, url string) error {
+	mpvPath, err := findWindowsMPV()
+	if err != nil {
+		return err
+	}
+
+	p.ipcPath = fmt.Sprintf(`\\.\pipe\tdrive-mpv-%d-%d`, os.Getpid(), time.Now().UnixNano())
+	args := []string{
+		"--no-config",
+		"--terminal=no",
+		"--msg-level=all=warn",
+		"--ytdl=no",
+		"--hwdec=auto-safe",
+		"--osc=yes",
+		"--osd-bar=yes",
+		"--force-window=immediate",
+		"--input-terminal=no",
+		"--input-ipc-server=" + p.ipcPath,
+		fmt.Sprintf("--wid=%d", p.child),
+		"--",
+		url,
+	}
+
+	cmd := exec.CommandContext(ctx, mpvPath, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("native player: start mpv: %w", err)
+	}
+	p.cmd = cmd
+	go func() {
+		err := cmd.Wait()
+		p.done <- err
+		p.destroyChild()
+	}()
+	return nil
+}
+
+func (p *Player) Resize(rect Rect) error {
+	if p == nil {
+		return nil
+	}
+	if !rect.Valid() {
+		return fmt.Errorf("native player: invalid view rect")
+	}
+
+	p.mu.Lock()
+	child := p.child
+	closed := p.closed
+	p.mu.Unlock()
+	if closed || child == 0 {
+		return nil
+	}
+	parent := uintptr(0)
+	if hwnd, err := findTDriveWindow(); err == nil {
+		parent = hwnd
+	}
+	x, y, w, h := scaleRect(rect, parent)
+	ret, _, callErr := procMoveWindow.Call(child, uintptr(x), uintptr(y), uintptr(w), uintptr(h), 1)
+	if ret == 0 {
+		return callFailed("MoveWindow", callErr)
+	}
+	procSetWindowPos.Call(child, 0, uintptr(x), uintptr(y), uintptr(w), uintptr(h), swpNoZOrder|swpNoActivate)
+	return nil
+}
+
+func (p *Player) Command(command ...string) error {
+	if p == nil || len(command) == 0 {
+		return nil
+	}
+
+	p.mu.Lock()
+	ipcPath := p.ipcPath
+	closed := p.closed
+	p.mu.Unlock()
+	if closed || ipcPath == "" {
+		return nil
+	}
+
+	payload, err := json.Marshal(struct {
+		Command []string `json:"command"`
+	}{Command: command})
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+	return writeMPVIPC(ipcPath, payload)
+}
+
+func (p *Player) Close() error {
+	if p == nil {
+		return nil
+	}
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	ipcPath := p.ipcPath
+	cmd := p.cmd
+	done := p.done
+	p.mu.Unlock()
+
+	if ipcPath != "" {
+		_ = writeMPVIPC(ipcPath, []byte(`{"command":["quit"]}`+"\n"))
+	}
+	if cmd != nil && cmd.Process != nil {
+		select {
+		case <-done:
+		case <-time.After(750 * time.Millisecond):
+			_ = cmd.Process.Kill()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+			}
+		}
+	}
+	p.destroyChild()
+	return nil
+}
+
+func (p *Player) destroyChild() {
+	if p == nil {
+		return
+	}
+	p.destroyOnce.Do(func() {
+		p.mu.Lock()
+		child := p.child
+		p.child = 0
+		p.mu.Unlock()
+		if child != 0 {
+			procShowWindow.Call(child, swHide)
+			procDestroyWindow.Call(child)
+		}
+	})
+}
+
+func writeMPVIPC(path string, payload []byte) error {
+	var lastErr error
+	for attempt := 0; attempt < 20; attempt++ {
+		file, err := os.OpenFile(path, os.O_WRONLY, 0)
+		if err == nil {
+			_, writeErr := file.Write(payload)
+			closeErr := file.Close()
+			if writeErr != nil {
+				return writeErr
+			}
+			return closeErr
+		}
+		lastErr = err
+		time.Sleep(25 * time.Millisecond)
+	}
+	return fmt.Errorf("native player: mpv IPC unavailable: %w", lastErr)
+}
+
+func findTDriveWindow() (uintptr, error) {
+	currentPID := uint32(os.Getpid())
+	var first uintptr
+	var titled uintptr
+	cb := syscall.NewCallback(func(hwnd uintptr, lparam uintptr) uintptr {
+		if !windowVisible(hwnd) || windowProcessID(hwnd) != currentPID {
+			return 1
+		}
+		if first == 0 {
+			first = hwnd
+		}
+		if strings.Contains(windowText(hwnd), "TDrive") {
+			titled = hwnd
+			return 0
+		}
+		return 1
+	})
+	ret, _, callErr := procEnumWindows.Call(cb, 0)
+	if ret == 0 && titled == 0 && first == 0 {
+		return 0, callFailed("EnumWindows", callErr)
+	}
+	if titled != 0 {
+		return titled, nil
+	}
+	if first != 0 {
+		return first, nil
+	}
+	return 0, fmt.Errorf("native player: TDrive window not found")
+}
+
+func createVideoChildWindow(parent uintptr, rect Rect) (uintptr, error) {
+	x, y, w, h := scaleRect(rect, parent)
+	className, _ := syscall.UTF16PtrFromString("STATIC")
+	title, _ := syscall.UTF16PtrFromString("TDriveNativeVideo")
+	style := uintptr(wsChild | wsVisible | wsClipChildren | wsClipSiblings)
+	child, _, callErr := procCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(className)),
+		uintptr(unsafe.Pointer(title)),
+		style,
+		uintptr(x),
+		uintptr(y),
+		uintptr(w),
+		uintptr(h),
+		parent,
+		0,
+		0,
+		0,
+	)
+	if child == 0 {
+		return 0, callFailed("CreateWindowExW", callErr)
+	}
+	return child, nil
+}
+
+func scaleRect(rect Rect, hwnd uintptr) (int, int, int, int) {
+	scale := 1.0
+	if hwnd != 0 {
+		scale = float64(dpiForWindow(hwnd)) / 96.0
+	}
+	x := int(math.Round(math.Max(0, rect.X*scale)))
+	y := int(math.Round(math.Max(0, rect.Y*scale)))
+	w := int(math.Round(math.Max(1, rect.Width*scale)))
+	h := int(math.Round(math.Max(1, rect.Height*scale)))
+	return x, y, w, h
+}
+
+func dpiForWindow(hwnd uintptr) int {
+	if err := procGetDpiForWindow.Find(); err != nil {
+		return 96
+	}
+	ret, _, _ := procGetDpiForWindow.Call(hwnd)
+	if ret == 0 {
+		return 96
+	}
+	return int(ret)
+}
+
+func windowVisible(hwnd uintptr) bool {
+	ret, _, _ := procIsWindowVisible.Call(hwnd)
+	return ret != 0
+}
+
+func windowProcessID(hwnd uintptr) uint32 {
+	var pid uint32
+	procGetWindowThreadProcess.Call(hwnd, uintptr(unsafe.Pointer(&pid)))
+	return pid
+}
+
+func windowText(hwnd uintptr) string {
+	length, _, _ := procGetWindowTextLengthW.Call(hwnd)
+	if length == 0 {
+		return ""
+	}
+	buf := make([]uint16, int(length)+1)
+	procGetWindowTextW.Call(hwnd, uintptr(unsafe.Pointer(&buf[0])), length+1)
+	return syscall.UTF16ToString(buf)
+}
+
+func callFailed(name string, err error) error {
+	if errno, ok := err.(syscall.Errno); ok && errno == 0 {
+		return fmt.Errorf("native player: %s failed", name)
+	}
+	return fmt.Errorf("native player: %s failed: %w", name, err)
+}

--- a/backend/nativeplayer/player_windows.go
+++ b/backend/nativeplayer/player_windows.go
@@ -73,7 +73,7 @@ type Player struct {
 	jobOnce     sync.Once
 }
 
-func Start(ctx context.Context, url string, rect Rect) (*Player, error) {
+func Start(ctx context.Context, url string, rect Rect, opts Options) (*Player, error) {
 	if !windowsNativePlayerEnabled() {
 		return nil, ErrUnsupported
 	}

--- a/backend/nativeplayer/player_windows.go
+++ b/backend/nativeplayer/player_windows.go
@@ -31,6 +31,8 @@ const (
 	processSetQuota  = 0x0100
 )
 
+const windowsNativePlayerFlag = "TDRIVE_EXPERIMENTAL_WINDOWS_NATIVE_PLAYER"
+
 var (
 	kernel32 = syscall.NewLazyDLL("kernel32.dll")
 	user32   = syscall.NewLazyDLL("user32.dll")
@@ -72,6 +74,9 @@ type Player struct {
 }
 
 func Start(ctx context.Context, url string, rect Rect) (*Player, error) {
+	if !windowsNativePlayerEnabled() {
+		return nil, ErrUnsupported
+	}
 	if !rect.Valid() {
 		return nil, fmt.Errorf("native player: invalid view rect")
 	}
@@ -453,4 +458,8 @@ func callFailed(name string, err error) error {
 		return fmt.Errorf("native player: %s failed", name)
 	}
 	return fmt.Errorf("native player: %s failed: %w", name, err)
+}
+
+func windowsNativePlayerEnabled() bool {
+	return os.Getenv(windowsNativePlayerFlag) == "1"
 }

--- a/backend/nativeplayer/preflight_unsupported.go
+++ b/backend/nativeplayer/preflight_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !darwin && !windows
 
 package nativeplayer
 

--- a/backend/nativeplayer/preflight_windows.go
+++ b/backend/nativeplayer/preflight_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package nativeplayer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+const preflightTimeout = 6 * time.Second
+
+// PreflightDecode decodes one frame out-of-process before the sidecar player is
+// attached to the app window. The sidecar is already out-of-process, but this
+// keeps broken local decoder builds from flashing a window or attaching a dead
+// child surface before we can show a normal error.
+func PreflightDecode(ctx context.Context, url string) error {
+	if os.Getenv("TDRIVE_SKIP_MPV_PREFLIGHT") == "1" {
+		return nil
+	}
+	mpvPath, err := findWindowsMPV()
+	if err != nil {
+		return nil
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, preflightTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(runCtx, mpvPath,
+		"--no-config",
+		"--really-quiet",
+		"--terminal=no",
+		"--force-window=no",
+		"--vo=null",
+		"--ao=null",
+		"--frames=1",
+		"--demuxer-readahead-secs=0.5",
+		"--demuxer-max-bytes=2097152",
+		"--",
+		url,
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		if runCtx.Err() != nil {
+			return fmt.Errorf("%w: timed out", ErrDecoderUnsafe)
+		}
+		if len(output) > 0 {
+			return fmt.Errorf("%w: %v: %s", ErrDecoderUnsafe, err, string(output))
+		}
+		return fmt.Errorf("%w: %v", ErrDecoderUnsafe, err)
+	}
+	return nil
+}

--- a/backend/nativeplayer/preflight_windows.go
+++ b/backend/nativeplayer/preflight_windows.go
@@ -18,6 +18,9 @@ const preflightTimeout = 6 * time.Second
 // keeps broken local decoder builds from flashing a window or attaching a dead
 // child surface before we can show a normal error.
 func PreflightDecode(ctx context.Context, url string) error {
+	if !windowsNativePlayerEnabled() {
+		return nil
+	}
 	if os.Getenv("TDRIVE_SKIP_MPV_PREFLIGHT") == "1" {
 		return nil
 	}

--- a/scripts/package-mpv-windows.ps1
+++ b/scripts/package-mpv-windows.ps1
@@ -1,0 +1,77 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppExe
+)
+
+$ErrorActionPreference = "Stop"
+
+function Fail($Message) {
+    throw "package-mpv-windows: $Message"
+}
+
+function Find-MpvExecutable {
+    if ($env:TDRIVE_MPV_BIN) {
+        if (Test-Path -LiteralPath $env:TDRIVE_MPV_BIN -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $env:TDRIVE_MPV_BIN).Path
+        }
+        Fail "TDRIVE_MPV_BIN does not exist: $env:TDRIVE_MPV_BIN"
+    }
+
+    if ($env:TDRIVE_MPV_DIR) {
+        $candidate = Join-Path $env:TDRIVE_MPV_DIR "mpv.exe"
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+        Fail "TDRIVE_MPV_DIR does not contain mpv.exe: $env:TDRIVE_MPV_DIR"
+    }
+
+    $chocoRoot = if ($env:ChocolateyInstall) { $env:ChocolateyInstall } else { "C:\ProgramData\chocolatey" }
+    $known = @(
+        (Join-Path $chocoRoot "lib\mpvio.install\tools\mpv.exe"),
+        (Join-Path $chocoRoot "lib\mpv.install\tools\mpv.exe"),
+        (Join-Path $chocoRoot "lib\mpv\tools\mpv.exe")
+    )
+    foreach ($candidate in $known) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    $command = Get-Command "mpv.exe" -ErrorAction SilentlyContinue
+    if ($command -and (Test-Path -LiteralPath $command.Source -PathType Leaf)) {
+        return (Resolve-Path -LiteralPath $command.Source).Path
+    }
+
+    Fail "could not find mpv.exe; install mpv or set TDRIVE_MPV_BIN"
+}
+
+if ($env:OS -ne "Windows_NT") {
+    Fail "this script only runs on Windows"
+}
+if (-not (Test-Path -LiteralPath $AppExe -PathType Leaf)) {
+    Fail "app executable not found: $AppExe"
+}
+
+$appPath = (Resolve-Path -LiteralPath $AppExe).Path
+$appDir = Split-Path -Parent $appPath
+$mediaDir = Join-Path $appDir "media"
+$mpvPath = Find-MpvExecutable
+$mpvDir = Split-Path -Parent $mpvPath
+
+Write-Host "package-mpv-windows: using mpv: $mpvPath"
+
+Remove-Item -LiteralPath $mediaDir -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $mediaDir | Out-Null
+
+Copy-Item -LiteralPath $mpvPath -Destination (Join-Path $mediaDir "mpv.exe") -Force
+Get-ChildItem -LiteralPath $mpvDir -File -Filter "*.dll" | ForEach-Object {
+    Copy-Item -LiteralPath $_.FullName -Destination $mediaDir -Force
+}
+
+$bundledMPV = Join-Path $mediaDir "mpv.exe"
+& $bundledMPV --no-config --version | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Fail "bundled mpv smoke test failed"
+}
+
+Write-Host "package-mpv-windows: bundled mpv runtime into $mediaDir"


### PR DESCRIPTION
Adds experimental Windows native video playback.

- embeds bundled mpv in a Win32 child window
- controls mpv over Windows named-pipe IPC
- bundles mpv runtime into Windows release zips
- caches the parent HWND and uses one package-level EnumWindows callback
- wraps mpv.exe in a kill-on-close Job Object to avoid orphaned sidecars

