### PR TITLE
stabilize backend

### DIFF
--- a/app.go
+++ b/app.go
@@ -31,6 +31,7 @@ type App struct {
 	// fileDropEnabled tracks whether the native OS file-drop handler is
 	// registered. The frontend toggles it off during an internal drag-to-move so
 	// macOS does not intercept the in-app HTML5 drag.
+	fileDropMu      sync.Mutex
 	fileDropEnabled bool
 
 	// transferMu guards the cancel handles for the active upload/import and the
@@ -145,7 +146,8 @@ type PreviewPayload struct {
 }
 
 func (a *App) CheckLoginStatus() bool {
-	return a.authService().IsLoggedIn(a.ctx)
+	svc := a.authService()
+	return svc != nil && svc.IsLoggedIn(a.ctx)
 }
 
 func (a *App) SelectFiles() ([]string, error) {
@@ -195,7 +197,11 @@ func (a *App) endUpload() {
 // never an upload still in flight, so it's safe to run at the start of an upload
 // flow. Best effort — a normal session finds nothing and never hits Telegram.
 func (a *App) sweepOrphanParts(ctx context.Context) {
-	if err := a.fileService().SweepOrphanParts(ctx, a.ActiveChannelID()); err != nil {
+	svc := a.fileService()
+	if svc == nil {
+		return
+	}
+	if err := svc.SweepOrphanParts(ctx, a.ActiveChannelID()); err != nil {
 		fmt.Printf("warn: orphan-part sweep failed: %v\n", err)
 	}
 }
@@ -241,10 +247,14 @@ func (a *App) CancelDownload() {
 }
 
 func (a *App) UploadToDriveFS(filePaths []string, parentIDs []string, encrypt bool) ([]backend.FileMetaData, error) {
+	svc, err := a.requireFileService()
+	if err != nil {
+		return nil, err
+	}
 	ctx := a.beginUpload()
 	defer a.endUpload()
 	a.sweepOrphanParts(ctx)
-	files, err := a.fileService().Upload(ctx, a.ActiveChannelID(), filePaths, parentIDs, encrypt)
+	files, err := svc.Upload(ctx, a.ActiveChannelID(), filePaths, parentIDs, encrypt)
 	if err != nil {
 		out := make([]backend.FileMetaData, 0, len(files))
 		for _, f := range files {
@@ -264,6 +274,9 @@ func (a *App) UploadToDriveFS(filePaths []string, parentIDs []string, encrypt bo
 // mutates nothing.
 func (a *App) PlanImport(paths []string, encrypt bool, extractArchives bool) fileservice.ImportPlan {
 	svc := a.fileService()
+	if svc == nil {
+		return fileservice.ImportPlan{Errors: []string{"backend not ready"}}
+	}
 	return svc.PlanImport(paths, encrypt, extractArchives)
 }
 
@@ -272,7 +285,10 @@ func (a *App) PlanImport(paths []string, encrypt bool, extractArchives bool) fil
 // is set, otherwise uploaded as-is. Progress flows through the import_* and the
 // per-file upload_* events.
 func (a *App) ImportPaths(paths []string, parentID string, encrypt bool, extractArchives bool) error {
-	svc := a.fileService()
+	svc, err := a.requireFileService()
+	if err != nil {
+		return err
+	}
 	ctx := a.beginUpload()
 	defer a.endUpload()
 	a.sweepOrphanParts(ctx)
@@ -298,11 +314,25 @@ func (a *App) folderService() *folderservice.Service {
 	return a.engine.FolderService()
 }
 
+func (a *App) requireFolderService() (*folderservice.Service, error) {
+	if svc := a.folderService(); svc != nil {
+		return svc, nil
+	}
+	return nil, fmt.Errorf("backend not ready")
+}
+
 func (a *App) fileService() *fileservice.Service {
 	if a.engine == nil {
 		return nil
 	}
 	return a.engine.FileService()
+}
+
+func (a *App) requireFileService() (*fileservice.Service, error) {
+	if svc := a.fileService(); svc != nil {
+		return svc, nil
+	}
+	return nil, fmt.Errorf("backend not ready")
 }
 
 func (a *App) readService() *readservice.Service {
@@ -312,6 +342,13 @@ func (a *App) readService() *readservice.Service {
 	return a.engine.ReadService()
 }
 
+func (a *App) requireReadService() (*readservice.Service, error) {
+	if svc := a.readService(); svc != nil {
+		return svc, nil
+	}
+	return nil, fmt.Errorf("backend not ready")
+}
+
 func (a *App) lifecycleService() *lifecycleservice.Service {
 	if a.engine == nil {
 		return nil
@@ -319,11 +356,25 @@ func (a *App) lifecycleService() *lifecycleservice.Service {
 	return a.engine.LifecycleService()
 }
 
+func (a *App) requireLifecycleService() (*lifecycleservice.Service, error) {
+	if svc := a.lifecycleService(); svc != nil {
+		return svc, nil
+	}
+	return nil, fmt.Errorf("backend not ready")
+}
+
 func (a *App) userService() *userservice.Service {
 	if a.engine == nil {
 		return nil
 	}
 	return a.engine.UserService()
+}
+
+func (a *App) requireUserService() (*userservice.Service, error) {
+	if svc := a.userService(); svc != nil {
+		return svc, nil
+	}
+	return nil, fmt.Errorf("backend not ready")
 }
 
 func (a *App) authService() *authsvc.Service {
@@ -334,15 +385,27 @@ func (a *App) authService() *authsvc.Service {
 }
 
 func (a *App) LoginPhoneNumber(phoneNumber string) error {
-	return a.authService().StartLogin(a.ctx, phoneNumber)
+	svc := a.authService()
+	if svc == nil {
+		return fmt.Errorf("backend not ready")
+	}
+	return svc.StartLogin(a.ctx, phoneNumber)
 }
 
 func (a *App) InitDrive() string {
-	return a.lifecycleService().InitDrive(a.ctx)
+	svc, err := a.requireLifecycleService()
+	if err != nil {
+		return err.Error()
+	}
+	return svc.InitDrive(a.ctx)
 }
 
 func (a *App) GetFileList() []TDriveFile {
-	files, err := a.readService().TelegramRootFiles(a.ctx, a.ActiveChannelID())
+	svc, err := a.requireReadService()
+	if err != nil {
+		return nil
+	}
+	files, err := svc.TelegramRootFiles(a.ctx, a.ActiveChannelID())
 	if err != nil {
 		return nil
 	}
@@ -360,7 +423,11 @@ func (a *App) GetFileList() []TDriveFile {
 }
 
 func (a *App) PreviewThumbnail(msgID int) (PreviewPayload, error) {
-	payload, err := a.fileService().PreviewThumbnail(a.ctx, a.ActiveChannelID(), msgID)
+	svc, err := a.requireFileService()
+	if err != nil {
+		return PreviewPayload{}, err
+	}
+	payload, err := svc.PreviewThumbnail(a.ctx, a.ActiveChannelID(), msgID)
 	if err != nil {
 		return PreviewPayload{}, err
 	}
@@ -368,7 +435,11 @@ func (a *App) PreviewThumbnail(msgID int) (PreviewPayload, error) {
 }
 
 func (a *App) PreviewFile(msgID int) (PreviewPayload, error) {
-	payload, err := a.fileService().PreviewFile(a.ctx, a.ActiveChannelID(), msgID)
+	svc, err := a.requireFileService()
+	if err != nil {
+		return PreviewPayload{}, err
+	}
+	payload, err := svc.PreviewFile(a.ctx, a.ActiveChannelID(), msgID)
 	if err != nil {
 		return PreviewPayload{}, err
 	}
@@ -376,9 +447,13 @@ func (a *App) PreviewFile(msgID int) (PreviewPayload, error) {
 }
 
 func (a *App) DownloadFile(msgID int, TgMsgID int) DownloadResult {
+	svc, err := a.requireFileService()
+	if err != nil {
+		return DownloadResult{Status: "error", Message: err.Error()}
+	}
 	ctx := a.beginDownload()
 	defer a.endDownload()
-	result := a.fileService().Download(ctx, a.ActiveChannelID(), msgID, TgMsgID, func(defaultName string) (string, error) {
+	result := svc.Download(ctx, a.ActiveChannelID(), msgID, TgMsgID, func(defaultName string) (string, error) {
 		return runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
 			DefaultFilename: defaultName,
 			Title:           "Save File As...",
@@ -392,14 +467,22 @@ func (a *App) DownloadFile(msgID int, TgMsgID int) DownloadResult {
 }
 
 func (a *App) DeleteFile(msgID int) string {
-	if err := a.fileService().Delete(a.ctx, a.ActiveChannelID(), msgID); err != nil {
+	svc, err := a.requireFileService()
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	if err := svc.Delete(a.ctx, a.ActiveChannelID(), msgID); err != nil {
 		return "Error: " + err.Error()
 	}
 	return "Success"
 }
 
 func (a *App) GetStorageUsed() (int64, error) {
-	return a.readService().StorageUsed(a.ActiveChannelID())
+	svc, err := a.requireReadService()
+	if err != nil {
+		return 0, err
+	}
+	return svc.StorageUsed(a.ActiveChannelID())
 }
 
 func (a *App) GetCodech() chan string {
@@ -436,7 +519,11 @@ func (a *App) SumbitPassword(password string) {
 
 func (a *App) CreateFolder(foldername string, parentID string) (backend.Folder, error) {
 	channelID := a.ActiveChannelID()
-	folder, err := a.folderService().Create(channelID, foldername, parentID)
+	svc, err := a.requireFolderService()
+	if err != nil {
+		return backend.Folder{}, err
+	}
+	folder, err := svc.Create(channelID, foldername, parentID)
 	if err != nil {
 		return backend.Folder{}, err
 	}
@@ -464,6 +551,8 @@ func (a *App) shutdown(ctx context.Context) {
 
 // enableFileDrop registers the native OS file-drop handler (idempotent).
 func (a *App) enableFileDrop() {
+	a.fileDropMu.Lock()
+	defer a.fileDropMu.Unlock()
 	if a.fileDropEnabled {
 		return
 	}
@@ -488,6 +577,8 @@ func (a *App) SetFileDropEnabled(enabled bool) {
 		a.enableFileDrop()
 		return
 	}
+	a.fileDropMu.Lock()
+	defer a.fileDropMu.Unlock()
 	if a.fileDropEnabled {
 		runtime.OnFileDropOff(a.ctx)
 		a.fileDropEnabled = false
@@ -539,17 +630,29 @@ func (a *App) startup(ctx context.Context) {
 // SyncChannel triggers an incremental sync for the given channel. Wails-bound
 // for the future "Refresh" UI button and for debug.
 func (a *App) SyncChannel(channelID int64) error {
-	return a.lifecycleService().SyncChannel(a.ctx, channelID)
+	svc, err := a.requireLifecycleService()
+	if err != nil {
+		return err
+	}
+	return svc.SyncChannel(a.ctx, channelID)
 }
 
 // RebuildProjection wipes and replays the local projection for a channel
 // from the channel's replay_log. Hidden Wails method for debug/recovery.
 func (a *App) RebuildProjection(channelID int64) error {
-	return a.lifecycleService().RebuildProjection(channelID)
+	svc, err := a.requireLifecycleService()
+	if err != nil {
+		return err
+	}
+	return svc.RebuildProjection(channelID)
 }
 
 func (a *App) GetFolderContents(parentID string) (backend.FileSystem, error) {
-	fs, err := a.readService().FolderContents(a.ActiveChannelID(), parentID)
+	svc, err := a.requireReadService()
+	if err != nil {
+		return backend.FileSystem{}, err
+	}
+	fs, err := svc.FolderContents(a.ActiveChannelID(), parentID)
 	if err != nil {
 		return backend.FileSystem{}, err
 	}
@@ -581,7 +684,11 @@ func (a *App) GetFolderContents(parentID string) (backend.FileSystem, error) {
 }
 
 func (a *App) Search(query string, limit int) ([]backend.SearchResult, error) {
-	hits, err := a.readService().Search(a.ActiveChannelID(), query, limit)
+	svc, err := a.requireReadService()
+	if err != nil {
+		return nil, err
+	}
+	hits, err := svc.Search(a.ActiveChannelID(), query, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -589,68 +696,106 @@ func (a *App) Search(query string, limit int) ([]backend.SearchResult, error) {
 	results := make([]backend.SearchResult, 0, len(hits))
 	for _, h := range hits {
 		results = append(results, backend.SearchResult{
-			Type:       h.Type,
-			ID:         h.ID,
-			Name:       h.Name,
-			ParentID:   h.ParentID,
-			Size:       h.Size,
-			UploadTime: h.UploadTime,
-			UploaderID: h.UploaderID,
-			Path:       h.Path,
+			Type:          h.Type,
+			ID:            h.ID,
+			Name:          h.Name,
+			ParentID:      h.ParentID,
+			Size:          h.Size,
+			UploadTime:    h.UploadTime,
+			UploaderID:    h.UploaderID,
+			Encrypted:     h.Encrypted,
+			PlaintextSize: h.PlaintextSize,
+			Path:          h.Path,
 		})
 	}
 	return results, nil
 }
 
 func (a *App) GetAllFsMsgIDs() ([]int, error) {
-	return a.readService().AllFileMsgIDs(a.ActiveChannelID())
+	svc, err := a.requireReadService()
+	if err != nil {
+		return nil, err
+	}
+	return svc.AllFileMsgIDs(a.ActiveChannelID())
 }
 
 func (a *App) GetFolderSize(folderID string) (int64, error) {
-	return a.readService().FolderSize(a.ActiveChannelID(), folderID)
+	svc, err := a.requireReadService()
+	if err != nil {
+		return 0, err
+	}
+	return svc.FolderSize(a.ActiveChannelID(), folderID)
 }
 
 func (a *App) GetFolderSizes(parentID string) (map[string]int64, error) {
-	return a.readService().ChildFolderSizes(a.ActiveChannelID(), parentID)
+	svc, err := a.requireReadService()
+	if err != nil {
+		return nil, err
+	}
+	return svc.ChildFolderSizes(a.ActiveChannelID(), parentID)
 }
 
 func (a *App) DeleteFolder(folderID string) string {
-	if err := a.folderService().Delete(a.ctx, a.ActiveChannelID(), folderID); err != nil {
+	svc, err := a.requireFolderService()
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	if err := svc.Delete(a.ctx, a.ActiveChannelID(), folderID); err != nil {
 		return "Error: " + err.Error()
 	}
 	return "Success"
 }
 
 func (a *App) MsgToTdriveSystem(msgID int, name string, size int64, parentID string) string {
-	if err := a.fileService().Meta(a.ActiveChannelID(), msgID, name, size, parentID); err != nil {
+	svc, err := a.requireFileService()
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	if err := svc.Meta(a.ActiveChannelID(), msgID, name, size, parentID); err != nil {
 		return "Error: " + err.Error()
 	}
 	return "Success"
 }
 
 func (a *App) RenameFile(msgID int, newName string) string {
-	if err := a.fileService().Rename(a.ctx, a.ActiveChannelID(), msgID, newName); err != nil {
+	svc, err := a.requireFileService()
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	if err := svc.Rename(a.ctx, a.ActiveChannelID(), msgID, newName); err != nil {
 		return "Error: " + err.Error()
 	}
 	return "Success"
 }
 
 func (a *App) RenameFolder(folderID string, newName string) string {
-	if err := a.folderService().Rename(a.ActiveChannelID(), folderID, newName); err != nil {
+	svc, err := a.requireFolderService()
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	if err := svc.Rename(a.ActiveChannelID(), folderID, newName); err != nil {
 		return "Error: " + err.Error()
 	}
 	return "Success"
 }
 
 func (a *App) MoveFile(msgID int, newParentID string) string {
-	if err := a.fileService().Move(a.ctx, a.ActiveChannelID(), msgID, newParentID); err != nil {
+	svc, err := a.requireFileService()
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	if err := svc.Move(a.ctx, a.ActiveChannelID(), msgID, newParentID); err != nil {
 		return "Error: " + err.Error()
 	}
 	return "Success"
 }
 
 func (a *App) MoveFolder(folderID string, newParentID string) string {
-	if err := a.folderService().Move(a.ActiveChannelID(), folderID, newParentID); err != nil {
+	svc, err := a.requireFolderService()
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	if err := svc.Move(a.ActiveChannelID(), folderID, newParentID); err != nil {
 		return "Error: " + err.Error()
 	}
 	return "Success"

--- a/app_channels.go
+++ b/app_channels.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"TDrive/backend/projection"
 	channelservice "TDrive/backend/services/channel"
 )
@@ -49,10 +51,21 @@ func (a *App) channelService() *channelservice.Service {
 	return a.engine.ChannelService()
 }
 
+func (a *App) requireChannelService() (*channelservice.Service, error) {
+	if svc := a.channelService(); svc != nil {
+		return svc, nil
+	}
+	return nil, fmt.Errorf("backend not ready")
+}
+
 // ListChannels returns every drive known to this client (personal first,
 // then shared in joined-at order). Used to render the sidebar.
 func (a *App) ListChannels() ([]ChannelInfo, error) {
-	rows, err := a.channelService().ListChannels()
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := svc.ListChannels()
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +82,11 @@ func (a *App) ListChannels() ([]ChannelInfo, error) {
 //
 // Returns the new ChannelInfo with the invite link populated.
 func (a *App) CreateSharedDrive(title string, requireApproval bool) (ChannelInfo, error) {
-	row, err := a.channelService().CreateSharedDrive(a.ctx, title, requireApproval)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return ChannelInfo{}, err
+	}
+	row, err := svc.CreateSharedDrive(a.ctx, title, requireApproval)
 	if err != nil {
 		return ChannelInfo{}, err
 	}
@@ -80,7 +97,11 @@ func (a *App) CreateSharedDrive(title string, requireApproval bool) (ChannelInfo
 // channel. Approval-required links send a Telegram join request and return a
 // durable pending record that can be checked later.
 func (a *App) JoinSharedDrive(inviteLink string) (JoinDriveResult, error) {
-	result, err := a.channelService().JoinSharedDrive(a.ctx, inviteLink)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return JoinDriveResult{}, err
+	}
+	result, err := svc.JoinSharedDrive(a.ctx, inviteLink)
 	if err != nil {
 		return JoinDriveResult{}, err
 	}
@@ -89,7 +110,11 @@ func (a *App) JoinSharedDrive(inviteLink string) (JoinDriveResult, error) {
 
 // ListPendingJoins returns approval-required joins this client is waiting on.
 func (a *App) ListPendingJoins() ([]PendingJoinInfo, error) {
-	rows, err := a.channelService().ListPendingJoins()
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := svc.ListPendingJoins()
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +129,11 @@ func (a *App) ListPendingJoins() ([]PendingJoinInfo, error) {
 // become a membership. Users call this manually from the sidebar; no realtime
 // Telegram update stream is required for v1.
 func (a *App) CheckPendingJoin(inviteHash string) (JoinDriveResult, error) {
-	result, err := a.channelService().CheckPendingJoin(a.ctx, inviteHash)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return JoinDriveResult{}, err
+	}
+	result, err := svc.CheckPendingJoin(a.ctx, inviteHash)
 	if err != nil {
 		return JoinDriveResult{}, err
 	}
@@ -114,7 +143,11 @@ func (a *App) CheckPendingJoin(inviteHash string) (JoinDriveResult, error) {
 // RemovePendingJoin forgets a local pending request. It does not revoke the
 // Telegram-side request; only a drive admin can reject it.
 func (a *App) RemovePendingJoin(inviteHash string) error {
-	return a.channelService().RemovePendingJoin(inviteHash)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return err
+	}
+	return svc.RemovePendingJoin(inviteHash)
 }
 
 // GetInviteLink fetches a fresh link from Telegram and caches it. Admin-
@@ -122,18 +155,30 @@ func (a *App) RemovePendingJoin(inviteHash string) error {
 // MessagesExportChatInvite. (Step 4 doesn't gate this client-side; we
 // surface whatever Telegram returns.)
 func (a *App) GetInviteLink(channelID int64) (string, error) {
-	return a.channelService().ExportInviteLink(a.ctx, channelID, false)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return "", err
+	}
+	return svc.ExportInviteLink(a.ctx, channelID, false)
 }
 
 // GetApprovalInviteLink fetches an invite link where Telegram requires an
 // admin to approve each requester before they become a member.
 func (a *App) GetApprovalInviteLink(channelID int64) (string, error) {
-	return a.channelService().ExportInviteLink(a.ctx, channelID, true)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return "", err
+	}
+	return svc.ExportInviteLink(a.ctx, channelID, true)
 }
 
 // ListJoinRequests lists Telegram users waiting for admin approval on a drive.
 func (a *App) ListJoinRequests(channelID int64) ([]JoinRequestInfo, error) {
-	reqs, err := a.channelService().ListJoinRequests(a.ctx, channelID)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return nil, err
+	}
+	reqs, err := svc.ListJoinRequests(a.ctx, channelID)
 	if err != nil {
 		return nil, err
 	}
@@ -152,18 +197,30 @@ func (a *App) ListJoinRequests(channelID int64) ([]JoinRequestInfo, error) {
 }
 
 func (a *App) ApproveJoinRequest(channelID, userID int64) error {
-	return a.channelService().HideJoinRequest(a.ctx, channelID, userID, true)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return err
+	}
+	return svc.HideJoinRequest(a.ctx, channelID, userID, true)
 }
 
 func (a *App) RejectJoinRequest(channelID, userID int64) error {
-	return a.channelService().HideJoinRequest(a.ctx, channelID, userID, false)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return err
+	}
+	return svc.HideJoinRequest(a.ctx, channelID, userID, false)
 }
 
 // LeaveSharedDrive leaves the Telegram channel and drops every local row
 // scoped to it. If the active drive was this one, switches active to the
 // personal drive.
 func (a *App) LeaveSharedDrive(channelID int64) error {
-	return a.channelService().LeaveSharedDrive(a.ctx, channelID)
+	svc, err := a.requireChannelService()
+	if err != nil {
+		return err
+	}
+	return svc.LeaveSharedDrive(a.ctx, channelID)
 }
 
 func channelInfo(c projection.Channel, active int64) ChannelInfo {

--- a/app_logout.go
+++ b/app_logout.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"TDrive/backend"
 	"TDrive/backend/auth"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -40,13 +39,6 @@ func (a *App) Logout(mode string) error {
 
 	if m == auth.LogoutFull {
 		a.revokeTelegramSession()
-	}
-
-	if backend.DB != nil {
-		if err := backend.DB.Close(); err != nil {
-			fmt.Printf("logout: close db: %v\n", err)
-		}
-		backend.DB = nil
 	}
 
 	// Drop the cached self user so a re-login (without re-launching, in

--- a/app_media.go
+++ b/app_media.go
@@ -32,7 +32,11 @@ func newThumbnailCache() *thumbnail.Cache {
 // ListMedia returns every image in the active drive, newest first, for the
 // gallery view. Non-image files are filtered out in the read service.
 func (a *App) ListMedia() ([]backend.FileMetaData, error) {
-	files, err := a.readService().MediaFiles(a.ActiveChannelID())
+	svc, err := a.requireReadService()
+	if err != nil {
+		return nil, err
+	}
+	files, err := svc.MediaFiles(a.ActiveChannelID())
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +60,11 @@ func (a *App) ListMedia() ([]backend.FileMetaData, error) {
 // frontend to turn into a data URL. Cheap on a cache hit; on a miss it pulls
 // and downscales the original once.
 func (a *App) Thumbnail(msgID int) (PreviewPayload, error) {
-	payload, err := a.fileService().Thumbnail(a.ctx, a.ActiveChannelID(), msgID)
+	svc, err := a.requireFileService()
+	if err != nil {
+		return PreviewPayload{}, err
+	}
+	payload, err := svc.Thumbnail(a.ctx, a.ActiveChannelID(), msgID)
 	if err != nil {
 		return PreviewPayload{}, err
 	}
@@ -75,21 +83,21 @@ func (a *App) OpenMedia(msgID int) (media.OpenResult, error) {
 
 func (a *App) CloseMedia(token string) error {
 	if a.engine == nil {
-		return fmt.Errorf("backend not ready")
+		return nil
 	}
 	return a.engine.MediaService().CloseSession(token)
 }
 
 func (a *App) UpdateMediaPlayback(update media.PlaybackUpdate) error {
 	if a.engine == nil {
-		return fmt.Errorf("backend not ready")
+		return nil
 	}
 	return a.engine.MediaService().UpdatePlayback(update)
 }
 
 func (a *App) GetMediaStats(token string) (media.MediaStats, error) {
 	if a.engine == nil {
-		return media.MediaStats{}, fmt.Errorf("backend not ready")
+		return media.MediaStats{}, nil
 	}
 	return a.engine.MediaService().Stats(token), nil
 }

--- a/app_self.go
+++ b/app_self.go
@@ -15,7 +15,11 @@ type SelfUser struct {
 // avatar photo. The result is cached by the user service for the lifetime
 // of the process; logout clears it.
 func (a *App) Me() (SelfUser, error) {
-	me, err := a.userService().Me(a.ctx)
+	svc, err := a.requireUserService()
+	if err != nil {
+		return SelfUser{}, err
+	}
+	me, err := svc.Me(a.ctx)
 	if err != nil {
 		return SelfUser{}, err
 	}

--- a/app_users.go
+++ b/app_users.go
@@ -3,5 +3,9 @@ package main
 // ResolveUsernames maps Telegram user IDs to display names. Used by the
 // frontend uploader-chip cache.
 func (a *App) ResolveUsernames(userIDs []int64) (map[string]string, error) {
-	return a.userService().ResolveUsernames(a.ctx, userIDs)
+	svc, err := a.requireUserService()
+	if err != nil {
+		return nil, err
+	}
+	return svc.ResolveUsernames(a.ctx, userIDs)
 }

--- a/backend/core/engine.go
+++ b/backend/core/engine.go
@@ -264,6 +264,62 @@ func (e *Engine) EmitAndProject(channelID int64, op projection.Op) (int64, error
 	return msgID, nil
 }
 
+type projectedOp struct {
+	msgID  int64
+	op     projection.Op
+	header string
+}
+
+// EmitAndProjectBatch sends a sequence of control ops, then commits their
+// local projection in one transaction. The network side cannot be atomic, but
+// the UI-facing cache must be: if a later send fails, the already-sent ops will
+// converge through the next sync instead of locally half-applying a subtree.
+func (e *Engine) EmitAndProjectBatch(channelID int64, ops []projection.Op) error {
+	if len(ops) == 0 {
+		return nil
+	}
+	if e == nil || e.tg == nil {
+		return fmt.Errorf("tg client not ready")
+	}
+	actorID, err := e.ActorID(e.ctx)
+	if err != nil {
+		return err
+	}
+	peer, err := e.ChannelPeer(e.ctx, channelID)
+	if err != nil {
+		return err
+	}
+
+	sent := make([]projectedOp, 0, len(ops))
+	for _, op := range ops {
+		header := projection.Format(op)
+		msgID, err := e.tg.SendControl(e.ctx, peer, header, true)
+		if err != nil {
+			return err
+		}
+		sent = append(sent, projectedOp{msgID: msgID, op: op, header: header})
+	}
+
+	tx, err := backend.DB.Begin()
+	if err != nil {
+		return fmt.Errorf("projection: begin batch tx: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, item := range sent {
+		if _, err = projection.ProjectFromOpTx(tx, channelID, item.msgID, item.op, actorID, item.header); err != nil {
+			return fmt.Errorf("projection: project batch msg=%d op=%s: %w", item.msgID, item.op.Type, err)
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("projection: commit batch tx: %w", err)
+	}
+	return nil
+}
+
 func (e *Engine) AuthService() *authsvc.Service {
 	if e.auth == nil {
 		e.auth = authsvc.NewService(e.events)
@@ -361,6 +417,9 @@ func (e *Engine) newFolderService() *folderservice.Service {
 		EmitOp: func(channelID int64, op projection.Op) error {
 			_, err := e.EmitAndProject(channelID, op)
 			return err
+		},
+		EmitOps: func(channelID int64, ops []projection.Op) error {
+			return e.EmitAndProjectBatch(channelID, ops)
 		},
 		ActorID: func(ctx context.Context) (int64, error) {
 			return e.ActorID(ctx)

--- a/backend/core/paths.go
+++ b/backend/core/paths.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -8,6 +9,8 @@ import (
 	"TDrive/backend"
 	"TDrive/backend/projection"
 )
+
+var ErrPathNotFound = errors.New("path not found")
 
 type ResolvedFolder struct {
 	ID   string `json:"id"`
@@ -149,7 +152,7 @@ func (e *Engine) ResolveFolderPath(channelID int64, cwd string, input string) (R
 			}
 		}
 		if next == "" {
-			return ResolvedFolder{}, fmt.Errorf("folder not found: %s", abs)
+			return ResolvedFolder{}, fmt.Errorf("%w: folder %s", ErrPathNotFound, abs)
 		}
 		cur = next
 	}
@@ -243,7 +246,7 @@ func (e *Engine) ResolveEntryPath(channelID int64, cwd string, input string) (Re
 	case len(files) > 1:
 		return ResolvedEntry{}, fmt.Errorf("file path is ambiguous: %s", abs)
 	default:
-		return ResolvedEntry{}, fmt.Errorf("path not found: %s", abs)
+		return ResolvedEntry{}, fmt.Errorf("%w: %s", ErrPathNotFound, abs)
 	}
 }
 

--- a/backend/crypto/stream.go
+++ b/backend/crypto/stream.go
@@ -35,6 +35,7 @@ const (
 	streamPrefixLen   = 20
 	streamTagLen      = chacha20poly1305.Overhead // 16, AEAD tag per chunk
 	finalChunkBit     = uint32(1) << 31
+	maxPlaintextSize  = int64(finalChunkBit) * int64(chunkSizePlain)
 	hkdfInfo          = "tdrive/file/v1"
 )
 
@@ -54,6 +55,9 @@ var (
 func EncryptStream(src io.Reader, dst io.Writer, masterKey []byte, plaintextSize int64) error {
 	if plaintextSize < 0 {
 		return fmt.Errorf("crypto: negative plaintext size")
+	}
+	if plaintextSize > maxPlaintextSize {
+		return fmt.Errorf("crypto: plaintext size exceeds stream counter capacity")
 	}
 	salt := make([]byte, streamFileSaltLen)
 	if _, err := rand.Read(salt); err != nil {

--- a/backend/crypto/stream_test.go
+++ b/backend/crypto/stream_test.go
@@ -122,6 +122,15 @@ func TestStreamLargeFile(t *testing.T) {
 	}
 }
 
+func TestEncryptStreamRejectsCounterOverflow(t *testing.T) {
+	master, _ := NewMasterKey()
+	var enc bytes.Buffer
+	err := EncryptStream(bytes.NewReader(nil), &enc, master, maxPlaintextSize+1)
+	if err == nil {
+		t.Fatal("EncryptStream accepted plaintext beyond the stream counter capacity")
+	}
+}
+
 type zeroReader struct{}
 
 func (zeroReader) Read(p []byte) (int, error) {

--- a/backend/daemon/auth_drive.go
+++ b/backend/daemon/auth_drive.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"TDrive/backend"
 	coreauth "TDrive/backend/auth"
 	"TDrive/backend/projection"
 	channelservice "TDrive/backend/services/channel"
@@ -94,12 +93,6 @@ func (s *Server) authLogout(ctx context.Context, mode string) (AuthLogoutRespons
 	}
 	if s.engine != nil {
 		s.engine.Close()
-	}
-	if backend.DB != nil {
-		if err := backend.DB.Close(); err != nil {
-			s.warnf("logout: close db: %v\n", err)
-		}
-		backend.DB = nil
 	}
 	if err := coreauth.ClearUserData(m); err != nil {
 		return AuthLogoutResponse{}, err

--- a/backend/daemon/server.go
+++ b/backend/daemon/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path"
@@ -13,9 +14,17 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"TDrive/backend/core"
 	"TDrive/backend/processlock"
+)
+
+const (
+	daemonMaxFrameBytes = 1 << 20 // 1 MiB is far above the CLI protocol needs.
+	daemonReadTimeout   = 5 * time.Minute
+	daemonWriteTimeout  = 30 * time.Second
+	daemonDrainTimeout  = 10 * time.Second
 )
 
 type ServerConfig struct {
@@ -42,6 +51,7 @@ type Server struct {
 	streamMu sync.Mutex
 	stopOnce sync.Once
 	stop     context.CancelFunc
+	wg       sync.WaitGroup
 }
 
 func Run(ctx context.Context, cfg ServerConfig) error {
@@ -83,6 +93,7 @@ func Run(ctx context.Context, cfg ServerConfig) error {
 	}
 	s.engine = engine
 	defer s.engine.Close()
+	defer s.wg.Wait()
 
 	if err := s.loadState(); err != nil {
 		s.warnf("daemon: load cli state: %v\n", err)
@@ -114,7 +125,11 @@ func Run(ctx context.Context, cfg ServerConfig) error {
 			s.warnf("daemon: accept: %v\n", err)
 			continue
 		}
-		go s.handleConn(runCtx, conn)
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.handleConn(runCtx, conn)
+		}()
 	}
 }
 
@@ -122,18 +137,19 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 	defer func() { _ = conn.Close() }()
 
 	reader := bufio.NewReader(conn)
-	dec := json.NewDecoder(reader)
 	enc := json.NewEncoder(conn)
 	var encMu sync.Mutex
 	writeFrame := func(frame Frame) error {
 		encMu.Lock()
 		defer encMu.Unlock()
+		_ = conn.SetWriteDeadline(time.Now().Add(daemonWriteTimeout))
+		defer func() { _ = conn.SetWriteDeadline(time.Time{}) }()
 		return enc.Encode(frame)
 	}
 
 	for {
 		var req Request
-		if err := dec.Decode(&req); err != nil {
+		if err := readRequestFrame(conn, reader, &req); err != nil {
 			return
 		}
 		if isStreamingCommand(req.Command) {
@@ -141,6 +157,7 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 			// Streaming requests do not read from the socket again while work is
 			// in flight. Watch for EOF so an abandoned prompt cancels the backend
 			// operation and releases streamMu.
+			_ = conn.SetReadDeadline(time.Time{})
 			go cancelOnConnectionClose(reader, cancelReq)
 			if err := s.handleStreamingRequest(reqCtx, req, writeFrame); err != nil {
 				cancelReq()
@@ -159,6 +176,43 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 func cancelOnConnectionClose(reader *bufio.Reader, cancel context.CancelFunc) {
 	_, _ = reader.Peek(1)
 	cancel()
+}
+
+func readRequestFrame(conn net.Conn, reader *bufio.Reader, req *Request) error {
+	_ = conn.SetReadDeadline(time.Now().Add(daemonReadTimeout))
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
+	line, err := readLimitedLine(reader, daemonMaxFrameBytes)
+	if err != nil {
+		return err
+	}
+	if len(strings.TrimSpace(string(line))) == 0 {
+		return io.EOF
+	}
+	if err := json.Unmarshal(line, req); err != nil {
+		return err
+	}
+	if len(req.Payload) > daemonMaxFrameBytes {
+		return fmt.Errorf("daemon: payload too large")
+	}
+	return nil
+}
+
+func readLimitedLine(reader *bufio.Reader, limit int) ([]byte, error) {
+	var out []byte
+	for {
+		part, isPrefix, err := reader.ReadLine()
+		if err != nil {
+			return nil, err
+		}
+		if len(out)+len(part) > limit {
+			return nil, fmt.Errorf("daemon: request too large")
+		}
+		out = append(out, part...)
+		if !isPrefix {
+			return out, nil
+		}
+	}
 }
 
 func (s *Server) handleStreamingRequest(ctx context.Context, req Request, writeFrame func(Frame) error) error {
@@ -190,7 +244,12 @@ func (s *Server) handleStreamingRequest(ctx context.Context, req Request, writeF
 		case frame := <-done:
 			return writeFrame(frame)
 		case <-ctx.Done():
-			return ctx.Err()
+			select {
+			case frame := <-done:
+				return writeFrame(frame)
+			case <-time.After(daemonDrainTimeout):
+				return ctx.Err()
+			}
 		}
 	}
 }
@@ -1255,7 +1314,7 @@ func (s *Server) moveTarget(channelID int64, dstAbs string, sourceName string) (
 		}
 		return dst.ID, dst.Path, sourceName, nil
 	}
-	if !strings.Contains(err.Error(), "not found") {
+	if !errors.Is(err, core.ErrPathNotFound) {
 		return "", "", "", err
 	}
 
@@ -1289,7 +1348,7 @@ func (s *Server) importTarget(channelID int64, remotePath string) (folderID stri
 		}
 		return dst.ID, dst.Path, nil
 	}
-	if !strings.Contains(err.Error(), "not found") {
+	if !errors.Is(err, core.ErrPathNotFound) {
 		return "", "", err
 	}
 	return "", "", fmt.Errorf("destination folder not found: %s", dstAbs)
@@ -1317,7 +1376,7 @@ func (s *Server) uploadTarget(channelID int64, remotePath string, defaultName st
 		}
 		return dst.ID, dst.Path, defaultName, nil
 	}
-	if !strings.Contains(err.Error(), "not found") {
+	if !errors.Is(err, core.ErrPathNotFound) {
 		return "", "", "", err
 	}
 	if mustBeFolder {

--- a/backend/fstructs.go
+++ b/backend/fstructs.go
@@ -23,12 +23,14 @@ type FileSystem struct {
 }
 
 type SearchResult struct {
-	Type       string `json:"type"`
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	ParentID   string `json:"parent_id"`
-	Size       int64  `json:"size"`
-	UploadTime int64  `json:"upload_time"`
-	UploaderID int64  `json:"uploader_id"`
-	Path       string `json:"path"`
+	Type          string `json:"type"`
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	ParentID      string `json:"parent_id"`
+	Size          int64  `json:"size"`
+	UploadTime    int64  `json:"upload_time"`
+	UploaderID    int64  `json:"uploader_id"`
+	Encrypted     bool   `json:"encrypted,omitempty"`
+	PlaintextSize int64  `json:"plaintext_size,omitempty"`
+	Path          string `json:"path"`
 }

--- a/backend/media/server.go
+++ b/backend/media/server.go
@@ -19,6 +19,8 @@ const (
 	mediaRoutePrefix       = "/media/file/"
 	mediaThumbRoutePrefix  = "/media/thumb/"
 	mediaThumbSourcePrefix = "/media/thumb-source/"
+	mediaSessionIdleTTL    = 2 * time.Hour
+	mediaSessionSweepEvery = 5 * time.Minute
 )
 
 type PlaybackUpdate struct {
@@ -38,6 +40,7 @@ type Server struct {
 	listener net.Listener
 	server   *http.Server
 	baseURL  string
+	closed   bool
 	sessions map[string]*Session
 }
 
@@ -57,6 +60,10 @@ func (s *Server) Add(session *Session) error {
 	}
 
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrSessionNotFound
+	}
 	s.sessions[session.Token()] = session
 	url := s.baseURL + mediaRoutePrefix + session.Token()
 	thumbSourceURL := s.baseURL + mediaThumbSourcePrefix + session.Token()
@@ -86,6 +93,7 @@ func (s *Server) UpdatePlayback(update PlaybackUpdate) error {
 	if session == nil {
 		return ErrSessionNotFound
 	}
+	session.touch()
 	session.UpdatePlayback(update.CurrentTime, update.Duration, update.BufferAhead)
 	return nil
 }
@@ -95,6 +103,7 @@ func (s *Server) Stats(token string) MediaStats {
 	if session == nil {
 		return MediaStats{}
 	}
+	session.touch()
 	stats := session.Stats()
 	session.logStats(stats)
 	return stats
@@ -107,6 +116,7 @@ func (s *Server) Close() error {
 	s.server = nil
 	s.listener = nil
 	s.baseURL = ""
+	s.closed = true
 	sessions := s.sessions
 	s.sessions = make(map[string]*Session)
 	s.mu.Unlock()
@@ -125,6 +135,10 @@ func (s *Server) Close() error {
 
 func (s *Server) ensureStarted() error {
 	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrSessionNotFound
+	}
 	if s.server != nil {
 		s.mu.Unlock()
 		return nil
@@ -152,7 +166,34 @@ func (s *Server) ensureStarted() error {
 			// There is intentionally no logging dependency in backend/media.
 		}
 	}()
+	go s.sweepIdleSessions(srv)
 	return nil
+}
+
+func (s *Server) sweepIdleSessions(server *http.Server) {
+	ticker := time.NewTicker(mediaSessionSweepEvery)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.mu.Lock()
+		if s.server != server || s.closed {
+			s.mu.Unlock()
+			return
+		}
+		now := time.Now()
+		expired := make([]*Session, 0)
+		for token, session := range s.sessions {
+			if session == nil || now.Sub(session.LastTouch()) < mediaSessionIdleTTL {
+				continue
+			}
+			delete(s.sessions, token)
+			expired = append(expired, session)
+		}
+		s.mu.Unlock()
+
+		for _, session := range expired {
+			session.Close()
+		}
+	}
 }
 
 func (s *Server) handleFile(w http.ResponseWriter, r *http.Request) {

--- a/backend/media/session.go
+++ b/backend/media/session.go
@@ -135,6 +135,15 @@ func (s *Session) touch() {
 	s.mu.Unlock()
 }
 
+func (s *Session) LastTouch() time.Time {
+	if s == nil {
+		return time.Time{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastTouch
+}
+
 func (s *Session) Close() {
 	if s == nil {
 		return
@@ -175,6 +184,7 @@ func (s *Session) Thumbnail(ctx context.Context, seconds float64) ([]byte, error
 	if closed {
 		return nil, ErrSessionNotFound
 	}
+	s.touch()
 	return s.thumbs.Get(ctx, seconds)
 }
 

--- a/backend/media/video_thumbnails.go
+++ b/backend/media/video_thumbnails.go
@@ -91,6 +91,7 @@ type videoThumbnailer struct {
 	wake           chan struct{}
 	precomputeWake chan struct{}
 	wg             sync.WaitGroup
+	extractMu      sync.Mutex
 
 	mu                  sync.Mutex
 	ready               map[int]string
@@ -246,10 +247,9 @@ func (t *videoThumbnailer) Close() {
 	dir := t.dir
 	t.dir = ""
 	t.mu.Unlock()
-	if t.persistent != nil {
-		t.persistent.Close()
-		t.persistent = nil
-	}
+	t.extractMu.Lock()
+	t.resetPersistent()
+	t.extractMu.Unlock()
 	if dir != "" {
 		_ = os.RemoveAll(dir)
 	}
@@ -539,8 +539,7 @@ func (t *videoThumbnailer) precomputeCandidateReady(bucket int, now time.Time) b
 		return false
 	}
 	t.mu.Unlock()
-	_, cached := t.cache.Get(t.cacheKey(bucket))
-	return !cached
+	return !t.cache.Has(t.cacheKey(bucket))
 }
 
 func (t *videoThumbnailer) precomputeStillIdle() bool {
@@ -586,6 +585,10 @@ func (t *videoThumbnailer) generate(bucket int, background bool) {
 		t.mu.Unlock()
 		return
 	}
+	if _, ok := t.inflight[bucket]; ok {
+		t.mu.Unlock()
+		return
+	}
 	t.inflight[bucket] = struct{}{}
 	t.mu.Unlock()
 
@@ -611,6 +614,10 @@ func (t *videoThumbnailer) generate(bucket int, background bool) {
 		t.markFailed(bucket, fmt.Errorf("missing source URL"), background)
 		return
 	}
+
+	t.extractMu.Lock()
+	defer t.extractMu.Unlock()
+
 	if background && t.precomputeShouldYield() {
 		t.logf("precompute preempted bucket=%d before mpv", bucket)
 		return

--- a/backend/media/video_thumbnails_test.go
+++ b/backend/media/video_thumbnails_test.go
@@ -141,6 +141,55 @@ func TestVideoThumbnailerBackgroundPrecomputeYieldsToForeground(t *testing.T) {
 	}
 }
 
+func TestVideoThumbnailerSerializesPersistentForegroundAndPrecompute(t *testing.T) {
+	persistent := &blockingVideoThumbSession{
+		entered: make(chan int, 2),
+		release: make(chan struct{}),
+	}
+	gen := &blockingStatefulVideoThumbGenerator{session: persistent}
+	session := testVideoThumbSession()
+	session.setThumbnailURLs("http://127.0.0.1/thumb-source", "http://127.0.0.1/thumb")
+
+	thumbs := newVideoThumbnailer(session, thumbnail.NewCache(t.TempDir(), 1<<20), gen)
+	defer thumbs.Close()
+
+	backgroundDone := make(chan struct{})
+	go func() {
+		defer close(backgroundDone)
+		thumbs.generate(10, true)
+	}()
+	if got := waitForGeneratorEntry(t, persistent.entered); got != 10 {
+		t.Fatalf("background bucket = %d, want 10", got)
+	}
+
+	foregroundDone := make(chan struct{})
+	go func() {
+		defer close(foregroundDone)
+		thumbs.generate(20, false)
+	}()
+
+	select {
+	case got := <-persistent.entered:
+		t.Fatalf("foreground entered persistent extractor before background released; got bucket %d", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(persistent.release)
+	select {
+	case <-backgroundDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background generation did not finish")
+	}
+	if got := waitForGeneratorEntry(t, persistent.entered); got != 20 {
+		t.Fatalf("foreground bucket = %d, want 20", got)
+	}
+	select {
+	case <-foregroundDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("foreground generation did not finish")
+	}
+}
+
 func TestVideoThumbnailerBufferBandGating(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
 	cases := []struct {
@@ -436,3 +485,40 @@ func (s *fakeVideoThumbSession) GenerateVideoThumbnail(_ context.Context, outPat
 }
 
 func (s *fakeVideoThumbSession) Close() {}
+
+type blockingStatefulVideoThumbGenerator struct {
+	session *blockingVideoThumbSession
+}
+
+func (g *blockingStatefulVideoThumbGenerator) Available() bool { return true }
+
+func (g *blockingStatefulVideoThumbGenerator) GenerateVideoThumbnail(_ context.Context, _ string, _ string, _ int) error {
+	return errors.New("cold extractor should not be used")
+}
+
+func (g *blockingStatefulVideoThumbGenerator) NewVideoThumbnailSession(_ string) (VideoThumbnailSession, error) {
+	return g.session, nil
+}
+
+type blockingVideoThumbSession struct {
+	entered chan int
+	release chan struct{}
+}
+
+func (s *blockingVideoThumbSession) GenerateVideoThumbnail(ctx context.Context, outPath string, seconds int) error {
+	select {
+	case s.entered <- seconds:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if seconds == 10 {
+		select {
+		case <-s.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return os.WriteFile(outPath, []byte{byte(seconds)}, videoThumbFileMode)
+}
+
+func (s *blockingVideoThumbSession) Close() {}

--- a/backend/nativeplayer/native_enabled_linux.go
+++ b/backend/nativeplayer/native_enabled_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package nativeplayer
+
+import "os"
+
+const linuxNativePlayerFlag = "TDRIVE_EXPERIMENTAL_LINUX_NATIVE_PLAYER"
+
+func linuxNativePlayerEnabled() bool {
+	return os.Getenv(linuxNativePlayerFlag) == "1"
+}

--- a/backend/nativeplayer/player_darwin.go
+++ b/backend/nativeplayer/player_darwin.go
@@ -73,14 +73,16 @@ static int64_t tdrive_mpv_get_int64(mpv_handle *mpv, const char *name) {
 }
 - (BOOL)startWithURL:(NSString *)url htmlControls:(BOOL)htmlControls;
 - (void)shutdown;
+- (void)shutdownSynchronously;
 - (int)sendCommand:(int)argc argv:(const char **)argv;
 - (BOOL)snapshot:(tdrive_player_state *)state;
 @end
 
 static void tdrive_mpv_render_update(void *ctx) {
-    TDriveMPVView *view = (TDriveMPVView *)ctx;
+    TDriveMPVView *view = [(TDriveMPVView *)ctx retain];
     dispatch_async(dispatch_get_main_queue(), ^{
         [view setNeedsDisplay:YES];
+        [view release];
     });
 }
 
@@ -212,7 +214,7 @@ static void tdrive_mpv_render_update(void *ctx) {
     return YES;
 }
 
-- (void)shutdown {
+- (void)shutdownWithAsyncTerminate:(BOOL)asyncTerminate {
     if (_closed) {
         return;
     }
@@ -227,14 +229,30 @@ static void tdrive_mpv_render_update(void *ctx) {
         [NSOpenGLContext clearCurrentContext];
     }
     if (mpv != NULL) {
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        if (asyncTerminate) {
+            TDriveMPVView *view = [self retain];
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                mpv_terminate_destroy(mpv);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [view release];
+                });
+            });
+        } else {
             mpv_terminate_destroy(mpv);
-        });
+        }
     }
 }
 
+- (void)shutdown {
+    [self shutdownWithAsyncTerminate:YES];
+}
+
+- (void)shutdownSynchronously {
+    [self shutdownWithAsyncTerminate:NO];
+}
+
 - (void)dealloc {
-    [self shutdown];
+    [self shutdownSynchronously];
     [super dealloc];
 }
 
@@ -276,7 +294,11 @@ static void* tdrive_player_create_view(const char *rawURL, double x, double y, d
         }
         NSRect frame = tdrive_player_frame(content, x, y, w, h);
         view = [[TDriveMPVView alloc] initWithFrame:frame];
-        if (view == nil || ![view startWithURL:url htmlControls:(htmlControls != 0)]) {
+        if (view == nil) {
+            return;
+        }
+        if (![view startWithURL:url htmlControls:(htmlControls != 0)]) {
+            [view shutdownSynchronously];
             [view release];
             view = nil;
             return;

--- a/backend/nativeplayer/player_linux.go
+++ b/backend/nativeplayer/player_linux.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && cgo
 
 package nativeplayer
 
@@ -292,13 +292,12 @@ import (
 	"unsafe"
 )
 
-const linuxNativePlayerFlag = "TDRIVE_EXPERIMENTAL_LINUX_NATIVE_PLAYER"
-
 type Player struct {
 	mu      sync.Mutex
 	closed  bool
 	view    unsafe.Pointer
 	ipcPath string
+	ipcDir  string
 	cmd     *exec.Cmd
 	done    chan error
 
@@ -340,7 +339,13 @@ func (p *Player) startProcess(ctx context.Context, url string, windowID uintptr)
 		return err
 	}
 
-	p.ipcPath = filepath.Join(os.TempDir(), fmt.Sprintf("tdrive-mpv-%d-%d.sock", os.Getpid(), time.Now().UnixNano()))
+	ipcDir, err := os.MkdirTemp("", "tdrive-mpv-*")
+	if err != nil {
+		return fmt.Errorf("native player: create IPC dir: %w", err)
+	}
+	_ = os.Chmod(ipcDir, 0o700)
+	p.ipcDir = ipcDir
+	p.ipcPath = filepath.Join(ipcDir, fmt.Sprintf("mpv-%d.sock", os.Getpid()))
 	_ = os.Remove(p.ipcPath)
 	args := []string{
 		"--no-config",
@@ -348,6 +353,10 @@ func (p *Player) startProcess(ctx context.Context, url string, windowID uintptr)
 		"--msg-level=all=warn",
 		"--ytdl=no",
 		"--hwdec=auto-safe",
+		"--cache=yes",
+		"--demuxer-readahead-secs=20",
+		"--demuxer-max-bytes=67108864",
+		"--demuxer-max-back-bytes=33554432",
 		"--osc=yes",
 		"--osd-bar=yes",
 		"--force-window=immediate",
@@ -361,7 +370,7 @@ func (p *Player) startProcess(ctx context.Context, url string, windowID uintptr)
 	cmd := exec.CommandContext(ctx, mpvPath, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := cmd.Start(); err != nil {
-		_ = os.Remove(p.ipcPath)
+		_ = os.RemoveAll(p.ipcDir)
 		return fmt.Errorf("native player: start mpv: %w", err)
 	}
 	p.cmd = cmd
@@ -369,7 +378,7 @@ func (p *Player) startProcess(ctx context.Context, url string, windowID uintptr)
 		err := cmd.Wait()
 		p.done <- err
 		p.destroyView()
-		_ = os.Remove(p.ipcPath)
+		_ = os.RemoveAll(p.ipcDir)
 	}()
 	return nil
 }
@@ -429,6 +438,7 @@ func (p *Player) Close() error {
 	}
 	p.closed = true
 	ipcPath := p.ipcPath
+	ipcDir := p.ipcDir
 	cmd := p.cmd
 	done := p.done
 	p.mu.Unlock()
@@ -449,7 +459,7 @@ func (p *Player) Close() error {
 		}
 	}
 	p.destroyView()
-	_ = os.Remove(ipcPath)
+	_ = os.RemoveAll(ipcDir)
 	return nil
 }
 
@@ -484,8 +494,4 @@ func writeMPVIPC(path string, payload []byte) error {
 		time.Sleep(25 * time.Millisecond)
 	}
 	return fmt.Errorf("native player: mpv IPC unavailable: %w", lastErr)
-}
-
-func linuxNativePlayerEnabled() bool {
-	return os.Getenv(linuxNativePlayerFlag) == "1"
 }

--- a/backend/nativeplayer/player_linux_nocgo.go
+++ b/backend/nativeplayer/player_linux_nocgo.go
@@ -1,0 +1,23 @@
+//go:build linux && !cgo
+
+package nativeplayer
+
+import "context"
+
+type Player struct{}
+
+func Start(ctx context.Context, url string, rect Rect, opts Options) (*Player, error) {
+	return nil, ErrUnsupported
+}
+
+func (p *Player) Resize(rect Rect) error {
+	return nil
+}
+
+func (p *Player) Command(command ...string) error {
+	return nil
+}
+
+func (p *Player) Close() error {
+	return nil
+}

--- a/backend/nativeplayer/player_windows.go
+++ b/backend/nativeplayer/player_windows.go
@@ -4,16 +4,19 @@ package nativeplayer
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -26,9 +29,6 @@ const (
 
 	jobObjectInfoClassExtendedLimitInformation = 9
 	jobObjectLimitKillOnJobClose               = 0x00002000
-
-	processTerminate = 0x0001
-	processSetQuota  = 0x0100
 )
 
 const windowsNativePlayerFlag = "TDRIVE_EXPERIMENTAL_WINDOWS_NATIVE_PLAYER"
@@ -65,7 +65,7 @@ type Player struct {
 	parent  uintptr
 	child   uintptr
 	ipcPath string
-	cmd     *exec.Cmd
+	proc    *windowsMPVProcess
 	done    chan error
 	job     syscall.Handle
 
@@ -109,13 +109,22 @@ func (p *Player) startProcess(ctx context.Context, url string) error {
 	}
 	p.job = job
 
-	p.ipcPath = fmt.Sprintf(`\\.\pipe\tdrive-mpv-%d-%d`, os.Getpid(), time.Now().UnixNano())
+	suffix, err := randomPipeSuffix()
+	if err != nil {
+		p.closeJob()
+		return err
+	}
+	p.ipcPath = fmt.Sprintf(`\\.\pipe\tdrive-mpv-%d-%s`, os.Getpid(), suffix)
 	args := []string{
 		"--no-config",
 		"--terminal=no",
 		"--msg-level=all=warn",
 		"--ytdl=no",
 		"--hwdec=auto-safe",
+		"--cache=yes",
+		"--demuxer-readahead-secs=20",
+		"--demuxer-max-bytes=67108864",
+		"--demuxer-max-back-bytes=33554432",
 		"--osc=yes",
 		"--osd-bar=yes",
 		"--force-window=immediate",
@@ -126,26 +135,39 @@ func (p *Player) startProcess(ctx context.Context, url string) error {
 		url,
 	}
 
-	cmd := exec.CommandContext(ctx, mpvPath, args...)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	if err := cmd.Start(); err != nil {
-		p.closeJob()
-		return fmt.Errorf("native player: start mpv: %w", err)
-	}
-	if err := assignProcessToJob(job, cmd.Process.Pid); err != nil {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
+	proc, err := startSuspendedMPV(ctx, mpvPath, args)
+	if err != nil {
 		p.closeJob()
 		return err
 	}
-	p.cmd = cmd
+	if err := assignProcessToJob(job, proc.process); err != nil {
+		proc.kill()
+		_ = proc.wait()
+		p.closeJob()
+		return err
+	}
+	if err := proc.resume(); err != nil {
+		proc.kill()
+		_ = proc.wait()
+		p.closeJob()
+		return err
+	}
+	p.proc = proc
 	go func() {
-		err := cmd.Wait()
+		err := proc.wait()
 		p.done <- err
 		p.destroyChild()
 		p.closeJob()
 	}()
 	return nil
+}
+
+func randomPipeSuffix() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("native player: generate IPC name: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
 }
 
 func (p *Player) Resize(rect Rect) error {
@@ -207,18 +229,18 @@ func (p *Player) Close() error {
 	}
 	p.closed = true
 	ipcPath := p.ipcPath
-	cmd := p.cmd
+	proc := p.proc
 	done := p.done
 	p.mu.Unlock()
 
 	if ipcPath != "" {
 		_ = writeMPVIPC(ipcPath, []byte(`{"command":["quit"]}`+"\n"))
 	}
-	if cmd != nil && cmd.Process != nil {
+	if proc != nil {
 		select {
 		case <-done:
 		case <-time.After(750 * time.Millisecond):
-			_ = cmd.Process.Kill()
+			proc.kill()
 			select {
 			case <-done:
 			case <-time.After(2 * time.Second):
@@ -395,18 +417,112 @@ func createKillOnCloseJob() (syscall.Handle, error) {
 	return syscall.Handle(handle), nil
 }
 
-func assignProcessToJob(job syscall.Handle, pid int) error {
-	process, err := syscall.OpenProcess(processSetQuota|processTerminate, false, uint32(pid))
-	if err != nil {
-		return fmt.Errorf("native player: open mpv process for job assignment: %w", err)
-	}
-	defer syscall.CloseHandle(process)
-
+func assignProcessToJob(job syscall.Handle, process windows.Handle) error {
 	ret, _, callErr := procAssignProcessToJobObject.Call(uintptr(job), uintptr(process))
 	if ret == 0 {
 		return callFailed("AssignProcessToJobObject", callErr)
 	}
 	return nil
+}
+
+type windowsMPVProcess struct {
+	process windows.Handle
+	thread  windows.Handle
+	once    sync.Once
+}
+
+func startSuspendedMPV(ctx context.Context, mpvPath string, args []string) (*windowsMPVProcess, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	appName, err := windows.UTF16PtrFromString(mpvPath)
+	if err != nil {
+		return nil, fmt.Errorf("native player: encode mpv path: %w", err)
+	}
+	commandLine := windows.ComposeCommandLine(append([]string{mpvPath}, args...))
+	commandLinePtr, err := windows.UTF16PtrFromString(commandLine)
+	if err != nil {
+		return nil, fmt.Errorf("native player: encode mpv command line: %w", err)
+	}
+
+	var startup windows.StartupInfo
+	startup.Cb = uint32(unsafe.Sizeof(startup))
+	startup.Flags = windows.STARTF_USESHOWWINDOW
+	startup.ShowWindow = windows.SW_HIDE
+
+	var info windows.ProcessInformation
+	flags := uint32(windows.CREATE_SUSPENDED | windows.CREATE_NO_WINDOW | windows.CREATE_UNICODE_ENVIRONMENT)
+	if err := windows.CreateProcess(
+		appName,
+		commandLinePtr,
+		nil,
+		nil,
+		false,
+		flags,
+		nil,
+		nil,
+		&startup,
+		&info,
+	); err != nil {
+		return nil, fmt.Errorf("native player: start mpv suspended: %w", err)
+	}
+	return &windowsMPVProcess{process: info.Process, thread: info.Thread}, nil
+}
+
+func (p *windowsMPVProcess) resume() error {
+	if p == nil || p.thread == 0 {
+		return nil
+	}
+	if _, err := windows.ResumeThread(p.thread); err != nil {
+		return fmt.Errorf("native player: resume mpv: %w", err)
+	}
+	return nil
+}
+
+func (p *windowsMPVProcess) kill() {
+	if p == nil || p.process == 0 {
+		return
+	}
+	_ = windows.TerminateProcess(p.process, 1)
+}
+
+func (p *windowsMPVProcess) wait() error {
+	if p == nil || p.process == 0 {
+		return nil
+	}
+	_, waitErr := windows.WaitForSingleObject(p.process, windows.INFINITE)
+	var exitCode uint32
+	exitErr := windows.GetExitCodeProcess(p.process, &exitCode)
+	p.close()
+	if waitErr != nil {
+		return fmt.Errorf("native player: wait for mpv: %w", waitErr)
+	}
+	if exitErr != nil {
+		return fmt.Errorf("native player: read mpv exit code: %w", exitErr)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("native player: mpv exited with status %d", exitCode)
+	}
+	return nil
+}
+
+func (p *windowsMPVProcess) close() {
+	if p == nil {
+		return
+	}
+	p.once.Do(func() {
+		if p.thread != 0 {
+			_ = windows.CloseHandle(p.thread)
+			p.thread = 0
+		}
+		if p.process != 0 {
+			_ = windows.CloseHandle(p.process)
+			p.process = 0
+		}
+	})
 }
 
 func scaleRect(rect Rect, hwnd uintptr) (int, int, int, int) {

--- a/backend/processlock/process_windows.go
+++ b/backend/processlock/process_windows.go
@@ -2,18 +2,29 @@
 
 package processlock
 
-import "os"
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
 
 func processRunning(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
-	p, err := os.FindProcess(pid)
+	h, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
+		// Access denied means a process exists but this user cannot inspect it.
+		// Treat it as live; invalid parameter means the PID is stale.
+		if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
+			return true
+		}
 		return false
 	}
-	_ = p.Release()
-	// Windows cannot reliably probe liveness through os.FindProcess alone.
-	// Prefer preserving the lock over accidentally allowing a second backend.
-	return true
+	defer windows.CloseHandle(h)
+	status, err := windows.WaitForSingleObject(h, 0)
+	if err != nil {
+		return true
+	}
+	return status == uint32(windows.WAIT_TIMEOUT)
 }

--- a/backend/projection/channels.go
+++ b/backend/projection/channels.go
@@ -65,6 +65,7 @@ func DeleteChannel(db *sql.DB, channelID int64) error {
 		`DELETE FROM file_parts WHERE channel_id = ?`,
 		`DELETE FROM pending_part_cleanup WHERE channel_id = ?`,
 		`DELETE FROM folders WHERE channel_id = ?`,
+		`DELETE FROM replay_log_rejects WHERE channel_id = ?`,
 		`DELETE FROM replay_log WHERE channel_id = ?`,
 		`DELETE FROM replay_log_tamper WHERE channel_id = ?`,
 		`DELETE FROM backfill_progress WHERE channel_id = ?`,

--- a/backend/projection/multipart.go
+++ b/backend/projection/multipart.go
@@ -114,6 +114,54 @@ func DeleteFilePartsByMsgIDs(db *sql.DB, channelID int64, msgIDs []int64) error 
 	return deleteByMsgIDs(db, "file_parts", channelID, msgIDs)
 }
 
+// MultipartPartMsgIDsForFiles returns all part document msg_ids behind the given
+// live multipart manifest msg_ids. It is chunked so folder-delete cleanup can
+// collect part bodies with one set-based query per chunk instead of one
+// MultipartParts lookup per file.
+func MultipartPartMsgIDsForFiles(db *sql.DB, channelID int64, fileMsgIDs []int64) ([]int64, error) {
+	const chunk = 500
+	var out []int64
+	for start := 0; start < len(fileMsgIDs); start += chunk {
+		end := min(start+chunk, len(fileMsgIDs))
+		batch := fileMsgIDs[start:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, 0, len(batch)+1)
+		args = append(args, channelID)
+		for i, id := range batch {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		rows, err := db.Query(`
+			SELECT fp.msg_id
+			FROM files f
+			JOIN file_parts fp
+			  ON fp.channel_id = f.channel_id
+			 AND fp.upload_uuid = f.upload_uuid
+			WHERE f.channel_id = ?
+			  AND f.msg_id IN (`+strings.Join(placeholders, ",")+`)
+			  AND f.upload_uuid != ''
+			ORDER BY f.msg_id ASC, fp.part_index ASC
+		`, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var id int64
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			out = append(out, id)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+	return out, nil
+}
+
 func deleteByMsgIDs(db *sql.DB, table string, channelID int64, msgIDs []int64) error {
 	const chunk = 500
 	for start := 0; start < len(msgIDs); start += chunk {
@@ -161,26 +209,6 @@ func MultipartComplete(db *sql.DB, channelID, fileMsgID int64, parts []FilePart)
 		return fmt.Errorf("multipart file is incomplete: parts total %d bytes, expected %d", sum, size)
 	}
 	return nil
-}
-
-// MultipartFileMsgIDs returns the set of live multipart-file msg_ids (manifests).
-// Views that can't operate on a manifest (a text message, not a document) use it
-// to exclude multipart files — e.g. the Photos gallery thumbnail/preview path.
-func MultipartFileMsgIDs(db *sql.DB, channelID int64) (map[int64]bool, error) {
-	rows, err := db.Query(`SELECT msg_id FROM files WHERE channel_id = ? AND upload_uuid != '' AND tombstoned = 0`, channelID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	out := make(map[int64]bool)
-	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		out[id] = true
-	}
-	return out, rows.Err()
 }
 
 // QueuePartCleanup records part message ids whose bodies couldn't be deleted

--- a/backend/projection/read.go
+++ b/backend/projection/read.go
@@ -25,14 +25,16 @@ type FileSlim struct {
 }
 
 type SearchHit struct {
-	Type       string
-	ID         string
-	Name       string
-	ParentID   string
-	Size       int64
-	Time       int64
-	MsgID      int64
-	UploaderID int64
+	Type          string
+	ID            string
+	Name          string
+	ParentID      string
+	Size          int64
+	Time          int64
+	MsgID         int64
+	UploaderID    int64
+	Encrypted     bool
+	PlaintextSize int64
 }
 
 func ListFolderContents(db *sql.DB, channelID int64, parentID string) ([]FolderSlim, []FileSlim, error) {
@@ -164,17 +166,23 @@ ORDER BY f.upload_time DESC
 	return out, rows.Err()
 }
 
-// ListAllFiles returns every non-tombstoned file in the channel, newest
-// first. Used by the gallery, which filters the result down to images in the
-// service layer. Returns metadata only (no bodies), so it stays cheap even
-// for large drives.
-func ListAllFiles(db *sql.DB, channelID int64) ([]FileSlim, error) {
-	// msg_id is the tiebreaker so the gallery order is stable across refreshes
-	// when several files share an upload_time (batch uploads collide on the
-	// second). msg_id is monotonic and unique per channel.
+// MediaFiles returns gallery-compatible image files only, newest first. Keeping
+// the extension filter and multipart-manifest exclusion in SQL avoids loading
+// every document in large drives just to discard most of them in Go.
+func MediaFiles(db *sql.DB, channelID int64) ([]FileSlim, error) {
 	rows, err := db.Query(`
 		SELECT msg_id, name, size, parent_id, upload_time, uploader_user_id, encrypted, plaintext_size FROM files
-		WHERE channel_id = ? AND tombstoned = 0
+		WHERE channel_id = ?
+		  AND tombstoned = 0
+		  AND upload_uuid = ''
+		  AND (
+		      name LIKE '%.jpg' COLLATE NOCASE
+		   OR name LIKE '%.jpeg' COLLATE NOCASE
+		   OR name LIKE '%.png' COLLATE NOCASE
+		   OR name LIKE '%.gif' COLLATE NOCASE
+		   OR name LIKE '%.webp' COLLATE NOCASE
+		   OR name LIKE '%.bmp' COLLATE NOCASE
+		  )
 		ORDER BY upload_time DESC, msg_id DESC
 	`, channelID)
 	if err != nil {
@@ -346,7 +354,7 @@ func Search(db *sql.DB, channelID int64, query string, limit int) ([]SearchHit, 
 	_ = folderRows.Close()
 
 	fileRows, err := db.Query(`
-		SELECT msg_id, name, size, parent_id, upload_time, uploader_user_id FROM files
+		SELECT msg_id, name, size, parent_id, upload_time, uploader_user_id, encrypted, plaintext_size FROM files
 		WHERE channel_id = ? AND tombstoned = 0 AND name LIKE ? COLLATE NOCASE
 		ORDER BY upload_time DESC LIMIT ?
 	`, channelID, pattern, limit)
@@ -355,11 +363,13 @@ func Search(db *sql.DB, channelID int64, query string, limit int) ([]SearchHit, 
 	}
 	for fileRows.Next() {
 		var h SearchHit
+		var enc int
 		h.Type = "file"
-		if err := fileRows.Scan(&h.MsgID, &h.Name, &h.Size, &h.ParentID, &h.Time, &h.UploaderID); err != nil {
+		if err := fileRows.Scan(&h.MsgID, &h.Name, &h.Size, &h.ParentID, &h.Time, &h.UploaderID, &enc, &h.PlaintextSize); err != nil {
 			_ = fileRows.Close()
 			return nil, err
 		}
+		h.Encrypted = enc == 1
 		results = append(results, h)
 	}
 	if err := fileRows.Err(); err != nil {
@@ -601,7 +611,7 @@ func LookupFileName(db *sql.DB, channelID int64, msgID int64) string {
 	var name string
 	err := db.QueryRow(`
 		SELECT name FROM files
-		WHERE channel_id = ? AND msg_id = ?
+		WHERE channel_id = ? AND msg_id = ? AND tombstoned = 0
 	`, channelID, msgID).Scan(&name)
 	if err != nil {
 		return ""

--- a/backend/projection/rebuild.go
+++ b/backend/projection/rebuild.go
@@ -32,6 +32,9 @@ func RebuildProjection(db *sql.DB, channelID int64) error {
 	if _, err := tx.Exec(`DELETE FROM file_parts WHERE channel_id = ?`, channelID); err != nil {
 		return fmt.Errorf("projection: rebuild clear file_parts: %w", err)
 	}
+	if _, err := tx.Exec(`DELETE FROM replay_log_rejects WHERE channel_id = ?`, channelID); err != nil {
+		return fmt.Errorf("projection: rebuild clear replay_log_rejects: %w", err)
+	}
 
 	rows, err := tx.Query(`
 		SELECT msg_id, op_type, op_payload_json, actor_user_id

--- a/backend/projection/schema.go
+++ b/backend/projection/schema.go
@@ -91,13 +91,13 @@ func EnsureSchema(db *sql.DB) error {
 			msg_id       INTEGER NOT NULL,
 			size         INTEGER NOT NULL DEFAULT 0,
 			PRIMARY KEY (channel_id, upload_uuid, part_index)
-		);`,
+			);`,
 		`CREATE INDEX IF NOT EXISTS idx_file_parts_msg ON file_parts(channel_id, msg_id);`,
 		`CREATE TABLE IF NOT EXISTS pending_part_cleanup (
-			channel_id  INTEGER NOT NULL,
-			msg_id      INTEGER NOT NULL,
-			PRIMARY KEY (channel_id, msg_id)
-		);`,
+				channel_id  INTEGER NOT NULL,
+				msg_id      INTEGER NOT NULL,
+				PRIMARY KEY (channel_id, msg_id)
+			);`,
 	}
 
 	for _, s := range stmts {
@@ -105,7 +105,70 @@ func EnsureSchema(db *sql.DB) error {
 			return fmt.Errorf("projection: ensure schema: %w", err)
 		}
 	}
+	if err := ensureCompatibleIndexes(db); err != nil {
+		return err
+	}
 	return nil
+}
+
+func ensureCompatibleIndexes(db *sql.DB) error {
+	if dbTableHasColumns(db, "files", "channel_id", "uploader_user_id", "upload_time", "msg_id", "tombstoned") {
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_files_uploader_latest
+			ON files(channel_id, uploader_user_id, upload_time DESC, msg_id DESC)
+			WHERE tombstoned = 0 AND uploader_user_id > 0;`); err != nil {
+			return fmt.Errorf("projection: create files uploader index: %w", err)
+		}
+	}
+	if dbTableHasColumns(db, "files", "channel_id", "upload_time", "msg_id", "tombstoned") {
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_files_channel_upload_time
+			ON files(channel_id, upload_time DESC, msg_id DESC)
+			WHERE tombstoned = 0;`); err != nil {
+			return fmt.Errorf("projection: create files upload-time index: %w", err)
+		}
+	}
+	if dbTableHasColumns(db, "files", "channel_id", "name", "tombstoned") {
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_files_channel_name_nocase
+			ON files(channel_id, name COLLATE NOCASE)
+			WHERE tombstoned = 0;`); err != nil {
+			return fmt.Errorf("projection: create files name index: %w", err)
+		}
+	}
+	if dbTableHasColumns(db, "folders", "channel_id", "name", "tombstoned") {
+		if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_folders_channel_name_nocase
+			ON folders(channel_id, name COLLATE NOCASE)
+			WHERE tombstoned = 0;`); err != nil {
+			return fmt.Errorf("projection: create folders name index: %w", err)
+		}
+	}
+	return nil
+}
+
+func dbTableHasColumns(db *sql.DB, table string, names ...string) bool {
+	rows, err := db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, table))
+	if err != nil {
+		return false
+	}
+	defer rows.Close()
+
+	needed := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		needed[name] = struct{}{}
+	}
+	for rows.Next() {
+		var (
+			cid     int
+			cname   string
+			ctype   string
+			notnull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &cname, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false
+		}
+		delete(needed, cname)
+	}
+	return rows.Err() == nil && len(needed) == 0
 }
 
 func currentVersion(db *sql.DB) (int, error) {
@@ -384,6 +447,9 @@ func createFreshFolders(tx *sql.Tx) error {
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_folders_channel_parent
 			ON folders(channel_id, parent_id) WHERE tombstoned = 0;`,
+		`CREATE INDEX IF NOT EXISTS idx_folders_channel_name_nocase
+			ON folders(channel_id, name COLLATE NOCASE)
+			WHERE tombstoned = 0;`,
 	}
 	for _, s := range stmts {
 		if _, err := tx.Exec(s); err != nil {
@@ -413,6 +479,15 @@ func createFreshFiles(tx *sql.Tx) error {
 		);`,
 		`CREATE INDEX IF NOT EXISTS idx_files_channel_parent
 			ON files(channel_id, parent_id) WHERE tombstoned = 0;`,
+		`CREATE INDEX IF NOT EXISTS idx_files_uploader_latest
+			ON files(channel_id, uploader_user_id, upload_time DESC, msg_id DESC)
+			WHERE tombstoned = 0 AND uploader_user_id > 0;`,
+		`CREATE INDEX IF NOT EXISTS idx_files_channel_upload_time
+			ON files(channel_id, upload_time DESC, msg_id DESC)
+			WHERE tombstoned = 0;`,
+		`CREATE INDEX IF NOT EXISTS idx_files_channel_name_nocase
+			ON files(channel_id, name COLLATE NOCASE)
+			WHERE tombstoned = 0;`,
 	}
 	for _, s := range stmts {
 		if _, err := tx.Exec(s); err != nil {

--- a/backend/services/file/service.go
+++ b/backend/services/file/service.go
@@ -177,6 +177,18 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 
 			meta, op, header, err := s.uploadSingle(ctx, uploadID, path, pid, channelID, encrypt)
 			if err != nil {
+				if meta.MsgID != 0 {
+					mu.Lock()
+					uploaded = append(uploaded, uploadedResult{
+						UploadID:  uploadID,
+						Meta:      meta,
+						RawHeader: header,
+						Op:        op,
+					})
+					mu.Unlock()
+					s.warnf("warn: upload committed but local projection is pending for %q: %v\n", meta.Name, err)
+					return
+				}
 				mu.Lock()
 				failed++
 				mu.Unlock()
@@ -502,6 +514,21 @@ func (s *Service) uploadMultipart(ctx context.Context, uploadID int, plainFile *
 		manifestOp.PlaintextSize = plaintextSize
 		manifestOp.EncryptionVersion = 1
 	}
+	committedMeta := func(msgID int64) Metadata {
+		return Metadata{
+			Name:          filename,
+			Size:          storedSize,
+			MsgID:         int(msgID),
+			ParentID:      parent,
+			UploadTime:    uploadTime,
+			Encrypted:     encrypt,
+			PlaintextSize: plaintextSize,
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		abort()
+		return Metadata{}, err
+	}
 	manifestMsgID, err := s.emit(channelID, manifestOp)
 	if err != nil {
 		if manifestMsgID == 0 {
@@ -514,19 +541,11 @@ func (s *Service) uploadMultipart(ctx context.Context, uploadID int, plainFile *
 		// is committed and the next sync will project it. Deleting the parts now
 		// would corrupt that committed file, so leave Telegram intact and surface
 		// the error.
-		return Metadata{}, err
+		return committedMeta(manifestMsgID), err
 	}
 
 	s.emitEvent("upload_progress", uploadID, 100.0)
-	return Metadata{
-		Name:          filename,
-		Size:          storedSize,
-		MsgID:         int(manifestMsgID),
-		ParentID:      parent,
-		UploadTime:    uploadTime,
-		Encrypted:     encrypt,
-		PlaintextSize: plaintextSize,
-	}, nil
+	return committedMeta(manifestMsgID), nil
 }
 
 // deleteMessagesChunked deletes Telegram messages in batches of 100 so a large
@@ -578,6 +597,9 @@ func (s *Service) Download(ctx context.Context, channelID int64, msgID int, look
 	fileID := int64(lookupID)
 	if fileID == 0 {
 		fileID = int64(msgID)
+	}
+	if !projection.FileExists(s.DB, channelID, fileID) {
+		return DownloadResult{Status: "error", Message: "Message deleted or not found"}
 	}
 	if parts, err := projection.MultipartParts(s.DB, channelID, fileID); err != nil {
 		return DownloadResult{Status: "error", Message: "System Error: " + err.Error()}

--- a/backend/services/folder/service.go
+++ b/backend/services/folder/service.go
@@ -17,6 +17,7 @@ type PeerResolver interface {
 }
 
 type EmitOpFunc func(channelID int64, op projection.Op) error
+type EmitOpsFunc func(channelID int64, ops []projection.Op) error
 type ActorIDFunc func(ctx context.Context) (int64, error)
 type RequireEncryptionKeyFunc func(encrypted bool) ([]byte, error)
 type WarnFunc func(format string, args ...any)
@@ -26,6 +27,7 @@ type Service struct {
 	TG                   tgclient.Client
 	Peers                PeerResolver
 	EmitOp               EmitOpFunc
+	EmitOps              EmitOpsFunc
 	ActorID              ActorIDFunc
 	RequireEncryptionKey RequireEncryptionKeyFunc
 	Warnf                WarnFunc
@@ -111,36 +113,24 @@ func (s *Service) Delete(ctx context.Context, channelID int64, folderID string) 
 		return err
 	}
 
-	// Delete the whole subtree, but don't abort on the first per-item failure.
-	// Each tombstone op is idempotent, so we make maximal progress and report
-	// what's left; a retry finishes the rest rather than stranding the tree in a
-	// worse half-state with a bare "delete failed".
-	var failed []string
-	deleted := make([]projection.FileSlim, 0, len(files))
+	ops := make([]projection.Op, 0, len(files)+len(folders))
 	for _, file := range files {
-		op := projection.Op{
+		ops = append(ops, projection.Op{
 			Type: projection.OpTomb,
 			Obj:  fmt.Sprintf("%s%d", projection.FileIDPrefix, file.MsgID),
-		}
-		if err := s.emit(channelID, op); err != nil {
-			failed = append(failed, fmt.Sprintf("file %q: %v", file.Name, err))
-			continue
-		}
-		deleted = append(deleted, file)
+		})
 	}
 	for _, folder := range folders {
-		if err := s.emit(channelID, projection.Op{Type: projection.OpRmdir, Obj: folder.ID}); err != nil {
-			failed = append(failed, fmt.Sprintf("folder %q: %v", folder.Name, err))
-		}
+		ops = append(ops, projection.Op{Type: projection.OpRmdir, Obj: folder.ID})
+	}
+	if err := s.emitMany(channelID, ops); err != nil {
+		return fmt.Errorf("delete folder failed: %w", err)
 	}
 
-	// Only drop bodies for files whose tombstone actually landed, so a file's
-	// content is never deleted while its metadata still shows it as present.
-	s.deleteBodiesBestEffort(ctx, channelID, deleted)
-
-	if len(failed) > 0 {
-		return fmt.Errorf("folder partially deleted, try again to finish (%d item(s) failed: %s)", len(failed), strings.Join(failed, "; "))
-	}
+	// Body deletion is best effort and runs only after the whole subtree's
+	// metadata is locally tombstoned. If Telegram body cleanup fails, replayed
+	// tombstone metadata stays canonical and the orphan sweep can retry parts.
+	s.deleteBodiesBestEffort(ctx, channelID, files)
 	return nil
 }
 
@@ -226,6 +216,16 @@ func (s *Service) emit(channelID int64, op projection.Op) error {
 	return s.EmitOp(channelID, op)
 }
 
+func (s *Service) emitMany(channelID int64, ops []projection.Op) error {
+	if len(ops) == 0 {
+		return nil
+	}
+	if s.EmitOps == nil {
+		return fmt.Errorf("folder batch emitter not ready")
+	}
+	return s.EmitOps(channelID, ops)
+}
+
 func (s *Service) requireDeletePermission(ctx context.Context, channelID int64, files []projection.FileSlim) error {
 	if len(files) == 0 {
 		return nil
@@ -287,16 +287,15 @@ func (s *Service) deleteBodiesBestEffort(ctx context.Context, channelID int64, f
 	// Each file's body is its own message; a multipart file also has N part
 	// document bodies that must be deleted too (and their file_parts rows).
 	ids := make([]int64, 0, len(files))
-	var partIDs []int64
 	for _, file := range files {
 		ids = append(ids, file.MsgID)
-		if parts, err := projection.MultipartParts(s.DB, channelID, file.MsgID); err == nil {
-			for _, p := range parts {
-				ids = append(ids, p.MsgID)
-				partIDs = append(partIDs, p.MsgID)
-			}
-		}
 	}
+	partIDs, err := projection.MultipartPartMsgIDsForFiles(s.DB, channelID, ids)
+	if err != nil {
+		s.warnf("warn: folder tomb succeeded but reading multipart part bodies failed: %v\n", err)
+		return
+	}
+	ids = append(ids, partIDs...)
 	peer, err := s.Peers.ResolvePeer(ctx, channelID)
 	if err != nil {
 		s.warnf("warn: folder tomb succeeded but peer resolve failed for %d file bodies: %v\n", len(ids), err)

--- a/backend/services/folder/service_test.go
+++ b/backend/services/folder/service_test.go
@@ -49,6 +49,25 @@ func newTestService(t *testing.T) (*Service, *sql.DB, *tgclient.Fake, *int64) {
 			_, err := projection.ProjectFromOp(db, channelID, msgID, op, actor, header)
 			return err
 		},
+		EmitOps: func(channelID int64, ops []projection.Op) (err error) {
+			tx, err := db.Begin()
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err != nil {
+					_ = tx.Rollback()
+				}
+			}()
+			for _, op := range ops {
+				msgID++
+				header := projection.Format(op)
+				if _, err = projection.ProjectFromOpTx(tx, channelID, msgID, op, actor, header); err != nil {
+					return err
+				}
+			}
+			return tx.Commit()
+		},
 		ActorID: func(ctx context.Context) (int64, error) {
 			return actor, nil
 		},
@@ -75,6 +94,49 @@ func TestCreateFolderProjectsMkdir(t *testing.T) {
 
 	if _, err := svc.Create(testChannelID, "Photos", ""); err == nil {
 		t.Fatalf("duplicate folder name unexpectedly succeeded")
+	}
+}
+
+func TestDeleteFolderBatchFailureLeavesProjectionUntouched(t *testing.T) {
+	svc, db, fakeTG, _ := newTestService(t)
+
+	folder, err := svc.Create(testChannelID, "Parent", "")
+	if err != nil {
+		t.Fatalf("create folder: %v", err)
+	}
+	if err := svc.EmitOp(testChannelID, projection.Op{
+		Type:           projection.OpFileUpload,
+		Parent:         folder.ID,
+		Name:           "keep.txt",
+		FileSize:       10,
+		FileUploadTime: 1,
+	}); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	var fileID int64
+	if err := db.QueryRow(`
+		SELECT msg_id FROM files
+		WHERE channel_id = ? AND parent_id = ? AND name = 'keep.txt'
+	`, testChannelID, folder.ID).Scan(&fileID); err != nil {
+		t.Fatalf("scan file id: %v", err)
+	}
+
+	batchErr := errors.New("injected batch failure")
+	svc.EmitOps = func(channelID int64, ops []projection.Op) error {
+		return batchErr
+	}
+
+	if err := svc.Delete(context.Background(), testChannelID, folder.ID); !errors.Is(err, batchErr) {
+		t.Fatalf("delete err = %v, want %v", err, batchErr)
+	}
+	if !projection.FolderExists(db, testChannelID, folder.ID) {
+		t.Fatalf("folder was locally tombstoned despite batch failure")
+	}
+	if !projection.FileExists(db, testChannelID, fileID) {
+		t.Fatalf("file was locally tombstoned despite batch failure")
+	}
+	if batches := fakeTG.DeletedBatches(); len(batches) != 0 {
+		t.Fatalf("body delete happened despite metadata failure: %+v", batches)
 	}
 }
 

--- a/backend/services/read/service.go
+++ b/backend/services/read/service.go
@@ -8,7 +8,6 @@ import (
 
 	"TDrive/backend/projection"
 	"TDrive/backend/tgclient"
-	"TDrive/backend/thumbnail"
 )
 
 type PeerResolver interface {
@@ -44,14 +43,16 @@ type FileSystem struct {
 }
 
 type SearchResult struct {
-	Type       string
-	ID         string
-	Name       string
-	ParentID   string
-	Size       int64
-	UploadTime int64
-	UploaderID int64
-	Path       string
+	Type          string
+	ID            string
+	Name          string
+	ParentID      string
+	Size          int64
+	UploadTime    int64
+	UploaderID    int64
+	Encrypted     bool
+	PlaintextSize int64
+	Path          string
 }
 
 type TelegramFile struct {
@@ -140,14 +141,16 @@ func (s *Service) Search(channelID int64, query string, limit int) ([]SearchResu
 			})
 		case "file":
 			results = append(results, SearchResult{
-				Type:       "file",
-				ID:         fmt.Sprintf("%d", h.MsgID),
-				Name:       h.Name,
-				ParentID:   h.ParentID,
-				Size:       h.Size,
-				UploadTime: h.Time,
-				UploaderID: h.UploaderID,
-				Path:       buildFolderPath(folderMap, h.ParentID),
+				Type:          "file",
+				ID:            fmt.Sprintf("%d", h.MsgID),
+				Name:          h.Name,
+				ParentID:      h.ParentID,
+				Size:          h.Size,
+				UploadTime:    h.Time,
+				UploaderID:    h.UploaderID,
+				Encrypted:     h.Encrypted,
+				PlaintextSize: h.PlaintextSize,
+				Path:          buildFolderPath(folderMap, h.ParentID),
 			})
 		}
 	}
@@ -187,21 +190,13 @@ func (s *Service) MediaFiles(channelID int64) ([]File, error) {
 	if channelID == 0 {
 		return []File{}, nil
 	}
-	all, err := projection.ListAllFiles(s.DB, channelID)
-	if err != nil {
-		return nil, err
-	}
-	// Multipart files have no single document (their id is a text manifest), so
-	// they can't thumbnail or preview — keep them out of the gallery.
-	multipart, err := projection.MultipartFileMsgIDs(s.DB, channelID)
+	all, err := projection.MediaFiles(s.DB, channelID)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]File, 0, len(all))
 	for _, f := range all {
-		if thumbnail.IsImage(f.Name) && !multipart[f.MsgID] {
-			out = append(out, fileFromProjection(f))
-		}
+		out = append(out, fileFromProjection(f))
 	}
 	return out, nil
 }

--- a/backend/services/user/service.go
+++ b/backend/services/user/service.go
@@ -145,24 +145,57 @@ func uploaderMessageRefs(db *sql.DB, channelID int64, userIDs []int64) (map[int6
 		return nil, fmt.Errorf("db not ready")
 	}
 	out := make(map[int64]int64, len(userIDs))
+	unique := make([]int64, 0, len(userIDs))
+	seen := make(map[int64]struct{}, len(userIDs))
 	for _, id := range userIDs {
 		if id <= 0 {
 			continue
 		}
-		var msgID int64
-		err := db.QueryRow(`
-			SELECT msg_id FROM files
-			WHERE channel_id = ? AND uploader_user_id = ? AND tombstoned = 0
-			ORDER BY upload_time DESC, msg_id DESC
-			LIMIT 1
-		`, channelID, id).Scan(&msgID)
-		if err == nil {
-			out[id] = msgID
+		if _, ok := seen[id]; ok {
 			continue
 		}
-		if err == sql.ErrNoRows {
-			continue
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	if len(unique) == 0 {
+		return out, nil
+	}
+
+	values := make([]string, len(unique))
+	args := make([]any, 0, len(unique)+1)
+	for i, id := range unique {
+		values[i] = "(?)"
+		args = append(args, id)
+	}
+	args = append(args, channelID)
+
+	query := `
+WITH wanted(user_id) AS (VALUES ` + strings.Join(values, ",") + `),
+ranked AS (
+	SELECT f.uploader_user_id, f.msg_id,
+	       ROW_NUMBER() OVER (
+	         PARTITION BY f.uploader_user_id
+	         ORDER BY f.upload_time DESC, f.msg_id DESC
+	       ) AS rn
+	FROM files f
+	JOIN wanted w ON w.user_id = f.uploader_user_id
+	WHERE f.channel_id = ? AND f.tombstoned = 0
+)
+SELECT uploader_user_id, msg_id FROM ranked WHERE rn = 1
+`
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var userID, msgID int64
+		if err := rows.Scan(&userID, &msgID); err != nil {
+			return nil, err
 		}
+		out[userID] = msgID
+	}
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/backend/sync/sync.go
+++ b/backend/sync/sync.go
@@ -216,14 +216,23 @@ func (e *Engine) InitialSyncEmptyChannel(ctx context.Context, channelID int64) e
 
 	SortAscending(allParsed)
 
+	tx, err := e.db.Begin()
+	if err != nil {
+		return fmt.Errorf("sync: begin initial projection: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	for _, p := range allParsed {
-		if _, err := projection.ProjectFromOp(e.db, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
+		if _, err := projection.ProjectFromOpTx(tx, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
 			return fmt.Errorf("sync: project msg=%d: %w", p.MsgID, err)
 		}
 	}
 
-	if err := markInitialSyncDone(e.db, channelID, highestSeen); err != nil {
+	if err := markInitialSyncDoneTx(tx, channelID, highestSeen); err != nil {
 		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sync: commit initial projection: %w", err)
 	}
 	return nil
 }
@@ -247,6 +256,15 @@ func writeWatermark(db *sql.DB, channelID int64, msgID int64) error {
 
 func markInitialSyncDone(db *sql.DB, channelID int64, watermark int64) error {
 	_, err := db.Exec(`
+		UPDATE channels
+		SET last_synced_msg = ?, initial_sync_done = 1
+		WHERE channel_id = ?
+	`, watermark, channelID)
+	return err
+}
+
+func markInitialSyncDoneTx(tx *sql.Tx, channelID int64, watermark int64) error {
+	_, err := tx.Exec(`
 		UPDATE channels
 		SET last_synced_msg = ?, initial_sync_done = 1
 		WHERE channel_id = ?

--- a/backend/thumbnail/cache.go
+++ b/backend/thumbnail/cache.go
@@ -88,6 +88,38 @@ func (c *Cache) Get(key string) ([]byte, bool) {
 	return data, true
 }
 
+// Has reports whether key is present and refreshes recency without reading the
+// value. It is used by background schedulers that only need to avoid duplicate
+// work; callers that need bytes should still use Get.
+func (c *Cache) Has(key string) bool {
+	if c == nil || c.dir == "" {
+		return false
+	}
+	name := fileName(key)
+
+	c.mu.Lock()
+	c.ensureInitLocked()
+	if _, known := c.entries[name]; !known {
+		c.mu.Unlock()
+		return false
+	}
+	now := time.Now()
+	e := c.entries[name]
+	e.used = now
+	c.entries[name] = e
+	c.mu.Unlock()
+
+	path := filepath.Join(c.dir, name)
+	if _, err := os.Stat(path); err != nil {
+		c.mu.Lock()
+		c.forgetLocked(name)
+		c.mu.Unlock()
+		return false
+	}
+	_ = os.Chtimes(path, now, now)
+	return true
+}
+
 // Put stores data under key, replacing any previous value, and evicts the
 // least-recently-used entries until the cache is within its size budget.
 // Empty data and disabled caches are no-ops. Errors are I/O failures writing

--- a/frontend/src/modules/modals/preview.ts
+++ b/frontend/src/modules/modals/preview.ts
@@ -57,14 +57,15 @@ let panPointerId = -1;
 let panStartX = 0;
 let panStartY = 0;
 
-// Full-resolution data URLs keyed by msgID, with neighbor prefetch so next/prev
-// is instant. preloadEpoch lets a new navigation abort the prior prefetch run.
+// Full-resolution data URLs keyed by drive + msgID, with neighbor prefetch so
+// next/prev is instant. Telegram message ids are scoped to a channel, so using
+// msgID alone can show the wrong image after switching drives.
 const FULL_CACHE_MAX = 12;
-const fullCache = new Map<number, string>();
-// In-flight full-image downloads keyed by msgID, so a neighbor prefetch and the
-// user's own navigation to the same image share one download instead of racing
-// two (which would serialize on the backend's preview mutex).
-const inflightFull = new Map<number, Promise<string>>();
+const fullCache = new Map<string, string>();
+// In-flight full-image downloads keyed by drive + msgID, so a neighbor prefetch
+// and the user's own navigation to the same image share one download instead of
+// racing two (which would serialize on the backend's preview mutex).
+const inflightFull = new Map<string, Promise<string>>();
 let preloadEpoch = 0;
 let previewReady = false;
 let previewRequestToken = 0;
@@ -105,8 +106,9 @@ function flashStatus(message: any) {
 }
 
 function getPreviewKey(item: any) {
-    if (!item || item.type !== "file") return "";
-    return `file:${Number(item.id || 0)}`;
+	if (!item || item.type !== "file") return "";
+	const channelID = Number(item.channel_id || item.channelId || item.ChannelID || state.activeChannel?.id || 0);
+	return `file:${channelID}:${Number(item.id || 0)}`;
 }
 
 function clearActivePreview() {
@@ -349,7 +351,7 @@ async function resolveFullPreviewEntry(target: any) {
     // Shares an in-flight neighbor prefetch for the same image. A locked
     // encrypted file rejects with "encryption password required"; loadPreview
     // turns that into the inline unlock card rather than a popup modal.
-    return { src: await fetchFullRaw(msgID), mimeType: "" };
+	return { src: await fetchFullRaw(target), mimeType: "" };
 }
 
 export async function loadPreview(target: any) {
@@ -392,7 +394,7 @@ export async function loadPreview(target: any) {
     try {
         // Already prefetched by a neighbor preload? Show it instantly with no
         // loading indicator at all.
-        const cachedFull = fullCache.get(msgID);
+		const cachedFull = fullCache.get(previewKey);
         if (cachedFull) {
             activeFullSrc = cachedFull;
             showPreviewImage(cachedFull, filename);
@@ -830,34 +832,36 @@ function handlePanEnd(e: any) {
 
 // --- full-image cache + neighbor prefetch ---
 
-function cacheFull(msgID: number, src: string) {
-    fullCache.set(msgID, src);
-    if (fullCache.size > FULL_CACHE_MAX) {
-        const oldest = fullCache.keys().next().value;
-        if (oldest !== undefined) fullCache.delete(oldest);
-    }
+function cacheFull(key: string, src: string) {
+	fullCache.set(key, src);
+	if (fullCache.size > FULL_CACHE_MAX) {
+		const oldest = fullCache.keys().next().value;
+		if (oldest !== undefined) fullCache.delete(oldest);
+	}
 }
 
 // fetchFullRaw downloads + decodes + caches one full image, returning its data
 // URL. Concurrent callers for the same id share a single download. It never
 // opens the unlock modal; callers that need it wrap this and retry.
-function fetchFullRaw(id: number): Promise<string> {
-    const cached = fullCache.get(id);
-    if (cached) return Promise.resolve(cached);
-    const existing = inflightFull.get(id);
-    if (existing) return existing;
+function fetchFullRaw(item: any): Promise<string> {
+	const id = Number(item?.id || 0);
+	const key = getPreviewKey(item);
+	const cached = fullCache.get(key);
+	if (cached) return Promise.resolve(cached);
+	const existing = inflightFull.get(key);
+	if (existing) return existing;
 
-    const p = (async () => {
-        const asset = payloadToPreviewAsset(await PreviewFile(id));
-        await decodePreviewSource(asset.src);
-        cacheFull(id, asset.src);
-        return asset.src;
-    })();
-    inflightFull.set(id, p);
-    void p.catch(() => {}).finally(() => {
-        if (inflightFull.get(id) === p) inflightFull.delete(id);
-    });
-    return p;
+	const p = (async () => {
+		const asset = payloadToPreviewAsset(await PreviewFile(id));
+		await decodePreviewSource(asset.src);
+		cacheFull(key, asset.src);
+		return asset.src;
+	})();
+	inflightFull.set(key, p);
+	void p.catch(() => {}).finally(() => {
+		if (inflightFull.get(key) === p) inflightFull.delete(key);
+	});
+	return p;
 }
 
 // preloadNeighbors prefetches the next/prev few full images so navigation is
@@ -874,11 +878,13 @@ function preloadNeighbors() {
             if (epoch !== preloadEpoch) return;
             const idx = baseIndex + off;
             if (idx < 0 || idx >= navItems.length) continue;
-            const id = Number(navItems[idx]?.id || 0);
-            if (!id || fullCache.has(id)) continue;
-            try {
-                await fetchFullRaw(id);
-            } catch {
+			const item = navItems[idx];
+			const id = Number(item?.id || 0);
+			const key = getPreviewKey(item);
+			if (!id || !key || fullCache.has(key)) continue;
+			try {
+				await fetchFullRaw(item);
+			} catch {
                 // Too large, locked, or failed — the on-demand view handles it.
             }
             if (epoch !== preloadEpoch) return;

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -83,6 +83,8 @@ export namespace backend {
 	    size: number;
 	    upload_time: number;
 	    uploader_id: number;
+	    encrypted?: boolean;
+	    plaintext_size?: number;
 	    path: string;
 
 	    static createFrom(source: any = {}) {
@@ -98,6 +100,8 @@ export namespace backend {
 	        this.size = source["size"];
 	        this.upload_time = source["upload_time"];
 	        this.uploader_id = source["uploader_id"];
+	        this.encrypted = source["encrypted"];
+	        this.plaintext_size = source["plaintext_size"];
 	        this.path = source["path"];
 	    }
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/image v0.39.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	modernc.org/sqlite v1.45.0
 )
@@ -63,7 +64,6 @@ require (
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect


### PR DESCRIPTION
- harden daemon IPC, backend lifecycle guards, logout, and Wails bound-method readiness checks
- fix native player lifecycle/build stability across macOS, Windows, and Linux
- tighten media thumbnail concurrency, folder deletes, sync atomicity, SQL/index paths, and crypto bounds
