### PR TITLE
optimize transfers, navigation, and media previews

### DIFF
--- a/app.go
+++ b/app.go
@@ -610,6 +610,10 @@ func (a *App) GetFolderSize(folderID string) (int64, error) {
 	return a.readService().FolderSize(a.ActiveChannelID(), folderID)
 }
 
+func (a *App) GetFolderSizes(parentID string) (map[string]int64, error) {
+	return a.readService().ChildFolderSizes(a.ActiveChannelID(), parentID)
+}
+
 func (a *App) DeleteFolder(folderID string) string {
 	if err := a.folderService().Delete(a.ctx, a.ActiveChannelID(), folderID); err != nil {
 		return "Error: " + err.Error()

--- a/backend/media/range_reader.go
+++ b/backend/media/range_reader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"sync"
 	"time"
 
 	"TDrive/backend/tgclient"
@@ -45,6 +46,16 @@ type RangeReaderConfig struct {
 	// OnFloodWait, when set, is called before sleeping for a Telegram
 	// FLOOD_WAIT. It is a logging/progress hook; nil is fine.
 	OnFloodWait func(wait time.Duration)
+
+	// PrefetchBlocks asynchronously warms this many sequential 1 MiB blocks
+	// after a foreground read. 0 disables prefetching.
+	PrefetchBlocks int
+
+	// Background routes this reader's fetches through the shared background getFile
+	// pool instead of the foreground playback reserve. Set it for non-playback
+	// readers (such as the thumbnail reader) so their reads yield to live
+	// playback. Prefetch fetches are always treated as background regardless.
+	Background bool
 }
 
 // RangeReader turns arbitrary app byte reads into Telegram-compatible block
@@ -58,6 +69,10 @@ type RangeReader struct {
 	meter            *throughputMeter
 	sem              chan struct{}
 	group            singleflight.Group
+	prefetchMu       sync.Mutex
+	prefetching      map[string]struct{}
+	prefetchBlocks   int
+	background       bool
 	floodWaitRetries int
 	floodWaitMax     time.Duration
 	onFloodWait      func(time.Duration)
@@ -92,6 +107,9 @@ func NewRangeReader(cfg RangeReaderConfig) *RangeReader {
 		cache:            newBlockCache(maxCache),
 		meter:            newThroughputMeter(),
 		sem:              make(chan struct{}, concurrency),
+		prefetching:      make(map[string]struct{}),
+		prefetchBlocks:   cfg.PrefetchBlocks,
+		background:       cfg.Background,
 		floodWaitRetries: retries,
 		floodWaitMax:     maxSleep,
 		onFloodWait:      cfg.OnFloodWait,
@@ -144,7 +162,7 @@ func (r *RangeReader) ReadStoredAt(ctx context.Context, ref tgclient.DocumentRef
 		}
 		absolute := off + int64(done)
 		blockStart := blockStartFor(absolute)
-		block, err := r.block(ctx, ref, blockStart)
+		block, err := r.block(ctx, ref, blockStart, r.background)
 		if err != nil {
 			if done > 0 {
 				return done, err
@@ -162,12 +180,52 @@ func (r *RangeReader) ReadStoredAt(ctx context.Context, ref tgclient.DocumentRef
 		done += n
 	}
 	if done < len(p) {
+		r.prefetchAfter(ref, off+int64(done))
 		return done, io.EOF
 	}
+	r.prefetchAfter(ref, off+int64(done))
 	return done, nil
 }
 
-func (r *RangeReader) block(ctx context.Context, ref tgclient.DocumentRef, blockStart int64) ([]byte, error) {
+func (r *RangeReader) prefetchAfter(ref tgclient.DocumentRef, nextOffset int64) {
+	if r == nil || r.prefetchBlocks <= 0 || nextOffset <= 0 || nextOffset >= ref.Size {
+		return
+	}
+	nextBlock := blockStartFor(nextOffset)
+	if nextBlock < nextOffset {
+		nextBlock += rangeUploadBoundary
+	}
+	for i := 0; i < r.prefetchBlocks && nextBlock < ref.Size; i++ {
+		r.prefetchBlock(ref, nextBlock)
+		nextBlock += rangeUploadBoundary
+	}
+}
+
+func (r *RangeReader) prefetchBlock(ref tgclient.DocumentRef, blockStart int64) {
+	key := blockKey(ref, blockStart)
+	if _, ok := r.cache.get(key); ok {
+		return
+	}
+	r.prefetchMu.Lock()
+	if _, ok := r.prefetching[key]; ok {
+		r.prefetchMu.Unlock()
+		return
+	}
+	r.prefetching[key] = struct{}{}
+	r.prefetchMu.Unlock()
+
+	go func() {
+		defer func() {
+			r.prefetchMu.Lock()
+			delete(r.prefetching, key)
+			r.prefetchMu.Unlock()
+		}()
+		// Prefetch is speculative read-ahead, so it always yields to live playback.
+		_, _ = r.block(r.ctx, ref, blockStart, true)
+	}()
+}
+
+func (r *RangeReader) block(ctx context.Context, ref tgclient.DocumentRef, blockStart int64, background bool) ([]byte, error) {
 	key := blockKey(ref, blockStart)
 	if data, ok := r.cache.get(key); ok {
 		return data, nil
@@ -180,7 +238,7 @@ func (r *RangeReader) block(ctx context.Context, ref tgclient.DocumentRef, block
 		// The shared fetch is tied to the reader lifetime, not the first
 		// caller's request context. Otherwise one aborted HTTP request could
 		// poison coalesced waiters for the same block.
-		data, err := r.fetchBlock(r.ctx, ref, blockStart)
+		data, err := r.fetchBlock(r.ctx, ref, blockStart, background)
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +261,7 @@ func (r *RangeReader) block(ctx context.Context, ref tgclient.DocumentRef, block
 	}
 }
 
-func (r *RangeReader) fetchBlock(ctx context.Context, ref tgclient.DocumentRef, blockStart int64) ([]byte, error) {
+func (r *RangeReader) fetchBlock(ctx context.Context, ref tgclient.DocumentRef, blockStart int64, background bool) ([]byte, error) {
 	limit := blockLimit(ref.Size, blockStart)
 	if limit <= 0 {
 		return nil, io.EOF
@@ -214,7 +272,13 @@ func (r *RangeReader) fetchBlock(ctx context.Context, ref tgclient.DocumentRef, 
 		if err := r.acquire(ctx); err != nil {
 			return nil, err
 		}
+		releaseGetFile, err := acquireGetFileSlot(ctx, background)
+		if err != nil {
+			r.release()
+			return nil, err
+		}
 		n, err := r.client.ReadDocumentRange(ctx, ref, blockStart, buf)
+		releaseGetFile()
 		r.release()
 		if n > 0 && r.meter != nil {
 			r.meter.Add(n)
@@ -257,6 +321,16 @@ func (r *RangeReader) acquire(ctx context.Context) error {
 
 func (r *RangeReader) release() {
 	<-r.sem
+}
+
+// acquireGetFileSlot reserves one global getFile slot. Background reads (the
+// thumbnail reader and all prefetch) go through the background pool so they yield
+// to foreground playback, which keeps its reserved headroom.
+func acquireGetFileSlot(ctx context.Context, background bool) (func(), error) {
+	if background {
+		return tgclient.AcquireBackgroundGetFileSlots(ctx, 1)
+	}
+	return tgclient.AcquireGetFileSlots(ctx, 1)
 }
 
 func blockStartFor(off int64) int64 {

--- a/backend/media/range_reader_test.go
+++ b/backend/media/range_reader_test.go
@@ -128,6 +128,36 @@ func TestRangeReaderCachesBlocks(t *testing.T) {
 	}
 }
 
+func TestRangeReaderPrefetchesNextBlockWhenEnabled(t *testing.T) {
+	data := testBytes(tgclient.RangeReadMaxBytes*3 + 1)
+	fake := newStrictRangeFake(data)
+	reader := NewRangeReader(RangeReaderConfig{Client: fake, PrefetchBlocks: 1})
+	defer reader.Close()
+
+	buf := make([]byte, 64)
+	if _, err := reader.ReadStoredAt(context.Background(), fake.ref(), buf, 128); err != nil {
+		t.Fatalf("ReadStoredAt: %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		calls := fake.calls()
+		if len(calls) >= 2 {
+			if calls[0].offset != 0 {
+				t.Fatalf("first call = %+v, want foreground block 0", calls[0])
+			}
+			if calls[1].offset != int64(tgclient.RangeReadMaxBytes) {
+				t.Fatalf("second call = %+v, want prefetched next block", calls[1])
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("calls = %+v, want foreground + prefetch", calls)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestRangeReaderCoalescesConcurrentBlockReads(t *testing.T) {
 	data := testBytes(tgclient.RangeReadMaxBytes)
 	fake := newStrictRangeFake(data)

--- a/backend/media/server.go
+++ b/backend/media/server.go
@@ -25,7 +25,10 @@ type PlaybackUpdate struct {
 	Token       string  `json:"token"`
 	CurrentTime float64 `json:"current_time"`
 	Duration    float64 `json:"duration"`
-	Busy        bool    `json:"busy"`
+	// BufferAhead is the number of seconds the player has buffered ahead of the
+	// playhead. The thumbnail scheduler uses it to steal slack: build aggressively
+	// while the buffer is comfortable and yield to playback as it drains.
+	BufferAhead float64 `json:"buffer_ahead"`
 }
 
 type Server struct {
@@ -83,7 +86,7 @@ func (s *Server) UpdatePlayback(update PlaybackUpdate) error {
 	if session == nil {
 		return ErrSessionNotFound
 	}
-	session.UpdatePlayback(update.CurrentTime, update.Duration, update.Busy)
+	session.UpdatePlayback(update.CurrentTime, update.Duration, update.BufferAhead)
 	return nil
 }
 

--- a/backend/media/session.go
+++ b/backend/media/session.go
@@ -52,11 +52,15 @@ func newSession(file LogicalFile, segments []resolvedSegment, ranges tgclient.Ra
 		segments:  copied,
 		lastTouch: time.Now(),
 	}
-	s.reader = NewRangeReader(RangeReaderConfig{Client: ranges})
+	s.reader = NewRangeReader(RangeReaderConfig{
+		Client:         ranges,
+		PrefetchBlocks: 2,
+	})
 	s.thumbReader = NewRangeReader(RangeReaderConfig{
 		Client:         ranges,
 		MaxCacheBytes:  8 * 1024 * 1024,
 		MaxConcurrency: 3,
+		Background:     true,
 		OnFloodWait: func(wait time.Duration) {
 			if s.thumbs != nil {
 				s.thumbs.NoteFloodWait(wait)
@@ -174,11 +178,11 @@ func (s *Session) Thumbnail(ctx context.Context, seconds float64) ([]byte, error
 	return s.thumbs.Get(ctx, seconds)
 }
 
-func (s *Session) UpdatePlayback(currentTime, duration float64, busy bool) {
+func (s *Session) UpdatePlayback(currentTime, duration, bufferAhead float64) {
 	if s == nil || s.thumbs == nil {
 		return
 	}
-	s.thumbs.UpdatePlayback(currentTime, duration, busy)
+	s.thumbs.UpdatePlayback(currentTime, duration, bufferAhead)
 }
 
 func (s *Session) Stats() MediaStats {

--- a/backend/media/video_thumbnails.go
+++ b/backend/media/video_thumbnails.go
@@ -29,6 +29,35 @@ const (
 	videoThumbDirMode          = 0o700
 	videoThumbFileMode         = 0o600
 	videoThumbMime             = "image/jpeg"
+
+	// Playback-buffer watermarks (seconds ahead of the playhead) govern how much
+	// the background thumbnail builder may steal from the shared pipe. Foreground
+	// playback reads are already reserved at the limiter; these bands keep the
+	// *background* precompute from competing while the buffer is at risk.
+	//
+	// HealthyStart/HealthyStop form a hysteresis band so precompute does not flap:
+	// it ramps to full speed at HealthyStart and keeps going until the buffer
+	// drains below HealthyStop. Below Emergency even the hovered thumbnail defers
+	// so playback can refill.
+	thumbBufferHealthyStart = 30.0
+	thumbBufferHealthyStop  = 20.0
+	thumbBufferEmergency    = 8.0
+
+	// thumbPrecomputeAging lets one background bucket through this often even while
+	// the buffer is only in the mid band, so a slow connection still builds the
+	// track instead of stalling at zero.
+	thumbPrecomputeAging = 3 * time.Second
+
+	// precomputeCoarseFactor sets the coarse precompute grid as a multiple of the
+	// fine interval. The builder fills the coarse grid across the whole timeline
+	// first (so the entire scrubber has a preview quickly), then refines.
+	precomputeCoarseFactor = 4
+
+	// precomputeAnchorCount is the number of evenly-spaced "anchor" thumbnails the
+	// builder lays down across the whole timeline before anything else, so even a
+	// multi-hour movie has a sparse full-bar preview within the first few seconds.
+	// Anchors fall on the coarse grid; the coarse and fine passes fill in between.
+	precomputeAnchorCount = 16
 )
 
 var errThumbnailSessionDead = errors.New("media: thumbnail session dead")
@@ -63,20 +92,23 @@ type videoThumbnailer struct {
 	precomputeWake chan struct{}
 	wg             sync.WaitGroup
 
-	mu                sync.Mutex
-	ready             map[int]string
-	latest            int
-	hasLatest         bool
-	inflight          map[int]struct{}
-	failed            map[int]time.Time
-	instrumentLog     bool
-	persistent        VideoThumbnailSession
-	persistentOff     bool
-	playbackTime      float64
-	playbackDuration  float64
-	playerBusy        bool
-	thumbBackoffUntil time.Time
-	lastStatsLog      time.Time
+	mu                  sync.Mutex
+	ready               map[int]string
+	latest              int
+	hasLatest           bool
+	inflight            map[int]struct{}
+	failed              map[int]time.Time
+	instrumentLog       bool
+	persistent          VideoThumbnailSession
+	persistentOff       bool
+	playbackTime        float64
+	playbackDuration    float64
+	playbackBufferAhead float64   // seconds buffered ahead of the playhead
+	playbackKnown       bool      // false until the first UpdatePlayback signal
+	precomputeFullSpeed bool      // hysteresis latch for the healthy buffer band
+	lastPrecomputeAt    time.Time // aging floor: last background bucket generated
+	thumbBackoffUntil   time.Time
+	lastStatsLog        time.Time
 }
 
 func newVideoThumbnailer(session *Session, cache *thumbnail.Cache, generator VideoThumbnailGenerator) *videoThumbnailer {
@@ -118,7 +150,7 @@ func (t *videoThumbnailer) Get(ctx context.Context, seconds float64) ([]byte, er
 	return nil, ErrThumbnailPending
 }
 
-func (t *videoThumbnailer) UpdatePlayback(currentTime, duration float64, busy bool) {
+func (t *videoThumbnailer) UpdatePlayback(currentTime, duration, bufferAhead float64) {
 	if t == nil {
 		return
 	}
@@ -131,14 +163,25 @@ func (t *videoThumbnailer) UpdatePlayback(currentTime, duration float64, busy bo
 	if duration > 0 && currentTime > duration {
 		currentTime = duration
 	}
+	if !isFiniteNonNegative(bufferAhead) {
+		bufferAhead = 0
+	}
 	t.mu.Lock()
 	t.playbackTime = currentTime
 	t.playbackDuration = duration
-	t.playerBusy = busy
-	t.mu.Unlock()
-	if !busy {
-		t.wakePrecompute()
+	t.playbackBufferAhead = bufferAhead
+	t.playbackKnown = true
+	// Hysteresis: ramp precompute to full speed once the buffer is comfortable and
+	// hold it there until the buffer drains past the lower watermark.
+	if bufferAhead >= thumbBufferHealthyStart {
+		t.precomputeFullSpeed = true
+	} else if bufferAhead < thumbBufferHealthyStop {
+		t.precomputeFullSpeed = false
 	}
+	t.mu.Unlock()
+	// Re-evaluate background work on every signal; the worker bails if the band no
+	// longer allows it.
+	t.wakePrecompute()
 }
 
 func (t *videoThumbnailer) NoteFloodWait(wait time.Duration) {
@@ -295,13 +338,29 @@ func (t *videoThumbnailer) precomputeWorker() {
 		}
 
 		for {
+			// Stop promptly on shutdown. Without this the loop could spin: a
+			// canceled t.ctx makes generate fail instantly, and a deferred result
+			// is intentionally not marked failed, so the same bucket is re-picked.
+			if t.ctx.Err() != nil {
+				return
+			}
 			bucket, ok := t.nextPrecomputeBucket()
 			if !ok {
 				break
 			}
 			t.logf("precompute bucket=%d", bucket)
 			t.generate(bucket, true)
-			if !t.precomputeStillIdle() {
+
+			t.mu.Lock()
+			_, produced := t.ready[bucket]
+			if produced {
+				t.lastPrecomputeAt = time.Now()
+			}
+			t.mu.Unlock()
+			// If the bucket did not actually generate (deferred/failed/canceled),
+			// don't immediately re-pick it. Yield to the idle timer so retries are
+			// spaced instead of hot-looping on a stuck bucket.
+			if !produced || !t.precomputeStillIdle() {
 				break
 			}
 		}
@@ -320,23 +379,55 @@ func (t *videoThumbnailer) takeLatest() (int, bool) {
 	return bucket, true
 }
 
+// foregroundShouldWaitLocked reports whether a hovered (foreground) thumbnail
+// must defer. It only defers when the playback buffer is critically low or
+// Telegram is rate-limiting, so the thumbnail the user is looking at still
+// appears while the player merely tops up its buffer. Caller holds t.mu.
+func (t *videoThumbnailer) foregroundShouldWaitLocked(now time.Time) bool {
+	if now.Before(t.thumbBackoffUntil) {
+		return true
+	}
+	return t.playbackKnown && t.playbackBufferAhead < thumbBufferEmergency
+}
+
+// precomputeAllowedLocked reports whether a background precompute bucket may run
+// now: full speed while the buffer is healthy, an occasional aging tick in the
+// mid band so slow links still build, and never while the buffer is critically
+// low or Telegram is rate-limiting. Caller holds t.mu.
+func (t *videoThumbnailer) precomputeAllowedLocked(now time.Time) bool {
+	if now.Before(t.thumbBackoffUntil) {
+		return false
+	}
+	if !t.playbackKnown {
+		// Build immediately on open, before the first buffer signal arrives.
+		return true
+	}
+	if t.playbackBufferAhead < thumbBufferEmergency {
+		return false
+	}
+	if t.precomputeFullSpeed {
+		return true
+	}
+	return now.Sub(t.lastPrecomputeAt) >= thumbPrecomputeAging
+}
+
 func (t *videoThumbnailer) waitForForegroundTurn(bucket int) bool {
 	logged := false
 	for {
 		now := time.Now()
 		t.mu.Lock()
 		stale := t.hasLatest
-		busy := t.playerBusy || now.Before(t.thumbBackoffUntil)
+		wait := t.foregroundShouldWaitLocked(now)
 		t.mu.Unlock()
 		if stale {
 			t.logf("foreground preempted bucket=%d", bucket)
 			return false
 		}
-		if !busy {
+		if !wait {
 			return true
 		}
 		if !logged {
-			t.logf("foreground paused bucket=%d while playback is busy", bucket)
+			t.logf("foreground deferred bucket=%d while playback buffer is low", bucket)
 			logged = true
 		}
 		select {
@@ -361,7 +452,34 @@ func (t *videoThumbnailer) nextPrecomputeBucket() (int, bool) {
 		return 0, false
 	}
 
-	interval := thumbnailInterval(duration)
+	fine := thumbnailInterval(duration)
+	coarse := fine * precomputeCoarseFactor
+	// Tiered coarse-to-fine. Each pass walks outward from the playhead:
+	//  1. anchors  — ~16 evenly-spaced frames so the whole bar has a preview ASAP,
+	//  2. coarse   — fills the coarse grid,
+	//  3. fine     — refines into every bucket.
+	// Anchors and coarse buckets are multiples of the fine interval, so they share
+	// the same grid the frontend requests on hover.
+	if anchor := anchorPrecomputeInterval(duration, coarse); anchor > coarse {
+		if bucket, ok := t.scanPrecompute(current, duration, anchor, now); ok {
+			return bucket, true
+		}
+	}
+	if coarse > fine {
+		if bucket, ok := t.scanPrecompute(current, duration, coarse, now); ok {
+			return bucket, true
+		}
+	}
+	return t.scanPrecompute(current, duration, fine, now)
+}
+
+// scanPrecompute walks the timeline outward from the current playhead at the
+// given bucket interval (ahead first, then behind) and returns the nearest bucket
+// that still needs generating, if any.
+func (t *videoThumbnailer) scanPrecompute(current, duration float64, interval int, now time.Time) (int, bool) {
+	if interval <= 0 {
+		return 0, false
+	}
 	currentBucket := int(math.Floor(current/float64(interval))) * interval
 	maxBucket := int(math.Floor(duration/float64(interval))) * interval
 	for step := 0; step <= maxBucket+interval; step += interval {
@@ -372,6 +490,21 @@ func (t *videoThumbnailer) nextPrecomputeBucket() (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// anchorPrecomputeInterval returns the spacing for the evenly-spaced anchor pass,
+// snapped to (a multiple of) the coarse grid so anchors stay on the shared bucket
+// grid. It returns 0 when the video is short enough that an anchor tier coarser
+// than the coarse grid would be pointless.
+func anchorPrecomputeInterval(duration float64, coarse int) int {
+	if coarse <= 0 || duration <= 0 {
+		return 0
+	}
+	steps := int(duration) / (precomputeAnchorCount * coarse)
+	if steps < 1 {
+		return 0
+	}
+	return steps * coarse
 }
 
 func precomputeCandidates(currentBucket, step, maxBucket int) []int {
@@ -393,7 +526,7 @@ func (t *videoThumbnailer) precomputeCandidateReady(bucket int, now time.Time) b
 		return false
 	}
 	t.mu.Lock()
-	if t.hasLatest || len(t.inflight) > 0 || t.playerBusy || now.Before(t.thumbBackoffUntil) {
+	if t.hasLatest || len(t.inflight) > 0 || !t.precomputeAllowedLocked(now) {
 		t.mu.Unlock()
 		return false
 	}
@@ -417,7 +550,7 @@ func (t *videoThumbnailer) precomputeStillIdle() bool {
 	now := time.Now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return !t.hasLatest && len(t.inflight) == 0 && !t.playerBusy && !now.Before(t.thumbBackoffUntil)
+	return !t.hasLatest && len(t.inflight) == 0 && t.precomputeAllowedLocked(now)
 }
 
 func (t *videoThumbnailer) precomputeShouldYield() bool {
@@ -427,7 +560,7 @@ func (t *videoThumbnailer) precomputeShouldYield() bool {
 	now := time.Now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.hasLatest || t.playerBusy || now.Before(t.thumbBackoffUntil)
+	return t.hasLatest || !t.precomputeAllowedLocked(now)
 }
 
 func (t *videoThumbnailer) wakePrecompute() {

--- a/backend/media/video_thumbnails_test.go
+++ b/backend/media/video_thumbnails_test.go
@@ -106,12 +106,14 @@ func TestVideoThumbnailerBackgroundPrecomputeGenerates(t *testing.T) {
 	thumbs := newVideoThumbnailer(session, thumbnail.NewCache(t.TempDir(), 1<<20), gen)
 	defer thumbs.Close()
 
-	thumbs.UpdatePlayback(30, 120, false)
+	// Healthy buffer → precompute runs; coarse-to-fine builds the coarse bucket at
+	// the playhead (currentTime 0) first.
+	thumbs.UpdatePlayback(0, 120, 60)
 	got := waitForGeneratorEntry(t, gen.entered)
-	if got != 30 {
-		t.Fatalf("precomputed bucket = %d, want 30", got)
+	if got != 0 {
+		t.Fatalf("precomputed bucket = %d, want 0", got)
 	}
-	if !waitForCachedThumbnail(t, thumbs, 30) {
+	if !waitForCachedThumbnail(t, thumbs, 0) {
 		t.Fatal("precomputed bucket was not cached")
 	}
 }
@@ -137,6 +139,176 @@ func TestVideoThumbnailerBackgroundPrecomputeYieldsToForeground(t *testing.T) {
 	if _, ok := thumbs.cached(30); ok {
 		t.Fatal("background bucket was cached even though foreground was pending")
 	}
+}
+
+func TestVideoThumbnailerBufferBandGating(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	cases := []struct {
+		name        string
+		bufferAhead float64
+		wantFGWait  bool
+		wantPC      bool
+	}{
+		{"healthy", thumbBufferHealthyStart + 5, false, true},
+		{"emergency", thumbBufferEmergency - 1, true, false},
+		{"mid band aging tick", (thumbBufferEmergency + thumbBufferHealthyStop) / 2, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vt := &videoThumbnailer{}
+			vt.UpdatePlayback(10, 120, tc.bufferAhead)
+			vt.mu.Lock()
+			fgWait := vt.foregroundShouldWaitLocked(now)
+			pc := vt.precomputeAllowedLocked(now)
+			vt.mu.Unlock()
+			if fgWait != tc.wantFGWait {
+				t.Fatalf("foregroundShouldWait = %v, want %v", fgWait, tc.wantFGWait)
+			}
+			if pc != tc.wantPC {
+				t.Fatalf("precomputeAllowed = %v, want %v", pc, tc.wantPC)
+			}
+		})
+	}
+}
+
+func TestVideoThumbnailerPrecomputeAgingFloor(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	vt := &videoThumbnailer{}
+	vt.UpdatePlayback(10, 120, (thumbBufferEmergency+thumbBufferHealthyStop)/2) // mid band
+	vt.mu.Lock()
+	defer vt.mu.Unlock()
+
+	vt.lastPrecomputeAt = time.Time{}
+	if !vt.precomputeAllowedLocked(now) {
+		t.Fatal("mid band should allow an aging precompute tick")
+	}
+	vt.lastPrecomputeAt = now
+	if vt.precomputeAllowedLocked(now) {
+		t.Fatal("mid band should throttle precompute right after a tick")
+	}
+	if !vt.precomputeAllowedLocked(now.Add(thumbPrecomputeAging)) {
+		t.Fatal("mid band should allow another tick once the aging interval elapses")
+	}
+}
+
+func TestVideoThumbnailerPrecomputeHysteresis(t *testing.T) {
+	vt := &videoThumbnailer{}
+	fullSpeed := func() bool {
+		vt.mu.Lock()
+		defer vt.mu.Unlock()
+		return vt.precomputeFullSpeed
+	}
+
+	vt.UpdatePlayback(10, 120, thumbBufferHealthyStart)
+	if !fullSpeed() {
+		t.Fatal("should latch full speed at the healthy-start watermark")
+	}
+	// Draining within the hysteresis band must not flap back off.
+	vt.UpdatePlayback(10, 120, (thumbBufferHealthyStart+thumbBufferHealthyStop)/2)
+	if !fullSpeed() {
+		t.Fatal("should hold full speed inside the hysteresis band")
+	}
+	// Below the stop watermark it releases.
+	vt.UpdatePlayback(10, 120, thumbBufferHealthyStop-1)
+	if fullSpeed() {
+		t.Fatal("should release full speed below the healthy-stop watermark")
+	}
+}
+
+func TestVideoThumbnailerPrecomputeCoarseToFine(t *testing.T) {
+	vt := &videoThumbnailer{
+		session:  testVideoThumbSession(),
+		cache:    thumbnail.NewCache(t.TempDir(), 1<<20),
+		ready:    map[int]string{},
+		inflight: map[int]struct{}{},
+		failed:   map[int]time.Time{},
+	}
+	vt.UpdatePlayback(0, 600, 60) // healthy buffer so precompute is allowed
+	coarse := thumbnailInterval(600) * precomputeCoarseFactor
+
+	// The first targets must all land on the coarse grid (whole-bar coverage first).
+	for i := range 4 {
+		bucket, ok := vt.nextPrecomputeBucket()
+		if !ok {
+			t.Fatalf("iteration %d: expected a precompute bucket", i)
+		}
+		if bucket%coarse != 0 {
+			t.Fatalf("iteration %d: bucket %d is not on the coarse grid (%d)", i, bucket, coarse)
+		}
+		vt.mu.Lock()
+		vt.ready[bucket] = "x" // simulate it being generated
+		vt.mu.Unlock()
+	}
+}
+
+func TestVideoThumbnailerPrecomputeAnchorTierFirst(t *testing.T) {
+	vt := &videoThumbnailer{
+		session:  testVideoThumbSession(),
+		cache:    thumbnail.NewCache(t.TempDir(), 1<<20),
+		ready:    map[int]string{},
+		inflight: map[int]struct{}{},
+		failed:   map[int]time.Time{},
+	}
+	const duration = 3.0 * 60 * 60 // 3 hours
+	vt.UpdatePlayback(0, duration, 120)
+
+	anchor := anchorPrecomputeInterval(duration, thumbnailInterval(duration)*precomputeCoarseFactor)
+	if anchor <= 0 {
+		t.Fatal("expected an anchor tier for a 3h video")
+	}
+
+	// The first targets must be evenly-spaced anchors across the whole timeline.
+	for i := range 5 {
+		bucket, ok := vt.nextPrecomputeBucket()
+		if !ok {
+			t.Fatalf("iteration %d: expected a precompute bucket", i)
+		}
+		if bucket%anchor != 0 {
+			t.Fatalf("iteration %d: bucket %d not on the anchor grid (%d)", i, bucket, anchor)
+		}
+		vt.mu.Lock()
+		vt.ready[bucket] = "x"
+		vt.mu.Unlock()
+	}
+}
+
+func TestVideoThumbnailerPrecomputeDoesNotHotLoopOnDefer(t *testing.T) {
+	gen := &deferringVideoThumbGenerator{available: true}
+	session := testVideoThumbSession()
+	session.setThumbnailURLs("http://127.0.0.1/thumb-source", "http://127.0.0.1/thumb")
+
+	thumbs := newVideoThumbnailer(session, thumbnail.NewCache(t.TempDir(), 1<<20), gen)
+	defer thumbs.Close()
+
+	// Healthy buffer makes precompute want to run; every generate "defers", which
+	// is intentionally not marked failed. A regressed inner loop would re-pick the
+	// same bucket with no delay and spin hundreds of times.
+	thumbs.UpdatePlayback(30, 120, 60)
+	time.Sleep(300 * time.Millisecond)
+	if n := gen.count(); n > 20 {
+		t.Fatalf("precompute hot-looped on deferred generation: %d calls in 300ms", n)
+	}
+}
+
+type deferringVideoThumbGenerator struct {
+	available bool
+	mu        sync.Mutex
+	calls     int
+}
+
+func (g *deferringVideoThumbGenerator) Available() bool { return g != nil && g.available }
+
+func (g *deferringVideoThumbGenerator) GenerateVideoThumbnail(_ context.Context, _, _ string, _ int) error {
+	g.mu.Lock()
+	g.calls++
+	g.mu.Unlock()
+	return context.Canceled
+}
+
+func (g *deferringVideoThumbGenerator) count() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.calls
 }
 
 type recordingVideoThumbGenerator struct {

--- a/backend/projection/read.go
+++ b/backend/projection/read.go
@@ -429,6 +429,54 @@ WHERE files.channel_id = ? AND files.tombstoned = 0;
 	return total, err
 }
 
+// ChildFolderSizes returns the recursive byte size for every direct child
+// folder under parentID. It performs one subtree walk for the visible folder
+// set instead of one recursive CTE per row in the UI.
+func ChildFolderSizes(db *sql.DB, channelID int64, parentID string) (map[string]int64, error) {
+	const q = `
+WITH RECURSIVE
+child_roots(id) AS (
+    SELECT id
+    FROM folders
+    WHERE channel_id = ? AND parent_id = ? AND tombstoned = 0
+),
+descendants(root_id, id, path) AS (
+    SELECT id, id, ',' || id || ','
+    FROM child_roots
+    UNION ALL
+    SELECT d.root_id, f.id, d.path || f.id || ','
+    FROM folders f
+    JOIN descendants d ON f.parent_id = d.id
+    WHERE f.channel_id = ?
+      AND f.tombstoned = 0
+      AND instr(d.path, ',' || f.id || ',') = 0
+)
+SELECT cr.id, COALESCE(SUM(files.size), 0)
+FROM child_roots cr
+LEFT JOIN descendants d ON d.root_id = cr.id
+LEFT JOIN files ON files.channel_id = ?
+    AND files.parent_id = d.id
+    AND files.tombstoned = 0
+GROUP BY cr.id;
+`
+	rows, err := db.Query(q, channelID, parentID, channelID, channelID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]int64)
+	for rows.Next() {
+		var id string
+		var size int64
+		if err := rows.Scan(&id, &size); err != nil {
+			return nil, err
+		}
+		out[id] = size
+	}
+	return out, rows.Err()
+}
+
 func FolderExists(db *sql.DB, channelID int64, folderID string) bool {
 	var tmp int
 	err := db.QueryRow(`

--- a/backend/services/file/multipart_test.go
+++ b/backend/services/file/multipart_test.go
@@ -24,7 +24,7 @@ func TestMultipartRoundTripPlain(t *testing.T) {
 	svc, db, _, _ := newTestService(t)
 	svc.MaxUploadBytes = 1000 // force splitting above 1000 stored bytes
 
-	body := bigBody(3500) // -> 4 parts (1000,1000,1000,500)
+	body := bigBody(3503) // -> 4 parts (1000,1000,1000,503)
 	path := writeTempNamedFile(t, "movie.bin", body)
 	files, err := svc.Upload(context.Background(), personalChannelID, []string{path}, []string{""}, false)
 	if err != nil {

--- a/backend/services/file/service.go
+++ b/backend/services/file/service.go
@@ -631,7 +631,7 @@ func (s *Service) Download(ctx context.Context, channelID int64, msgID int, look
 	}()
 
 	if !encrypted {
-		if err := s.TG.DownloadFile(ctx, peer, int64(msgID), finalTmp, s.downloadProgress(doc.Size)); err != nil {
+		if err := s.TG.DownloadFileAt(ctx, peer, int64(msgID), finalTmp, 0, s.downloadProgress(doc.Size)); err != nil {
 			return DownloadResult{Status: "error", Message: "Network Error: " + err.Error()}
 		}
 	} else {
@@ -643,7 +643,7 @@ func (s *Service) Download(ctx context.Context, channelID int64, msgID int, look
 			_ = cipher.Close()
 			_ = os.Remove(cipher.Name())
 		}()
-		if err := s.TG.DownloadFile(ctx, peer, int64(msgID), cipher, s.downloadProgress(doc.Size)); err != nil {
+		if err := s.TG.DownloadFileAt(ctx, peer, int64(msgID), cipher, 0, s.downloadProgress(doc.Size)); err != nil {
 			return DownloadResult{Status: "error", Message: "Network Error: " + err.Error()}
 		}
 		if _, err := cipher.Seek(0, io.SeekStart); err != nil {
@@ -723,9 +723,10 @@ func (s *Service) downloadMultipart(ctx context.Context, channelID int64, fileID
 	}
 	progress := s.downloadProgress(totalStored)
 
-	// downloadParts streams every part in order into dst, reporting aggregate
-	// progress by offsetting each part's bytes by the bytes already written.
-	downloadParts := func(dst io.Writer) error {
+	// downloadPartsOrdered streams every part in order into dst. The encrypted
+	// path depends on this exact ordering because DecryptStream consumes one
+	// concatenated ciphertext stream.
+	downloadPartsOrdered := func(dst io.Writer) error {
 		var base int64
 		for _, p := range parts {
 			startBase := base
@@ -739,14 +740,87 @@ func (s *Service) downloadMultipart(ctx context.Context, channelID int64, fileID
 		return nil
 	}
 
+	downloadPartsAt := func(dst io.WriterAt) error {
+		const partConcurrency = 2
+
+		partOffsets := make([]int64, len(parts))
+		var off int64
+		for i, p := range parts {
+			partOffsets[i] = off
+			off += p.Size
+		}
+
+		dlCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		sem := make(chan struct{}, partConcurrency)
+		errCh := make(chan error, len(parts))
+		var wg sync.WaitGroup
+		var progressMu sync.Mutex
+		partDone := make([]int64, len(parts))
+
+		report := func(i int, done int64) {
+			if done < 0 {
+				done = 0
+			}
+			if done > parts[i].Size {
+				done = parts[i].Size
+			}
+			progressMu.Lock()
+			if done > partDone[i] {
+				partDone[i] = done
+				var totalDone int64
+				for _, n := range partDone {
+					totalDone += n
+				}
+				progress(totalDone, totalStored)
+			}
+			progressMu.Unlock()
+		}
+
+		for i, part := range parts {
+			i, part := i, part
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				select {
+				case sem <- struct{}{}:
+				case <-dlCtx.Done():
+					return
+				}
+				defer func() { <-sem }()
+
+				if err := s.TG.DownloadFileAt(dlCtx, peer, part.MsgID, dst, partOffsets[i], func(partDone, _ int64) {
+					report(i, partDone)
+				}); err != nil {
+					errCh <- err
+					cancel()
+					return
+				}
+				report(i, part.Size)
+			}()
+		}
+
+		wg.Wait()
+		close(errCh)
+		if err, ok := <-errCh; ok {
+			return err
+		}
+		progress(totalStored, totalStored)
+		return nil
+	}
+
 	if !encrypted {
-		if err := downloadParts(finalTmp); err != nil {
+		if err := finalTmp.Truncate(totalStored); err != nil {
+			return DownloadResult{Status: "error", Message: "Disk Error: " + err.Error()}
+		}
+		if err := downloadPartsAt(finalTmp); err != nil {
 			return DownloadResult{Status: "error", Message: "Network Error: " + err.Error()}
 		}
 	} else {
 		pr, pw := io.Pipe()
 		go func() {
-			_ = pw.CloseWithError(downloadParts(pw))
+			_ = pw.CloseWithError(downloadPartsOrdered(pw))
 		}()
 		if _, err := tdcrypto.DecryptStream(pr, finalTmp, masterKey); err != nil {
 			_ = pr.CloseWithError(err)

--- a/backend/services/read/service.go
+++ b/backend/services/read/service.go
@@ -234,6 +234,16 @@ func (s *Service) FolderSize(channelID int64, folderID string) (int64, error) {
 	return projection.FolderSize(s.DB, channelID, folderID)
 }
 
+func (s *Service) ChildFolderSizes(channelID int64, parentID string) (map[string]int64, error) {
+	if err := s.ready(); err != nil {
+		return nil, err
+	}
+	if channelID == 0 {
+		return map[string]int64{}, nil
+	}
+	return projection.ChildFolderSizes(s.DB, channelID, parentID)
+}
+
 func (s *Service) TelegramRootFiles(ctx context.Context, channelID int64) ([]TelegramFile, error) {
 	if channelID == 0 {
 		return nil, nil

--- a/backend/services/read/service_test.go
+++ b/backend/services/read/service_test.go
@@ -110,6 +110,42 @@ func TestFolderContentsStorageIDsAndSize(t *testing.T) {
 	}
 }
 
+func TestChildFolderSizesBatchesVisibleSubtrees(t *testing.T) {
+	svc, db, _ := newTestService(t)
+
+	project(t, db, 10, projection.Op{Type: projection.OpMkdir, Obj: "d:a", Parent: projection.RootParent, Name: "A"})
+	project(t, db, 11, projection.Op{Type: projection.OpMkdir, Obj: "d:b", Parent: projection.RootParent, Name: "B"})
+	project(t, db, 12, projection.Op{Type: projection.OpMkdir, Obj: "d:a-child", Parent: "d:a", Name: "A child"})
+	project(t, db, 20, projection.Op{
+		Type:           projection.OpFileUpload,
+		Parent:         "d:a",
+		Name:           "a.txt",
+		FileSize:       7,
+		FileUploadTime: 1,
+	})
+	project(t, db, 21, projection.Op{
+		Type:           projection.OpFileUpload,
+		Parent:         "d:a-child",
+		Name:           "nested.txt",
+		FileSize:       13,
+		FileUploadTime: 2,
+	})
+
+	sizes, err := svc.ChildFolderSizes(testChannelID, projection.RootParent)
+	if err != nil {
+		t.Fatalf("child sizes: %v", err)
+	}
+	if got := sizes["d:a"]; got != 20 {
+		t.Fatalf("size d:a = %d, want 20", got)
+	}
+	if got := sizes["d:b"]; got != 0 {
+		t.Fatalf("size d:b = %d, want 0", got)
+	}
+	if _, ok := sizes["d:a-child"]; ok {
+		t.Fatalf("nested child should not be keyed as visible root: %+v", sizes)
+	}
+}
+
 func TestSearchBuildsFolderPaths(t *testing.T) {
 	svc, db, _ := newTestService(t)
 

--- a/backend/storage_sqlite.go
+++ b/backend/storage_sqlite.go
@@ -71,6 +71,17 @@ func InitDB() error {
 		_ = db.Close()
 		return err
 	}
+	if _, err := db.Exec(`PRAGMA temp_store=MEMORY;`); err != nil {
+		_ = db.Close()
+		return err
+	}
+	if _, err := db.Exec(`PRAGMA cache_size=-32768;`); err != nil {
+		_ = db.Close()
+		return err
+	}
+	// mmap_size is a read optimization on drivers/platforms that support it.
+	// Treat it as opportunistic so startup does not depend on mmap support.
+	_, _ = db.Exec(`PRAGMA mmap_size=134217728;`)
 
 	DB = db
 

--- a/backend/tgclient/client.go
+++ b/backend/tgclient/client.go
@@ -166,6 +166,11 @@ type Client interface {
 	// optional; callers can use it to surface transfer progress.
 	DownloadFile(ctx context.Context, peer InputPeer, msgID int64, w io.Writer, onProgress func(done, total int64)) error
 
+	// DownloadFileAt downloads a Telegram document into w using random-access
+	// writes starting at baseOffset. It may fetch chunks concurrently; callers
+	// that need append/order semantics must use DownloadFile instead.
+	DownloadFileAt(ctx context.Context, peer InputPeer, msgID int64, w io.WriterAt, baseOffset int64, onProgress func(done, total int64)) error
+
 	// DownloadFileThumbnail streams a Telegram document thumbnail into w.
 	DownloadFileThumbnail(ctx context.Context, peer InputPeer, msgID int64, thumbType string, w io.Writer) error
 

--- a/backend/tgclient/fake.go
+++ b/backend/tgclient/fake.go
@@ -490,6 +490,40 @@ func (f *Fake) DownloadFile(ctx context.Context, peer InputPeer, msgID int64, w 
 	return err
 }
 
+func (f *Fake) DownloadFileAt(ctx context.Context, peer InputPeer, msgID int64, w io.WriterAt, baseOffset int64, onProgress func(done, total int64)) error {
+	f.mu.Lock()
+	var (
+		msg   HistoryMessage
+		found bool
+	)
+	for _, m := range f.history {
+		if m.MsgID == msgID {
+			msg = m
+			found = true
+			break
+		}
+	}
+	if !found {
+		f.mu.Unlock()
+		return ErrMessageNotFound
+	}
+	if !msg.HasMedia {
+		f.mu.Unlock()
+		return ErrNotFile
+	}
+	body := append([]byte(nil), f.fileBodies[msgID]...)
+	f.mu.Unlock()
+
+	if len(body) == 0 && msg.MediaSize > 0 {
+		return ErrEmptyDocument
+	}
+	n, err := w.WriteAt(body, baseOffset)
+	if onProgress != nil {
+		onProgress(int64(n), msg.MediaSize)
+	}
+	return err
+}
+
 func (f *Fake) DownloadFileThumbnail(ctx context.Context, peer InputPeer, msgID int64, thumbType string, w io.Writer) error {
 	f.mu.Lock()
 	var (

--- a/backend/tgclient/getfile_limiter.go
+++ b/backend/tgclient/getfile_limiter.go
@@ -1,0 +1,101 @@
+package tgclient
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	// MaxConcurrentGetFile caps low-level Telegram upload.getFile pressure across
+	// every caller. Keeping it process-wide avoids multiplicative fan-out such as
+	// multipart parts * per-file threads, which would otherwise trip FLOOD_WAIT.
+	MaxConcurrentGetFile = 8
+
+	// PlaybackGetFileReserve is the number of global slots that background work can
+	// never consume, so foreground media playback always has headroom even while
+	// downloads or thumbnail generation are saturating everything else.
+	PlaybackGetFileReserve = 2
+
+	// MaxConcurrentBackgroundGetFile is the budget shared by all background getFile
+	// work: disk downloads, seek-thumbnail generation, and playback read-ahead.
+	// The remaining global slots stay reserved for foreground playback reads.
+	MaxConcurrentBackgroundGetFile = MaxConcurrentGetFile - PlaybackGetFileReserve
+
+	// DefaultDownloadThreads is the per-download random-access thread budget. With
+	// two multipart parts in flight this fills the background pool while still
+	// preserving playback headroom under MaxConcurrentGetFile.
+	DefaultDownloadThreads = 3
+
+	backgroundGlobalRetry = 10 * time.Millisecond
+)
+
+var (
+	getFileSlots           = semaphore.NewWeighted(MaxConcurrentGetFile)
+	backgroundGetFileSlots = semaphore.NewWeighted(MaxConcurrentBackgroundGetFile)
+)
+
+// AcquireGetFileSlots reserves n global getFile slots for foreground media
+// playback reads. Background work (downloads, thumbnails, read-ahead) must use
+// AcquireBackgroundGetFileSlots so playback keeps its reserved headroom.
+func AcquireGetFileSlots(ctx context.Context, n int) (func(), error) {
+	weight := int64(clampGetFileWeight(n, MaxConcurrentGetFile))
+	if err := getFileSlots.Acquire(ctx, weight); err != nil {
+		return nil, err
+	}
+	return func() {
+		getFileSlots.Release(weight)
+	}, nil
+}
+
+// AcquireBackgroundGetFileSlots reserves n getFile slots for background work:
+// disk downloads, seek-thumbnail generation, and playback read-ahead. It gates
+// through a smaller background pool first, then enters the global pool with a
+// non-queued TryAcquire. That second detail matters: a queued multi-slot
+// background acquire must never sit at the head of the global semaphore and block
+// a one-slot foreground playback read from using its reserved capacity.
+func AcquireBackgroundGetFileSlots(ctx context.Context, n int) (func(), error) {
+	weight := int64(clampGetFileWeight(n, MaxConcurrentBackgroundGetFile))
+	if err := backgroundGetFileSlots.Acquire(ctx, weight); err != nil {
+		return nil, err
+	}
+
+	releaseGlobal, err := acquireGlobalGetFileSlotsNoQueue(ctx, weight)
+	if err != nil {
+		backgroundGetFileSlots.Release(weight)
+		return nil, err
+	}
+	return func() {
+		releaseGlobal()
+		backgroundGetFileSlots.Release(weight)
+	}, nil
+}
+
+func acquireGlobalGetFileSlotsNoQueue(ctx context.Context, weight int64) (func(), error) {
+	weight = int64(clampGetFileWeight(int(weight), MaxConcurrentGetFile))
+	for {
+		if getFileSlots.TryAcquire(weight) {
+			return func() {
+				getFileSlots.Release(weight)
+			}, nil
+		}
+		timer := time.NewTimer(backgroundGlobalRetry)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func clampGetFileWeight(n, max int) int {
+	if n < 1 {
+		return 1
+	}
+	if n > max {
+		return max
+	}
+	return n
+}

--- a/backend/tgclient/getfile_limiter_test.go
+++ b/backend/tgclient/getfile_limiter_test.go
@@ -1,0 +1,123 @@
+package tgclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestBackgroundLimiterLeavesPlaybackHeadroom(t *testing.T) {
+	ctx := context.Background()
+
+	releaseA, err := AcquireBackgroundGetFileSlots(ctx, DefaultDownloadThreads)
+	if err != nil {
+		t.Fatalf("acquire first download: %v", err)
+	}
+	defer releaseA()
+
+	releaseB, err := AcquireBackgroundGetFileSlots(ctx, DefaultDownloadThreads)
+	if err != nil {
+		t.Fatalf("acquire second download: %v", err)
+	}
+	defer releaseB()
+
+	blockedCtx, cancelBlocked := context.WithCancel(ctx)
+	blocked := make(chan error, 1)
+	go func() {
+		release, err := AcquireBackgroundGetFileSlots(blockedCtx, DefaultDownloadThreads)
+		if err == nil {
+			release()
+		}
+		blocked <- err
+	}()
+
+	select {
+	case err := <-blocked:
+		t.Fatalf("third download acquired despite full download pool: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	playbackCtx, cancelPlayback := context.WithTimeout(ctx, time.Second)
+	defer cancelPlayback()
+	releasePlayback, err := AcquireGetFileSlots(playbackCtx, 1)
+	if err != nil {
+		t.Fatalf("playback should acquire reserved getFile slot while downloads are full: %v", err)
+	}
+	releasePlayback()
+
+	cancelBlocked()
+	if err := <-blocked; !errors.Is(err, context.Canceled) {
+		t.Fatalf("blocked download err = %v, want context.Canceled", err)
+	}
+}
+
+func TestBackgroundLimiterDoesNotHeadOfLineBlockPlayback(t *testing.T) {
+	ctx := context.Background()
+
+	releaseDownload, err := AcquireBackgroundGetFileSlots(ctx, DefaultDownloadThreads)
+	if err != nil {
+		t.Fatalf("acquire download: %v", err)
+	}
+	defer releaseDownload()
+
+	// Fill the remaining global slots with foreground reads. A second download
+	// still has room in the download pool, but not enough global capacity; it must
+	// wait outside the global semaphore so it cannot block later playback reads.
+	var foreground []func()
+	defer func() {
+		for _, release := range foreground {
+			release()
+		}
+	}()
+	for i := 0; i < MaxConcurrentGetFile-DefaultDownloadThreads; i++ {
+		release, err := AcquireGetFileSlots(ctx, 1)
+		if err != nil {
+			t.Fatalf("acquire foreground fill slot %d: %v", i, err)
+		}
+		foreground = append(foreground, release)
+	}
+
+	blockedCtx, cancelBlocked := context.WithCancel(ctx)
+	blockedDownload := make(chan error, 1)
+	go func() {
+		release, err := AcquireBackgroundGetFileSlots(blockedCtx, DefaultDownloadThreads)
+		if err == nil {
+			release()
+		}
+		blockedDownload <- err
+	}()
+
+	select {
+	case err := <-blockedDownload:
+		t.Fatalf("second download acquired despite full global pool: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	playbackAcquired := make(chan error, 1)
+	go func() {
+		release, err := AcquireGetFileSlots(ctx, 1)
+		if err == nil {
+			release()
+		}
+		playbackAcquired <- err
+	}()
+
+	// Free exactly one global slot. A queued weight-3 download would block this
+	// one-slot playback acquire; the non-queued download path leaves it available.
+	foreground[0]()
+	foreground = foreground[1:]
+	select {
+	case err := <-playbackAcquired:
+		if err != nil {
+			t.Fatalf("playback acquire: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("playback acquire was head-of-line blocked by download")
+	}
+
+	cancelBlocked()
+	if err := <-blockedDownload; !errors.Is(err, context.Canceled) {
+		t.Fatalf("blocked download err = %v, want context.Canceled", err)
+	}
+}

--- a/backend/tgclient/gotd.go
+++ b/backend/tgclient/gotd.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"TDrive/backend/auth"
@@ -399,9 +400,48 @@ func (g *Gotd) DownloadFile(ctx context.Context, peer InputPeer, msgID int64, w 
 				onProgress: onProgress,
 			}
 		}
+		release, err := AcquireBackgroundGetFileSlots(ctx, 1)
+		if err != nil {
+			return err
+		}
+		defer release()
+
 		d := downloader.NewDownloader()
 		if _, err := d.Download(api, doc.AsInputDocumentFileLocation()).Stream(ctx, dst); err != nil {
 			return fmt.Errorf("tgclient: download: %w", err)
+		}
+		return nil
+	})
+}
+
+func (g *Gotd) DownloadFileAt(ctx context.Context, peer InputPeer, msgID int64, w io.WriterAt, baseOffset int64, onProgress func(done, total int64)) error {
+	return g.run(ctx, func(ctx context.Context, api *tg.Client) error {
+		doc, _, err := getDocumentByMessageID(ctx, api, peer, msgID)
+		if err != nil {
+			return err
+		}
+
+		threads := DefaultDownloadThreads
+		release, err := AcquireBackgroundGetFileSlots(ctx, threads)
+		if err != nil {
+			return err
+		}
+		defer release()
+
+		dst := io.WriterAt(offsetWriterAt{w: w, base: baseOffset})
+		if onProgress != nil {
+			dst = &progressWriterAt{
+				w:          dst,
+				total:      doc.Size,
+				onProgress: onProgress,
+			}
+		}
+		d := downloader.NewDownloader()
+		if _, err := d.Download(api, doc.AsInputDocumentFileLocation()).WithThreads(threads).Parallel(ctx, dst); err != nil {
+			return fmt.Errorf("tgclient: download: %w", err)
+		}
+		if onProgress != nil {
+			onProgress(doc.Size, doc.Size)
 		}
 		return nil
 	})
@@ -413,6 +453,12 @@ func (g *Gotd) DownloadFileThumbnail(ctx context.Context, peer InputPeer, msgID 
 		if err != nil {
 			return err
 		}
+		release, err := AcquireBackgroundGetFileSlots(ctx, 1)
+		if err != nil {
+			return err
+		}
+		defer release()
+
 		d := downloader.NewDownloader()
 		location := &tg.InputDocumentFileLocation{
 			ID:            doc.ID,
@@ -715,6 +761,36 @@ func (p *progressWriter) Write(b []byte) (int, error) {
 		p.done += int64(n)
 		if p.onProgress != nil {
 			p.onProgress(p.done, p.total)
+		}
+	}
+	return n, err
+}
+
+type offsetWriterAt struct {
+	w    io.WriterAt
+	base int64
+}
+
+func (o offsetWriterAt) WriteAt(b []byte, off int64) (int, error) {
+	return o.w.WriteAt(b, o.base+off)
+}
+
+type progressWriterAt struct {
+	w          io.WriterAt
+	total      int64
+	done       atomic.Int64
+	lastEmit   atomic.Int64
+	onProgress func(done, total int64)
+}
+
+func (p *progressWriterAt) WriteAt(b []byte, off int64) (int, error) {
+	n, err := p.w.WriteAt(b, off)
+	if n > 0 && p.onProgress != nil {
+		done := p.done.Add(int64(n))
+		now := time.Now().UnixNano()
+		last := p.lastEmit.Load()
+		if now-last >= int64(100*time.Millisecond) && p.lastEmit.CompareAndSwap(last, now) {
+			p.onProgress(done, p.total)
 		}
 	}
 	return n, err

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -67,7 +67,7 @@ export interface MediaPlaybackUpdate {
     token: string;
     currentTime: number;
     duration: number;
-    busy: boolean;
+    bufferAhead: number;
 }
 
 export interface ThroughputStats {
@@ -235,7 +235,7 @@ export async function updateMediaPlayback(update: MediaPlaybackUpdate): Promise<
         token: update.token,
         current_time: update.currentTime,
         duration: update.duration,
-        busy: update.busy,
+        buffer_ahead: update.bufferAhead,
     } as any);
 }
 

--- a/frontend/src/modules/drive-data.ts
+++ b/frontend/src/modules/drive-data.ts
@@ -47,6 +47,20 @@ export async function calculateFolderTotalBytes(folderID: string): Promise<numbe
     throw new Error("GetFolderSize is not available. Restart `wails dev` to regenerate bindings.");
 }
 
+export async function calculateVisibleFolderBytes(parentID: string): Promise<Map<string, number>> {
+    const a = app();
+    if (a?.GetFolderSizes) {
+        const raw = await a.GetFolderSizes(String(parentID || ""));
+        const out = new Map<string, number>();
+        for (const [id, value] of Object.entries(raw || {})) {
+            const bytes = Number(value);
+            out.set(String(id), Number.isFinite(bytes) && bytes >= 0 ? bytes : 0);
+        }
+        return out;
+    }
+    throw new Error("GetFolderSizes is not available. Restart `wails dev` to regenerate bindings.");
+}
+
 export async function getAllFsMsgIDs(): Promise<number[]> {
     const a = app();
     if (a?.GetAllFsMsgIDs) {

--- a/frontend/src/modules/file-list.ts
+++ b/frontend/src/modules/file-list.ts
@@ -11,7 +11,7 @@ import {
     GetFileList, GetStorageUsed,
 } from '../../wailsjs/go/main/App';
 import { getFolderContents as apiGetFolderContents } from '../api';
-import { calculateFolderTotalBytes, getAllFsMsgIDs } from './drive-data';
+import { calculateVisibleFolderBytes, getAllFsMsgIDs } from './drive-data';
 import { refreshFolderIndex, collectDescendants } from './folder-index';
 import { enqueueDownload } from './transfers';
 import { populateUploaderChips, uploaderChipHTML } from './uploaders';
@@ -91,6 +91,34 @@ export function resetFileListScrollRestore() {
     lastRenderedFolderId = null;
 }
 
+function fillVisibleFolderSizes(folders: any[], parentId: string, folderEpoch: number, list: HTMLElement) {
+    if (!folders.length) return;
+    calculateVisibleFolderBytes(parentId)
+        .then((sizes) => {
+            if (state.folderSizeEpoch !== folderEpoch) return;
+            if (state.currentFolderId !== parentId) return;
+            for (const folder of folders) {
+                const id = String(folder?.id || "");
+                if (!id) continue;
+                const row = list.querySelector(`.folder-row[data-id="${CSS.escape(id)}"]`);
+                const sizeEl = row?.querySelector(".folder-size");
+                if (!sizeEl) continue;
+                sizeEl.textContent = formatBytes(sizes.get(id) ?? 0);
+            }
+        })
+        .catch(() => {
+            if (state.folderSizeEpoch !== folderEpoch) return;
+            if (state.currentFolderId !== parentId) return;
+            for (const folder of folders) {
+                const id = String(folder?.id || "");
+                if (!id) continue;
+                const row = list.querySelector(`.folder-row[data-id="${CSS.escape(id)}"]`);
+                const sizeEl = row?.querySelector(".folder-size");
+                if (sizeEl) sizeEl.textContent = "—";
+            }
+        });
+}
+
 export function refreshFiles() {
     if (state.virtualView === "photos") {
         clearSelection();
@@ -137,14 +165,7 @@ export function refreshFiles() {
         return null;
     });
 
-    const tgPromise = requestedFolderId === ""
-        ? GetFileList().catch((err) => {
-            console.error("GetFileList failed:", err);
-            return [];
-        })
-        : Promise.resolve([]);
-
-    Promise.all([folderPromise, tgPromise]).then(([fs, tgFiles]) => {
+    Promise.all([folderPromise]).then(async ([fs]) => {
         if (folderErr || !fs) {
             if (state.currentFolderId !== requestedFolderId) return;
             const msg = String(folderErr?.message || folderErr || "Failed to load files");
@@ -160,8 +181,6 @@ export function refreshFiles() {
 
         const folders = Array.isArray(fs?.folders) ? fs.folders : [];
         const fsFiles = Array.isArray(fs?.files) ? fs.files : [];
-        const telegramFiles = Array.isArray(tgFiles) ? tgFiles : [];
-        if (requestedFolderId === "") state.telegramRootCache = telegramFiles;
 
         const fsFileItems = fsFiles.map((f) => {
             const encrypted = !!f.encrypted;
@@ -180,9 +199,14 @@ export function refreshFiles() {
             };
         });
 
-        const finalize = async () => {
+        const finalize = async (tgFiles: any[] = [], preserveCurrentScroll = false) => {
+            if (state.folderSizeEpoch !== folderEpoch) return;
+            if (state.currentFolderId !== requestedFolderId) return;
+            const telegramFiles = Array.isArray(tgFiles) ? tgFiles : [];
+            const scrollTopForRender = preserveCurrentScroll ? list.scrollTop : prevScrollTop;
+            const keepScrollForRender = preserveCurrentScroll || keepScroll;
             let fsIDs;
-            if (requestedFolderId === "") {
+            if (requestedFolderId === "" && telegramFiles.length > 0) {
                 try {
                     fsIDs = new Set((await getAllFsMsgIDs()).filter((id) => typeof id === "number"));
                 } catch (err) {
@@ -312,23 +336,9 @@ export function refreshFiles() {
 
                 list.appendChild(row);
 
-                const sizeEl = row.querySelector(".folder-size");
-                if (sizeEl) {
-                    calculateFolderTotalBytes(folder.id)
-                        .then((bytes) => {
-                            if (state.folderSizeEpoch !== folderEpoch) return;
-                            if (state.currentFolderId !== requestedFolderId) return;
-                            if (!row.isConnected) return;
-                            sizeEl.textContent = formatBytes(bytes);
-                        })
-                        .catch(() => {
-                            if (state.folderSizeEpoch !== folderEpoch) return;
-                            if (state.currentFolderId !== requestedFolderId) return;
-                            if (!row.isConnected) return;
-                            sizeEl.textContent = "—";
-                        });
-                }
             });
+
+            fillVisibleFolderSizes(folders, requestedFolderId, folderEpoch, list);
 
             files.forEach((file: any) => {
                 const { base, ext } = splitNameAndExt(file.name);
@@ -402,8 +412,8 @@ export function refreshFiles() {
             // pendingFocus so a just-uploaded/renamed file can still scroll
             // itself into view and win.
             lastRenderedFolderId = requestedFolderId;
-            if (keepScroll && state.currentFolderId === requestedFolderId) {
-                list.scrollTop = prevScrollTop;
+            if (keepScrollForRender && state.currentFolderId === requestedFolderId) {
+                list.scrollTop = scrollTopForRender;
             }
 
             if (state.pendingFocus && state.pendingFocus.type === "file") {
@@ -427,7 +437,21 @@ export function refreshFiles() {
             populateUploaderChips(list);
         };
 
-        finalize();
+        await finalize();
+
+        if (requestedFolderId === "" && state.currentFolderId === requestedFolderId) {
+            GetFileList()
+                .then(async (tgFiles) => {
+                    if (state.folderSizeEpoch !== folderEpoch) return;
+                    if (state.currentFolderId !== requestedFolderId) return;
+                    const telegramFiles = Array.isArray(tgFiles) ? tgFiles : [];
+                    state.telegramRootCache = telegramFiles;
+                    await finalize(telegramFiles, true);
+                })
+                .catch((err) => {
+                    console.error("GetFileList failed:", err);
+                });
+        }
     });
 }
 

--- a/frontend/src/modules/modals/video.ts
+++ b/frontend/src/modules/modals/video.ts
@@ -29,6 +29,10 @@ const THUMBNAIL_REQUEST_DEBOUNCE_MS = 140;
 const THUMBNAIL_DWELL_PREFETCH_MS = 420;
 const THUMBNAIL_RETRY_MS = 650;
 const THUMBNAIL_FAILURE_TTL_MS = 15_000;
+// When the exact bucket isn't ready yet, show the nearest already-cached frame
+// within this many seconds as a placeholder (the exact frame swaps in on load).
+// Kept small so the placeholder is genuinely the same scene, never a far one.
+const THUMBNAIL_NEAREST_MAX_SECONDS = 120;
 const PLAYBACK_HINT_INTERVAL_MS = 1000;
 const MEDIA_STATS_POLL_MS = 1000;
 const STREAM_ACTIVITY_HOLD_MS = 2000;
@@ -954,13 +958,27 @@ async function sendPlaybackHint(state: PlayerState) {
             token: activeMediaToken,
             currentTime: state.currentTime,
             duration: state.duration,
-            busy: Boolean(state.loading),
+            bufferAhead: bufferAheadSeconds(state),
         });
     } catch (err) {
         console.warn("UpdateMediaPlayback failed:", err);
     } finally {
         playbackHintInFlight = false;
     }
+}
+
+// bufferAheadSeconds reports how many seconds are buffered ahead of the current
+// playhead. It reads the shared PlayerState.buffered ranges, so it works for both
+// the HTML <video> and native mpv engines. The thumbnail scheduler uses it to
+// decide how aggressively it may build previews without starving playback.
+function bufferAheadSeconds(state: PlayerState): number {
+    const t = state.currentTime;
+    for (const range of state.buffered) {
+        if (range.start <= t && t <= range.end) {
+            return Math.max(0, range.end - t);
+        }
+    }
+    return 0;
 }
 
 function clearPlaybackHintTimer() {
@@ -1027,19 +1045,48 @@ function updateThumbnailTooltip(seconds: number) {
     if (cached && scrubberTooltipImageEl && scrubberTooltipEl) {
         clearThumbnailRequestTimer();
         scheduleThumbnailDwell(bucket);
-        if (scrubberTooltipImageEl.src !== cached) {
-            scrubberTooltipImageEl.src = cached;
-        }
+        showTooltipImage(cached);
         setThumbnailTooltipState("ready");
         return;
     }
     clearThumbnailDwellTimer();
+    // No exact frame yet: show the nearest already-cached frame as a placeholder so
+    // the user never stares at a blank skeleton. The time label stays exact, and the
+    // precise frame swaps in when it loads (keepVisible avoids a skeleton flash).
+    const nearest = nearestCachedThumbnail(bucket);
+    if (nearest && scrubberTooltipImageEl && scrubberTooltipEl) {
+        showTooltipImage(nearest);
+        setThumbnailTooltipState("ready");
+        scheduleThumbnailRequest(bucket, true);
+        return;
+    }
     if (thumbnailFailedRecently(bucket)) {
         setThumbnailTooltipState("failed");
         return;
     }
     setThumbnailTooltipState("pending");
     scheduleThumbnailRequest(bucket);
+}
+
+// nearestCachedThumbnail returns the cached frame closest to bucket, but only if
+// it is within THUMBNAIL_NEAREST_MAX_SECONDS so the placeholder is the same scene.
+function nearestCachedThumbnail(bucket: number): string | null {
+    let bestURL: string | null = null;
+    let bestDistance = Infinity;
+    for (const [cachedBucket, url] of thumbnailObjectURLs) {
+        const distance = Math.abs(cachedBucket - bucket);
+        if (distance <= THUMBNAIL_NEAREST_MAX_SECONDS && distance < bestDistance) {
+            bestDistance = distance;
+            bestURL = url;
+        }
+    }
+    return bestURL;
+}
+
+function showTooltipImage(url: string) {
+    if (scrubberTooltipImageEl && scrubberTooltipImageEl.src !== url) {
+        scrubberTooltipImageEl.src = url;
+    }
 }
 
 function thumbnailBucket(seconds: number) {
@@ -1067,7 +1114,7 @@ function clearThumbnailDwellTimer() {
     thumbnailDwellTimer = null;
 }
 
-function scheduleThumbnailRequest(bucket: number) {
+function scheduleThumbnailRequest(bucket: number, keepVisible = false) {
     if (!activeThumbnailURL || thumbnailObjectURLs.has(bucket)) return;
     scheduledThumbnailBucket = bucket;
     if (thumbnailRequestTimer != null) window.clearTimeout(thumbnailRequestTimer);
@@ -1076,7 +1123,7 @@ function scheduleThumbnailRequest(bucket: number) {
         const bucketToRequest = scheduledThumbnailBucket;
         scheduledThumbnailBucket = -1;
         if (bucketToRequest !== currentPreviewBucket) return;
-        requestThumbnail(bucketToRequest);
+        requestThumbnail(bucketToRequest, false, keepVisible);
     }, THUMBNAIL_REQUEST_DEBOUNCE_MS);
 }
 
@@ -1094,11 +1141,11 @@ function scheduleThumbnailDwell(bucket: number) {
     }, THUMBNAIL_DWELL_PREFETCH_MS);
 }
 
-function requestThumbnail(bucket: number, prefetch = false) {
+function requestThumbnail(bucket: number, prefetch = false, keepVisible = false) {
     if (!activeThumbnailURL || pendingThumbnails.has(bucket) || thumbnailObjectURLs.has(bucket)) return;
     if (thumbnailFailedRecently(bucket)) return;
     pendingThumbnails.add(bucket);
-    if (!prefetch && currentPreviewBucket === bucket) setThumbnailTooltipState("pending");
+    if (!prefetch && !keepVisible && currentPreviewBucket === bucket) setThumbnailTooltipState("pending");
     const seq = thumbnailRequestSeq;
     const url = `${activeThumbnailURL}?t=${encodeURIComponent(String(bucket))}`;
     let retryScheduled = false;
@@ -1115,7 +1162,7 @@ function requestThumbnail(bucket: number, prefetch = false) {
             }
             if (!response.ok) {
                 failedThumbnails.set(bucket, Date.now());
-                if (!prefetch && currentPreviewBucket === bucket) setThumbnailTooltipState("failed");
+                if (!prefetch && !keepVisible && currentPreviewBucket === bucket) setThumbnailTooltipState("failed");
                 return;
             }
             const blob = await response.blob();
@@ -1134,7 +1181,7 @@ function requestThumbnail(bucket: number, prefetch = false) {
         })
         .catch(() => {
             if (seq === thumbnailRequestSeq) failedThumbnails.set(bucket, Date.now());
-            if (!prefetch && seq === thumbnailRequestSeq && currentPreviewBucket === bucket) setThumbnailTooltipState("failed");
+            if (!prefetch && !keepVisible && seq === thumbnailRequestSeq && currentPreviewBucket === bucket) setThumbnailTooltipState("failed");
         })
         .finally(() => {
             if (seq === thumbnailRequestSeq && !retryScheduled) pendingThumbnails.delete(bucket);

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -52,6 +52,8 @@ export function GetFolderContents(arg1:string):Promise<backend.FileSystem>;
 
 export function GetFolderSize(arg1:string):Promise<number>;
 
+export function GetFolderSizes(arg1:string):Promise<Record<string, number>>;
+
 export function GetInviteLink(arg1:number):Promise<string>;
 
 export function GetMediaStats(arg1:string):Promise<media.MediaStats>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -94,6 +94,10 @@ export function GetFolderSize(arg1) {
   return window['go']['main']['App']['GetFolderSize'](arg1);
 }
 
+export function GetFolderSizes(arg1) {
+  return window['go']['main']['App']['GetFolderSizes'](arg1);
+}
+
 export function GetInviteLink(arg1) {
   return window['go']['main']['App']['GetInviteLink'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -513,7 +513,7 @@ export namespace media {
 	    token: string;
 	    current_time: number;
 	    duration: number;
-	    busy: boolean;
+	    buffer_ahead: number;
 
 	    static createFrom(source: any = {}) {
 	        return new PlaybackUpdate(source);
@@ -524,7 +524,7 @@ export namespace media {
 	        this.token = source["token"];
 	        this.current_time = source["current_time"];
 	        this.duration = source["duration"];
-	        this.busy = source["busy"];
+	        this.buffer_ahead = source["buffer_ahead"];
 	    }
 	}
 


### PR DESCRIPTION
## changes
- faster folder navigation and folder-size reads
- parallelized downloads with getFile headroom for playback
- range-reader prefetch and throughput tracking
- faster long-video seek thumbnails with persistent mpv, precompute, and retry fixes
