### PR TITLE
add video scrub thumbnails

### DIFF
--- a/backend/core/engine.go
+++ b/backend/core/engine.go
@@ -431,6 +431,7 @@ func (e *Engine) newMediaService() *media.Service {
 		DB:     backend.DB,
 		Peers:  peerResolverFn(e.ResolvePeer),
 		Ranges: ranges,
+		Thumbs: e.thumbs,
 	})
 }
 

--- a/backend/media/server.go
+++ b/backend/media/server.go
@@ -15,7 +15,11 @@ import (
 	"time"
 )
 
-const mediaRoutePrefix = "/media/file/"
+const (
+	mediaRoutePrefix       = "/media/file/"
+	mediaThumbRoutePrefix  = "/media/thumb/"
+	mediaThumbSourcePrefix = "/media/thumb-source/"
+)
 
 type Server struct {
 	owner *Service
@@ -45,8 +49,11 @@ func (s *Server) Add(session *Session) error {
 	s.mu.Lock()
 	s.sessions[session.Token()] = session
 	url := s.baseURL + mediaRoutePrefix + session.Token()
+	thumbSourceURL := s.baseURL + mediaThumbSourcePrefix + session.Token()
+	thumbURL := s.baseURL + mediaThumbRoutePrefix + session.Token()
 	s.mu.Unlock()
 	session.setURL(url)
+	session.setThumbnailURLs(thumbSourceURL, thumbURL)
 	return nil
 }
 
@@ -100,6 +107,8 @@ func (s *Server) ensureStarted() error {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc(mediaRoutePrefix, s.handleFile)
+	mux.HandleFunc(mediaThumbSourcePrefix, s.handleThumbSource)
+	mux.HandleFunc(mediaThumbRoutePrefix, s.handleThumbnail)
 	srv := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
@@ -118,11 +127,19 @@ func (s *Server) ensureStarted() error {
 }
 
 func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
+	s.handleSessionBytes(w, r, mediaRoutePrefix, (*Session).ReadAt)
+}
+
+func (s *Server) handleThumbSource(w http.ResponseWriter, r *http.Request) {
+	s.handleSessionBytes(w, r, mediaThumbSourcePrefix, (*Session).ReadThumbAt)
+}
+
+func (s *Server) handleSessionBytes(w http.ResponseWriter, r *http.Request, prefix string, readAt func(*Session, context.Context, []byte, int64) (int, error)) {
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	token := strings.TrimPrefix(path.Clean(r.URL.Path), mediaRoutePrefix)
+	token := strings.TrimPrefix(path.Clean(r.URL.Path), prefix)
 	if token == "" || strings.Contains(token, "/") {
 		http.NotFound(w, r)
 		return
@@ -162,8 +179,54 @@ func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodHead || length == 0 {
 		return
 	}
-	if err := streamSessionRange(r.Context(), w, session, start, length); err != nil {
+	if err := streamSessionRange(r.Context(), w, session, start, length, readAt); err != nil {
 		return
+	}
+}
+
+func (s *Server) handleThumbnail(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	token := strings.TrimPrefix(path.Clean(r.URL.Path), mediaThumbRoutePrefix)
+	if token == "" || strings.Contains(token, "/") {
+		http.NotFound(w, r)
+		return
+	}
+	session := s.session(token)
+	if session == nil {
+		http.NotFound(w, r)
+		return
+	}
+	seconds, err := strconv.ParseFloat(r.URL.Query().Get("t"), 64)
+	if err != nil || seconds < 0 {
+		http.Error(w, "invalid thumbnail time", http.StatusBadRequest)
+		return
+	}
+	data, err := session.Thumbnail(r.Context(), seconds)
+	switch {
+	case err == nil:
+		w.Header().Set("Content-Type", videoThumbMime)
+		w.Header().Set("Cache-Control", "private, max-age=86400")
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+		w.WriteHeader(http.StatusOK)
+		if r.Method != http.MethodHead {
+			_, _ = w.Write(data)
+		}
+	case errors.Is(err, ErrThumbnailPending):
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusAccepted)
+	case errors.Is(err, ErrThumbnailUnavailable):
+		http.Error(w, "thumbnail unavailable", http.StatusServiceUnavailable)
+	default:
+		http.Error(w, "thumbnail error", http.StatusInternalServerError)
 	}
 }
 
@@ -214,7 +277,7 @@ func parseRangeHeader(raw string, size int64) (start, end int64, partial bool, o
 	}
 }
 
-func streamSessionRange(ctx context.Context, w io.Writer, session *Session, start, length int64) error {
+func streamSessionRange(ctx context.Context, w io.Writer, session *Session, start, length int64, readAt func(*Session, context.Context, []byte, int64) (int, error)) error {
 	const chunkSize = 256 * 1024
 	buf := make([]byte, chunkSize)
 	var sent int64
@@ -223,7 +286,7 @@ func streamSessionRange(ctx context.Context, w io.Writer, session *Session, star
 		if want > int64(len(buf)) {
 			want = int64(len(buf))
 		}
-		n, err := session.ReadAt(ctx, buf[:want], start+sent)
+		n, err := readAt(session, ctx, buf[:want], start+sent)
 		if n > 0 {
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				return writeErr

--- a/backend/media/server_test.go
+++ b/backend/media/server_test.go
@@ -5,12 +5,18 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"TDrive/backend/projection"
 	"TDrive/backend/tgclient"
+	"TDrive/backend/thumbnail"
 
 	_ "modernc.org/sqlite"
 )
@@ -204,6 +210,92 @@ func TestMediaSessionReadsAcrossMultipartSegments(t *testing.T) {
 	}
 }
 
+func TestMediaServerQueuesAndServesVideoThumbnail(t *testing.T) {
+	db := newResolverTestDB(t)
+	body := testBytes(4096)
+	mustApplyOp(t, db, 10, projection.Op{
+		Type:     projection.OpFileUpload,
+		Parent:   projection.RootParent,
+		Name:     "clip.mp4",
+		FileSize: int64(len(body)),
+	})
+	ranges := newMediaRangeFake(map[int64][]byte{10: body})
+	gen := &fakeVideoThumbGenerator{available: true}
+	svc := NewService(Config{
+		DB:             db,
+		Peers:          staticPeerResolver{peer: ranges.peer},
+		Ranges:         ranges,
+		Thumbs:         thumbnail.NewCache(t.TempDir(), 1<<20),
+		ThumbGenerator: gen,
+	})
+	defer svc.Close()
+	opened, err := svc.Open(context.Background(), testChannelID, 10)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if opened.ThumbnailURL == "" {
+		t.Fatalf("Open missing ThumbnailURL: %+v", opened)
+	}
+
+	resp, err := http.Get(opened.ThumbnailURL + "?t=14")
+	if err != nil {
+		t.Fatalf("first thumbnail GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("first thumbnail status = %d, want 202", resp.StatusCode)
+	}
+
+	got := waitForThumbnail(t, opened.ThumbnailURL+"?t=14")
+	wantPrefix := []byte("thumb:10:")
+	if !bytes.HasPrefix(got, wantPrefix) {
+		t.Fatalf("thumbnail body %q does not start with %q", got, wantPrefix)
+	}
+
+	call := gen.firstCall(t)
+	if call.seconds != 10 {
+		t.Fatalf("generated second = %d, want rounded bucket 10", call.seconds)
+	}
+	if !strings.Contains(call.sourceURL, mediaThumbSourcePrefix) {
+		t.Fatalf("generator source URL = %q, want thumbnail source route", call.sourceURL)
+	}
+	if !bytes.Equal(call.sourceBytes, body[16:24]) {
+		t.Fatalf("generator source bytes = %x, want %x", call.sourceBytes, body[16:24])
+	}
+}
+
+func TestMediaServerThumbnailUnavailableWithoutGenerator(t *testing.T) {
+	db := newResolverTestDB(t)
+	body := testBytes(256)
+	mustApplyOp(t, db, 10, projection.Op{
+		Type:     projection.OpFileUpload,
+		Parent:   projection.RootParent,
+		Name:     "clip.mp4",
+		FileSize: int64(len(body)),
+	})
+	ranges := newMediaRangeFake(map[int64][]byte{10: body})
+	svc := NewService(Config{
+		DB:             db,
+		Peers:          staticPeerResolver{peer: ranges.peer},
+		Ranges:         ranges,
+		ThumbGenerator: &fakeVideoThumbGenerator{available: false},
+	})
+	defer svc.Close()
+	opened, err := svc.Open(context.Background(), testChannelID, 10)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	resp, err := http.Get(opened.ThumbnailURL + "?t=1")
+	if err != nil {
+		t.Fatalf("thumbnail GET: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("thumbnail status = %d, want 503", resp.StatusCode)
+	}
+}
+
 func TestMediaOpenRejectsEncryptedFiles(t *testing.T) {
 	db := newResolverTestDB(t)
 	mustApplyOp(t, db, 10, projection.Op{
@@ -253,6 +345,93 @@ func (s staticPeerResolver) ResolvePeer(context.Context, int64) (tgclient.InputP
 type mediaRangeFake struct {
 	peer   tgclient.InputPeer
 	bodies map[int64][]byte
+}
+
+type fakeVideoThumbCall struct {
+	seconds     int
+	sourceURL   string
+	sourceBytes []byte
+}
+
+type fakeVideoThumbGenerator struct {
+	available bool
+
+	mu    sync.Mutex
+	calls []fakeVideoThumbCall
+}
+
+func (f *fakeVideoThumbGenerator) Available() bool {
+	return f != nil && f.available
+}
+
+func (f *fakeVideoThumbGenerator) GenerateVideoThumbnail(ctx context.Context, sourceURL, outPath string, seconds int) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sourceURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Range", "bytes=16-23")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	source, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("source status = %d", resp.StatusCode)
+	}
+	f.mu.Lock()
+	f.calls = append(f.calls, fakeVideoThumbCall{
+		seconds:     seconds,
+		sourceURL:   sourceURL,
+		sourceBytes: append([]byte(nil), source...),
+	})
+	f.mu.Unlock()
+	return os.WriteFile(outPath, []byte(fmt.Sprintf("thumb:%d:%x", seconds, source)), 0o600)
+}
+
+func (f *fakeVideoThumbGenerator) firstCall(t *testing.T) fakeVideoThumbCall {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		if len(f.calls) > 0 {
+			call := f.calls[0]
+			f.mu.Unlock()
+			return call
+		}
+		f.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("thumbnail generator was not called")
+	return fakeVideoThumbCall{}
+}
+
+func waitForThumbnail(t *testing.T, url string) []byte {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatalf("thumbnail GET: %v", err)
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			t.Fatalf("thumbnail read: %v", readErr)
+		}
+		if resp.StatusCode == http.StatusOK {
+			return body
+		}
+		if resp.StatusCode != http.StatusAccepted {
+			t.Fatalf("thumbnail status = %d body=%q", resp.StatusCode, body)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("thumbnail did not become ready")
+	return nil
 }
 
 func newMediaRangeFake(bodies map[int64][]byte) *mediaRangeFake {

--- a/backend/media/service.go
+++ b/backend/media/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"TDrive/backend/tgclient"
+	"TDrive/backend/thumbnail"
 )
 
 type PeerResolver interface {
@@ -13,9 +14,11 @@ type PeerResolver interface {
 }
 
 type Config struct {
-	DB     *sql.DB
-	Peers  PeerResolver
-	Ranges tgclient.RangeClient
+	DB             *sql.DB
+	Peers          PeerResolver
+	Ranges         tgclient.RangeClient
+	Thumbs         *thumbnail.Cache
+	ThumbGenerator VideoThumbnailGenerator
 }
 
 // Service is the app-facing media entry point. It owns logical file resolution
@@ -23,6 +26,8 @@ type Config struct {
 type Service struct {
 	peers    PeerResolver
 	ranges   tgclient.RangeClient
+	thumbs   *thumbnail.Cache
+	thumbGen VideoThumbnailGenerator
 	resolver *Resolver
 	server   *Server
 }
@@ -31,8 +36,14 @@ func NewService(cfg Config) *Service {
 	s := &Service{
 		peers:    cfg.Peers,
 		ranges:   cfg.Ranges,
+		thumbs:   cfg.Thumbs,
+		thumbGen: cfg.ThumbGenerator,
 		resolver: NewResolver(cfg.DB),
 	}
+	if s.thumbGen == nil {
+		s.thumbGen = NewMPVThumbnailGenerator()
+	}
+	sweepStaleVideoThumbnailDirs()
 	s.server = NewServer(s)
 	return s
 }
@@ -94,7 +105,7 @@ func (s *Service) Open(ctx context.Context, channelID, fileID int64) (OpenResult
 		return OpenResult{}, fmt.Errorf("media: logical size mismatch: segments=%d file=%d", start, file.StoredSize)
 	}
 
-	session, err := newSession(file, segments, s.ranges)
+	session, err := newSession(file, segments, s.ranges, s.thumbs, s.thumbGen)
 	if err != nil {
 		return OpenResult{}, err
 	}
@@ -103,10 +114,11 @@ func (s *Service) Open(ctx context.Context, channelID, fileID int64) (OpenResult
 		return OpenResult{}, err
 	}
 	return OpenResult{
-		Token: session.Token(),
-		URL:   session.URL(),
-		Name:  file.Name,
-		Info:  file,
+		Token:        session.Token(),
+		URL:          session.URL(),
+		ThumbnailURL: session.ThumbnailURL(),
+		Name:         file.Name,
+		Info:         file,
 	}, nil
 }
 

--- a/backend/media/session.go
+++ b/backend/media/session.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"TDrive/backend/tgclient"
+	"TDrive/backend/thumbnail"
 )
 
 type resolvedSegment struct {
@@ -19,30 +20,41 @@ type resolvedSegment struct {
 }
 
 type Session struct {
-	token    string
-	url      string
-	file     LogicalFile
-	segments []resolvedSegment
-	reader   *RangeReader
+	token       string
+	url         string
+	thumbURL    string
+	sourceURL   string
+	file        LogicalFile
+	segments    []resolvedSegment
+	reader      *RangeReader
+	thumbReader *RangeReader
+	thumbs      *videoThumbnailer
 
 	mu        sync.Mutex
 	lastTouch time.Time
 	closed    bool
 }
 
-func newSession(file LogicalFile, segments []resolvedSegment, ranges tgclient.RangeClient) (*Session, error) {
+func newSession(file LogicalFile, segments []resolvedSegment, ranges tgclient.RangeClient, cache *thumbnail.Cache, generator VideoThumbnailGenerator) (*Session, error) {
 	token, err := randomToken()
 	if err != nil {
 		return nil, err
 	}
 	copied := append([]resolvedSegment(nil), segments...)
-	return &Session{
-		token:     token,
-		file:      file,
-		segments:  copied,
-		reader:    NewRangeReader(RangeReaderConfig{Client: ranges}),
+	s := &Session{
+		token:    token,
+		file:     file,
+		segments: copied,
+		reader:   NewRangeReader(RangeReaderConfig{Client: ranges}),
+		thumbReader: NewRangeReader(RangeReaderConfig{
+			Client:         ranges,
+			MaxCacheBytes:  8 * 1024 * 1024,
+			MaxConcurrency: 1,
+		}),
 		lastTouch: time.Now(),
-	}, nil
+	}
+	s.thumbs = newVideoThumbnailer(s, cache, generator)
+	return s, nil
 }
 
 func (s *Session) Token() string {
@@ -61,10 +73,32 @@ func (s *Session) URL() string {
 	return s.url
 }
 
+func (s *Session) ThumbnailURL() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.thumbURL
+}
+
 func (s *Session) setURL(url string) {
 	s.mu.Lock()
 	s.url = url
 	s.mu.Unlock()
+}
+
+func (s *Session) setThumbnailURLs(sourceURL, thumbURL string) {
+	s.mu.Lock()
+	s.sourceURL = sourceURL
+	s.thumbURL = thumbURL
+	s.mu.Unlock()
+}
+
+func (s *Session) thumbnailSourceURL() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sourceURL
 }
 
 func (s *Session) Size() int64 {
@@ -101,14 +135,44 @@ func (s *Session) Close() {
 	if s.reader != nil {
 		s.reader.Close()
 	}
+	if s.thumbReader != nil {
+		s.thumbReader.Close()
+	}
+	if s.thumbs != nil {
+		s.thumbs.Close()
+	}
 }
 
 func (s *Session) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	return s.readAt(ctx, s.reader, p, off)
+}
+
+func (s *Session) ReadThumbAt(ctx context.Context, p []byte, off int64) (int, error) {
+	return s.readAt(ctx, s.thumbReader, p, off)
+}
+
+func (s *Session) Thumbnail(ctx context.Context, seconds float64) ([]byte, error) {
+	if s == nil || s.thumbs == nil {
+		return nil, ErrThumbnailUnavailable
+	}
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return nil, ErrSessionNotFound
+	}
+	return s.thumbs.Get(ctx, seconds)
+}
+
+func (s *Session) readAt(ctx context.Context, reader *RangeReader, p []byte, off int64) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
 	if off < 0 {
 		return 0, fmt.Errorf("media: negative session offset")
+	}
+	if reader == nil {
+		return 0, ErrRangeClientNotReady
 	}
 	s.mu.Lock()
 	closed := s.closed
@@ -142,7 +206,7 @@ func (s *Session) ReadAt(ctx context.Context, p []byte, off int64) (int, error) 
 		if int64(need) > available {
 			need = int(available)
 		}
-		n, err := s.reader.ReadStoredAt(ctx, seg.ref, p[done:done+need], segOff)
+		n, err := reader.ReadStoredAt(ctx, seg.ref, p[done:done+need], segOff)
 		done += n
 		if err != nil {
 			if done > 0 {

--- a/backend/media/types.go
+++ b/backend/media/types.go
@@ -17,6 +17,8 @@ var (
 	ErrEncryptedUnsupported = errors.New("media: encrypted playback is not implemented yet")
 	ErrUnsupportedMediaType = errors.New("media: unsupported media type")
 	ErrSessionNotFound      = errors.New("media: session not found")
+	ErrThumbnailPending     = errors.New("media: thumbnail pending")
+	ErrThumbnailUnavailable = errors.New("media: thumbnail unavailable")
 )
 
 // Segment is one stored Telegram document body in a logical TDrive file.
@@ -52,8 +54,9 @@ func (f LogicalFile) SegmentCount() int {
 }
 
 type OpenResult struct {
-	Token string      `json:"token"`
-	URL   string      `json:"url"`
-	Name  string      `json:"name"`
-	Info  LogicalFile `json:"info"`
+	Token        string      `json:"token"`
+	URL          string      `json:"url"`
+	ThumbnailURL string      `json:"thumbnail_url"`
+	Name         string      `json:"name"`
+	Info         LogicalFile `json:"info"`
 }

--- a/backend/media/video_thumbnails.go
+++ b/backend/media/video_thumbnails.go
@@ -1,0 +1,452 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"TDrive/backend/thumbnail"
+)
+
+const (
+	videoThumbIntervalSeconds = 10
+	videoThumbTimeout         = 8 * time.Second
+	videoThumbTempPrefix      = "tdrive-media-thumbs-"
+	videoThumbTempMaxAge      = 24 * time.Hour
+	videoThumbDirMode         = 0o700
+	videoThumbFileMode        = 0o600
+	videoThumbMime            = "image/jpeg"
+)
+
+// VideoThumbnailGenerator extracts one preview frame from a media URL.
+// Implementations must write an image file at outPath or return an error.
+type VideoThumbnailGenerator interface {
+	GenerateVideoThumbnail(ctx context.Context, sourceURL, outPath string, seconds int) error
+	Available() bool
+}
+
+type videoThumbnailer struct {
+	session   *Session
+	cache     *thumbnail.Cache
+	generator VideoThumbnailGenerator
+	dir       string
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	jobs   chan int
+	wg     sync.WaitGroup
+
+	mu       sync.Mutex
+	ready    map[int]string
+	queued   map[int]struct{}
+	inflight map[int]struct{}
+	failed   map[int]time.Time
+}
+
+func newVideoThumbnailer(session *Session, cache *thumbnail.Cache, generator VideoThumbnailGenerator) *videoThumbnailer {
+	ctx, cancel := context.WithCancel(context.Background())
+	t := &videoThumbnailer{
+		session:   session,
+		cache:     cache,
+		generator: generator,
+		ctx:       ctx,
+		cancel:    cancel,
+		jobs:      make(chan int, 16),
+		ready:     make(map[int]string),
+		queued:    make(map[int]struct{}),
+		inflight:  make(map[int]struct{}),
+		failed:    make(map[int]time.Time),
+	}
+	t.wg.Add(1)
+	go t.worker()
+	return t
+}
+
+func (t *videoThumbnailer) Get(ctx context.Context, seconds float64) ([]byte, error) {
+	if t == nil || t.session == nil || t.generator == nil || !t.generator.Available() {
+		return nil, ErrThumbnailUnavailable
+	}
+	bucket := thumbnailBucket(seconds, t.session.Size())
+	if bucket < 0 {
+		return nil, ErrThumbnailUnavailable
+	}
+	if data, ok := t.cached(bucket); ok {
+		return data, nil
+	}
+	if err := t.queue(ctx, bucket); err != nil {
+		return nil, err
+	}
+	return nil, ErrThumbnailPending
+}
+
+func (t *videoThumbnailer) Close() {
+	if t == nil {
+		return
+	}
+	t.cancel()
+	done := make(chan struct{})
+	go func() {
+		t.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+	}
+	t.mu.Lock()
+	dir := t.dir
+	t.dir = ""
+	t.mu.Unlock()
+	if dir != "" {
+		_ = os.RemoveAll(dir)
+	}
+}
+
+func (t *videoThumbnailer) cached(bucket int) ([]byte, bool) {
+	if data, ok := t.cache.Get(t.cacheKey(bucket)); ok {
+		return data, true
+	}
+
+	t.mu.Lock()
+	path := t.ready[bucket]
+	t.mu.Unlock()
+	if path == "" {
+		return nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.mu.Lock()
+		delete(t.ready, bucket)
+		t.mu.Unlock()
+		return nil, false
+	}
+	return data, true
+}
+
+func (t *videoThumbnailer) queue(ctx context.Context, bucket int) error {
+	t.mu.Lock()
+	if failedAt, failed := t.failed[bucket]; failed && time.Since(failedAt) < 15*time.Second {
+		t.mu.Unlock()
+		return ErrThumbnailUnavailable
+	}
+	if _, ok := t.queued[bucket]; ok {
+		t.mu.Unlock()
+		return nil
+	}
+	if _, ok := t.inflight[bucket]; ok {
+		t.mu.Unlock()
+		return nil
+	}
+	t.queued[bucket] = struct{}{}
+	t.mu.Unlock()
+
+	select {
+	case t.jobs <- bucket:
+		t.queueNeighbor(bucket - videoThumbIntervalSeconds)
+		t.queueNeighbor(bucket + videoThumbIntervalSeconds)
+		return nil
+	case <-t.ctx.Done():
+		return ErrSessionNotFound
+	case <-ctx.Done():
+		t.mu.Lock()
+		delete(t.queued, bucket)
+		t.mu.Unlock()
+		return ctx.Err()
+	default:
+		t.mu.Lock()
+		delete(t.queued, bucket)
+		t.mu.Unlock()
+		return nil
+	}
+}
+
+func (t *videoThumbnailer) queueNeighbor(bucket int) {
+	if bucket < 0 {
+		return
+	}
+	t.mu.Lock()
+	if _, ready := t.ready[bucket]; ready {
+		t.mu.Unlock()
+		return
+	}
+	if _, queued := t.queued[bucket]; queued {
+		t.mu.Unlock()
+		return
+	}
+	if _, inflight := t.inflight[bucket]; inflight {
+		t.mu.Unlock()
+		return
+	}
+	t.queued[bucket] = struct{}{}
+	t.mu.Unlock()
+
+	select {
+	case t.jobs <- bucket:
+	default:
+		t.mu.Lock()
+		delete(t.queued, bucket)
+		t.mu.Unlock()
+	}
+}
+
+func (t *videoThumbnailer) worker() {
+	defer t.wg.Done()
+	for {
+		select {
+		case <-t.ctx.Done():
+			return
+		case bucket := <-t.jobs:
+			t.generate(bucket)
+		}
+	}
+}
+
+func (t *videoThumbnailer) generate(bucket int) {
+	t.mu.Lock()
+	delete(t.queued, bucket)
+	if _, ok := t.ready[bucket]; ok {
+		t.mu.Unlock()
+		return
+	}
+	t.inflight[bucket] = struct{}{}
+	t.mu.Unlock()
+
+	defer func() {
+		t.mu.Lock()
+		delete(t.inflight, bucket)
+		t.mu.Unlock()
+	}()
+
+	if _, ok := t.cache.Get(t.cacheKey(bucket)); ok {
+		return
+	}
+
+	dir, err := t.ensureDir()
+	if err != nil {
+		t.markFailed(bucket)
+		return
+	}
+	outPath := filepath.Join(dir, fmt.Sprintf("thumb-%d.jpg", bucket))
+	sourceURL := t.session.thumbnailSourceURL()
+	if sourceURL == "" {
+		t.markFailed(bucket)
+		return
+	}
+
+	runCtx, cancel := context.WithTimeout(t.ctx, videoThumbTimeout)
+	defer cancel()
+	if err := t.generator.GenerateVideoThumbnail(runCtx, sourceURL, outPath, bucket); err != nil {
+		_ = os.Remove(outPath)
+		t.markFailed(bucket)
+		return
+	}
+	_ = os.Chmod(outPath, videoThumbFileMode)
+
+	data, err := os.ReadFile(outPath)
+	if err != nil || len(data) == 0 {
+		_ = os.Remove(outPath)
+		t.markFailed(bucket)
+		return
+	}
+	_ = t.cache.Put(t.cacheKey(bucket), data)
+
+	t.mu.Lock()
+	t.ready[bucket] = outPath
+	delete(t.failed, bucket)
+	t.mu.Unlock()
+}
+
+func (t *videoThumbnailer) ensureDir() (string, error) {
+	t.mu.Lock()
+	if t.dir != "" {
+		dir := t.dir
+		t.mu.Unlock()
+		return dir, nil
+	}
+	t.mu.Unlock()
+
+	dir, err := os.MkdirTemp("", videoThumbTempPrefix)
+	if err != nil {
+		return "", err
+	}
+	_ = os.Chmod(dir, videoThumbDirMode)
+
+	t.mu.Lock()
+	if t.dir == "" {
+		t.dir = dir
+		t.mu.Unlock()
+		return dir, nil
+	}
+	existing := t.dir
+	t.mu.Unlock()
+	_ = os.RemoveAll(dir)
+	return existing, nil
+}
+
+func (t *videoThumbnailer) markFailed(bucket int) {
+	t.mu.Lock()
+	t.failed[bucket] = time.Now()
+	t.mu.Unlock()
+}
+
+func (t *videoThumbnailer) cacheKey(bucket int) string {
+	file := t.session.file
+	return fmt.Sprintf("video-thumb-v1-ch%d-file%d-size%d-t%d", file.ChannelID, file.FileID, file.StoredSize, bucket)
+}
+
+func thumbnailBucket(seconds float64, size int64) int {
+	if size <= 0 || seconds < 0 {
+		return -1
+	}
+	bucket := int((seconds + float64(videoThumbIntervalSeconds)/2) / float64(videoThumbIntervalSeconds))
+	bucket *= videoThumbIntervalSeconds
+	if bucket < 0 {
+		return 0
+	}
+	return bucket
+}
+
+type MPVThumbnailGenerator struct {
+	path string
+}
+
+func NewMPVThumbnailGenerator() *MPVThumbnailGenerator {
+	path, _ := findMPVBinary()
+	return &MPVThumbnailGenerator{path: path}
+}
+
+func (g *MPVThumbnailGenerator) Available() bool {
+	return g != nil && g.path != ""
+}
+
+func (g *MPVThumbnailGenerator) GenerateVideoThumbnail(ctx context.Context, sourceURL, outPath string, seconds int) error {
+	if !g.Available() {
+		return ErrThumbnailUnavailable
+	}
+	dir := filepath.Dir(outPath)
+	// mpv's image VO owns the output filename. This glob-diff attribution is
+	// safe because videoThumbnailer runs one worker per session.
+	before, _ := filepath.Glob(filepath.Join(dir, "*.jpg"))
+	beforeSet := make(map[string]struct{}, len(before))
+	for _, path := range before {
+		beforeSet[path] = struct{}{}
+	}
+
+	cmd := exec.CommandContext(ctx, g.path,
+		"--no-config",
+		"--really-quiet",
+		"--terminal=no",
+		"--force-window=no",
+		"--ytdl=no",
+		"--vo=image",
+		"--vo-image-format=jpg",
+		"--vo-image-jpeg-quality=72",
+		"--vo-image-outdir="+dir,
+		"--frames=1",
+		"--start="+strconv.Itoa(seconds),
+		"--hr-seek=no",
+		"--aid=no",
+		"--sid=no",
+		"--vf=scale=192:-2",
+		"--demuxer-readahead-secs=0.5",
+		"--demuxer-max-bytes=4194304",
+		"--",
+		sourceURL,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("media: mpv thumbnail: %w: %s", err, string(output))
+	}
+
+	after, err := filepath.Glob(filepath.Join(dir, "*.jpg"))
+	if err != nil {
+		return err
+	}
+	newest := ""
+	var newestMod time.Time
+	for _, path := range after {
+		if _, existed := beforeSet[path]; existed {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() || info.Size() == 0 {
+			continue
+		}
+		if newest == "" || info.ModTime().After(newestMod) {
+			newest = path
+			newestMod = info.ModTime()
+		}
+	}
+	if newest == "" {
+		return ErrThumbnailUnavailable
+	}
+	if newest != outPath {
+		_ = os.Remove(outPath)
+		if err := os.Rename(newest, outPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findMPVBinary() (string, error) {
+	if override := os.Getenv("TDRIVE_MPV_BIN"); override != "" {
+		st, err := os.Stat(override)
+		if err != nil || st.IsDir() {
+			return "", fmt.Errorf("TDRIVE_MPV_BIN is not executable")
+		}
+		return override, nil
+	}
+	if bundled, err := bundledMPVBinaryPath(); err == nil {
+		return bundled, nil
+	}
+	return exec.LookPath("mpv")
+}
+
+func bundledMPVBinaryPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(exe)
+	candidates := []string{
+		filepath.Join(dir, "mpv"),
+		filepath.Join(dir, "mpv.exe"),
+		filepath.Join(dir, "..", "Resources", "media", "mpv"),
+		filepath.Join(dir, "..", "Resources", "media", "mpv.exe"),
+	}
+	for _, candidate := range candidates {
+		st, err := os.Stat(candidate)
+		if err == nil && !st.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", os.ErrNotExist
+}
+
+func sweepStaleVideoThumbnailDirs() {
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-videoThumbTempMaxAge)
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), videoThumbTempPrefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(os.TempDir(), entry.Name()))
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -384,7 +384,10 @@
                                 <span id="video-scrubber-buffered" class="video-scrubber-buffered"></span>
                                 <span id="video-scrubber-played" class="video-scrubber-played"></span>
                                 <span id="video-scrubber-thumb" class="video-scrubber-thumb"></span>
-                                <span id="video-scrubber-tooltip" class="video-scrubber-tooltip">0:00</span>
+                                <span id="video-scrubber-tooltip" class="video-scrubber-tooltip">
+                                    <img id="video-scrubber-tooltip-image" class="video-scrubber-tooltip-image" alt="" aria-hidden="true">
+                                    <span id="video-scrubber-tooltip-time" class="video-scrubber-tooltip-time">0:00</span>
+                                </span>
                             </div>
                         </div>
                         <span id="video-duration" class="video-time">--:--</span>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -41,6 +41,7 @@ export interface MediaOpenInfo {
 export interface MediaOpenResult {
     token: string;
     url: string;
+    thumbnailUrl: string;
     name: string;
     info: MediaOpenInfo;
 }
@@ -150,6 +151,7 @@ export async function openMedia(msgId: number): Promise<MediaOpenResult> {
     return {
         token: String(opened?.token ?? ""),
         url: String(opened?.url ?? ""),
+        thumbnailUrl: String(opened?.thumbnail_url ?? ""),
         name: String(opened?.name ?? ""),
         info: {
             channelId: Number(info?.channel_id ?? 0),

--- a/frontend/src/modules/modals/video.ts
+++ b/frontend/src/modules/modals/video.ts
@@ -19,6 +19,9 @@ const LOADING_DEBOUNCE_MS = 250;
 const SEEK_STEP_SECONDS = 10;
 const VOLUME_STEP = 0.05;
 const RATE_OPTIONS = [0.5, 0.75, 1, 1.25, 1.5, 2];
+const THUMBNAIL_BUCKET_SECONDS = 10;
+const THUMBNAIL_RETRY_MS = 650;
+const THUMBNAIL_FAILURE_TTL_MS = 15_000;
 
 interface VideoOpenTarget {
     id: number;
@@ -273,6 +276,8 @@ let scrubberPlayedEl: HTMLElement | null = null;
 let scrubberBufferedEl: HTMLElement | null = null;
 let scrubberThumbEl: HTMLElement | null = null;
 let scrubberTooltipEl: HTMLElement | null = null;
+let scrubberTooltipImageEl: HTMLImageElement | null = null;
+let scrubberTooltipTimeEl: HTMLElement | null = null;
 let volumeSliderEl: HTMLElement | null = null;
 let volumeFillEl: HTMLElement | null = null;
 let volumeThumbEl: HTMLElement | null = null;
@@ -295,6 +300,13 @@ let volumeDragging = false;
 let hasError = false;
 let isWindowFullscreen = false;
 let lastBufferedSignature = "";
+let activeThumbnailURL = "";
+let currentPreviewBucket = -1;
+let lastPreviewRatio = 0;
+let thumbnailRequestSeq = 0;
+const thumbnailObjectURLs = new Map<number, string>();
+const pendingThumbnails = new Set<number>();
+const failedThumbnails = new Map<number, number>();
 let a11y: ReturnType<typeof installModalA11y> | null = null;
 
 function byID<T extends HTMLElement>(id: string): T | null {
@@ -713,11 +725,99 @@ function previewScrubber(event: PointerEvent | MouseEvent) {
     const rect = scrubberEl.getBoundingClientRect();
     const ratio = clamp((event.clientX - rect.left) / Math.max(1, rect.width), 0, 1);
     const seconds = ratio * currentState.duration;
+    lastPreviewRatio = ratio;
+    updateThumbnailTooltip(seconds);
+    positionScrubberTooltip(ratio, rect);
+}
+
+function positionScrubberTooltip(ratio: number, rect?: DOMRect) {
+    if (!scrubberEl || !scrubberTooltipEl) return;
+    const bounds = rect || scrubberEl.getBoundingClientRect();
     const tooltipWidth = scrubberTooltipEl.offsetWidth || 44;
     const half = tooltipWidth / 2;
-    const x = clamp(ratio * rect.width, half, Math.max(half, rect.width - half));
-    scrubberTooltipEl.textContent = formatTime(seconds);
+    const x = clamp(ratio * bounds.width, half, Math.max(half, bounds.width - half));
     scrubberTooltipEl.style.left = `${x}px`;
+}
+
+function updateThumbnailTooltip(seconds: number) {
+    if (scrubberTooltipTimeEl) scrubberTooltipTimeEl.textContent = formatTime(seconds);
+    const bucket = thumbnailBucket(seconds);
+    currentPreviewBucket = bucket;
+    const cached = thumbnailObjectURLs.get(bucket);
+    if (cached && scrubberTooltipImageEl && scrubberTooltipEl) {
+        if (scrubberTooltipImageEl.src !== cached) {
+            scrubberTooltipImageEl.src = cached;
+        }
+        scrubberTooltipEl.classList.add("has-thumbnail");
+        return;
+    }
+    scrubberTooltipEl?.classList.remove("has-thumbnail");
+    requestThumbnail(bucket);
+}
+
+function thumbnailBucket(seconds: number) {
+    if (!Number.isFinite(seconds) || seconds < 0) return 0;
+    return Math.max(0, Math.round(seconds / THUMBNAIL_BUCKET_SECONDS) * THUMBNAIL_BUCKET_SECONDS);
+}
+
+function requestThumbnail(bucket: number) {
+    if (!activeThumbnailURL || pendingThumbnails.has(bucket) || thumbnailObjectURLs.has(bucket)) return;
+    const failedAt = failedThumbnails.get(bucket);
+    if (failedAt && Date.now() - failedAt < THUMBNAIL_FAILURE_TTL_MS) return;
+    pendingThumbnails.add(bucket);
+    const seq = thumbnailRequestSeq;
+    const url = `${activeThumbnailURL}?t=${encodeURIComponent(String(bucket))}`;
+    let retryScheduled = false;
+    fetch(url, { cache: "no-store" })
+        .then(async (response) => {
+            if (seq !== thumbnailRequestSeq) return;
+            if (response.status === 202) {
+                retryScheduled = true;
+                window.setTimeout(() => {
+                    pendingThumbnails.delete(bucket);
+                    if (seq === thumbnailRequestSeq && currentPreviewBucket === bucket) requestThumbnail(bucket);
+                }, THUMBNAIL_RETRY_MS);
+                return;
+            }
+            if (!response.ok) {
+                failedThumbnails.set(bucket, Date.now());
+                return;
+            }
+            const blob = await response.blob();
+            if (!blob.size || seq !== thumbnailRequestSeq) return;
+            const objectURL = URL.createObjectURL(blob);
+            const old = thumbnailObjectURLs.get(bucket);
+            if (old) URL.revokeObjectURL(old);
+            thumbnailObjectURLs.set(bucket, objectURL);
+            failedThumbnails.delete(bucket);
+            if (currentPreviewBucket === bucket && scrubberTooltipImageEl && scrubberTooltipEl) {
+                scrubberTooltipImageEl.src = objectURL;
+                scrubberTooltipEl.classList.add("has-thumbnail");
+                positionScrubberTooltip(lastPreviewRatio);
+            }
+        })
+        .catch(() => {
+            if (seq === thumbnailRequestSeq) failedThumbnails.set(bucket, Date.now());
+        })
+        .finally(() => {
+            if (seq === thumbnailRequestSeq && !retryScheduled) pendingThumbnails.delete(bucket);
+        });
+}
+
+function resetThumbnailPreview() {
+    thumbnailRequestSeq += 1;
+    activeThumbnailURL = "";
+    currentPreviewBucket = -1;
+    lastPreviewRatio = 0;
+    pendingThumbnails.clear();
+    failedThumbnails.clear();
+    for (const objectURL of thumbnailObjectURLs.values()) {
+        URL.revokeObjectURL(objectURL);
+    }
+    thumbnailObjectURLs.clear();
+    if (scrubberTooltipImageEl) scrubberTooltipImageEl.removeAttribute("src");
+    if (scrubberTooltipTimeEl) scrubberTooltipTimeEl.textContent = "0:00";
+    scrubberTooltipEl?.classList.remove("has-thumbnail");
 }
 
 function updateScrubVisual(seconds: number) {
@@ -746,6 +846,7 @@ async function releaseActive() {
     unsubscribeState?.();
     unsubscribeState = null;
     clearSkipFeedback();
+    resetThumbnailPreview();
     setSpeedMenuOpen(false);
     setNativeMode(false);
     if (adapter) {
@@ -766,6 +867,7 @@ function releaseActiveSoon() {
     unsubscribeState?.();
     unsubscribeState = null;
     clearSkipFeedback();
+    resetThumbnailPreview();
     setSpeedMenuOpen(false);
     setNativeMode(false);
     if (adapter) {
@@ -853,10 +955,12 @@ export async function openVideoModal(target: VideoOpenTarget) {
         const displayName = opened.info.name || opened.name || target.name || "Video";
         const displaySize = opened.info.plaintextSize || opened.info.storedSize || target.size || 0;
         updateMediaText(displayName, displaySize);
+        activeThumbnailURL = opened.thumbnailUrl;
+        thumbnailRequestSeq += 1;
         const adapter = new HtmlVideoAdapter(videoEl, opened);
         activeAdapter = adapter;
         unsubscribeState = adapter.subscribe(applyState);
-        adapter.load();
+		adapter.load();
     } catch (err: unknown) {
         console.error("OpenMedia failed:", err);
         setError(errorMessage(err, "Could not open this video."));
@@ -910,6 +1014,7 @@ function bindScrubber() {
         updateScrubVisual(scrubberSecondsFromEvent(event));
     });
     scrubberEl?.addEventListener("pointerleave", () => {
+        currentPreviewBucket = -1;
         if (!seekingWithPointer) scrubberEl?.classList.remove("is-hovered");
     });
     scrubberEl?.addEventListener("pointerdown", (event) => {
@@ -1191,8 +1296,10 @@ export function setupVideoModal() {
     scrubberBufferedEl = byID("video-scrubber-buffered");
     scrubberThumbEl = byID("video-scrubber-thumb");
     scrubberTooltipEl = byID("video-scrubber-tooltip");
-    volumeSliderEl = byID("video-volume-slider");
-    volumeFillEl = byID("video-volume-fill");
+    scrubberTooltipImageEl = byID("video-scrubber-tooltip-image");
+    scrubberTooltipTimeEl = byID("video-scrubber-tooltip-time");
+	volumeSliderEl = byID("video-volume-slider");
+	volumeFillEl = byID("video-volume-fill");
     volumeThumbEl = byID("video-volume-thumb");
     timeEl = byID("video-time");
     durationEl = byID("video-duration");

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -2415,11 +2415,16 @@ header {
     position: absolute;
     left: 0;
     bottom: calc(100% + 8px);
+    display: grid;
+    justify-items: center;
+    gap: 5px;
+    min-width: 42px;
     padding: 4px 7px;
-    border-radius: 6px;
+    border-radius: 7px;
     color: #fff;
     background: rgba(8, 10, 16, 0.92);
     border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.34);
     font-size: 11px;
     font-weight: 800;
     font-variant-numeric: tabular-nums;
@@ -2427,6 +2432,30 @@ header {
     opacity: 0;
     transform: translateX(-50%);
     transition: opacity 140ms ease;
+}
+
+.video-scrubber-tooltip.has-thumbnail {
+    width: 178px;
+    padding: 6px;
+    border-radius: 10px;
+    background: rgba(7, 9, 15, 0.96);
+}
+
+.video-scrubber-tooltip-image {
+    display: none;
+    width: 166px;
+    aspect-ratio: 16 / 9;
+    border-radius: 7px;
+    object-fit: cover;
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.video-scrubber-tooltip.has-thumbnail .video-scrubber-tooltip-image {
+    display: block;
+}
+
+.video-scrubber-tooltip-time {
+    line-height: 1;
 }
 
 .video-scrubber.is-hovered .video-scrubber-track,

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -422,6 +422,7 @@ export namespace media {
 	export class OpenResult {
 	    token: string;
 	    url: string;
+	    thumbnail_url: string;
 	    name: string;
 	    info: LogicalFile;
 
@@ -433,6 +434,7 @@ export namespace media {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.token = source["token"];
 	        this.url = source["url"];
+	        this.thumbnail_url = source["thumbnail_url"];
 	        this.name = source["name"];
 	        this.info = this.convertValues(source["info"], LogicalFile);
 	    }


### PR DESCRIPTION
Adds lazy scrub thumbnails for direct video playback.

Checks:
- go test ./backend/media
- npm run typecheck
- npm run lint -- --quiet
- packaged smoke test done locally