### PR TITLE
optimize hot paths

### DIFF
--- a/backend/backfill/backfill.go
+++ b/backend/backfill/backfill.go
@@ -13,6 +13,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -331,27 +332,32 @@ func orderParentsFirst(rows []folderRow) []folderRow {
 	for _, r := range rows {
 		byID[r.ID] = r
 	}
-	depth := func(id string) int {
-		d := 0
-		cur := id
-		seen := map[string]bool{}
-		for cur != projection.RootParent && !seen[cur] {
-			seen[cur] = true
-			f, ok := byID[cur]
-			if !ok {
-				return d
-			}
-			d++
-			cur = f.ParentID
+	depthMemo := make(map[string]int, len(rows))
+	var depth func(id string, seen map[string]bool) int
+	depth = func(id string, seen map[string]bool) int {
+		if id == projection.RootParent || id == "" || seen[id] {
+			return 0
 		}
+		if d, ok := depthMemo[id]; ok {
+			return d
+		}
+		seen[id] = true
+		f, ok := byID[id]
+		if !ok {
+			return 0
+		}
+		d := 1 + depth(f.ParentID, seen)
+		depthMemo[id] = d
 		return d
 	}
 	out := make([]folderRow, len(rows))
 	copy(out, rows)
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && depth(out[j].ID) < depth(out[j-1].ID); j-- {
-			out[j], out[j-1] = out[j-1], out[j]
-		}
+	depths := make(map[string]int, len(out))
+	for _, r := range out {
+		depths[r.ID] = depth(r.ID, make(map[string]bool))
 	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return depths[out[i].ID] < depths[out[j].ID]
+	})
 	return out
 }

--- a/backend/media/cache.go
+++ b/backend/media/cache.go
@@ -47,22 +47,23 @@ func (c *blockCache) put(key string, data []byte) {
 	if c == nil || len(data) == 0 {
 		return
 	}
-	stored := append([]byte(nil), data...)
+	// blockCache takes ownership of data. Callers must not mutate a fetched block
+	// after putting it; ReadStoredAt only copies from cached blocks.
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if elem, ok := c.items[key]; ok {
 		ent := elem.Value.(*cacheEntry)
 		c.used -= int64(len(ent.data))
-		ent.data = stored
-		c.used += int64(len(stored))
+		ent.data = data
+		c.used += int64(len(data))
 		c.lru.MoveToFront(elem)
 		c.evictLocked()
 		return
 	}
-	elem := c.lru.PushFront(&cacheEntry{key: key, data: stored})
+	elem := c.lru.PushFront(&cacheEntry{key: key, data: data})
 	c.items[key] = elem
-	c.used += int64(len(stored))
+	c.used += int64(len(data))
 	c.evictLocked()
 }
 

--- a/backend/media/range_reader.go
+++ b/backend/media/range_reader.go
@@ -242,7 +242,9 @@ func (r *RangeReader) block(ctx context.Context, ref tgclient.DocumentRef, block
 		if err != nil {
 			return nil, err
 		}
-		r.cache.put(key, data)
+		if r.cache != nil {
+			r.cache.put(key, data)
+		}
 		return data, nil
 	})
 

--- a/backend/media/server.go
+++ b/backend/media/server.go
@@ -21,7 +21,15 @@ const (
 	mediaThumbSourcePrefix = "/media/thumb-source/"
 	mediaSessionIdleTTL    = 2 * time.Hour
 	mediaSessionSweepEvery = 5 * time.Minute
+	mediaStreamChunkSize   = 256 * 1024
 )
+
+var mediaStreamBufferPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, mediaStreamChunkSize)
+		return &buf
+	},
+}
 
 type PlaybackUpdate struct {
 	Token       string  `json:"token"`
@@ -348,8 +356,9 @@ func parseRangeHeader(raw string, size int64) (start, end int64, partial bool, o
 }
 
 func streamSessionRange(ctx context.Context, w io.Writer, session *Session, start, length int64, readAt func(*Session, context.Context, []byte, int64) (int, error)) error {
-	const chunkSize = 256 * 1024
-	buf := make([]byte, chunkSize)
+	bufPtr := mediaStreamBufferPool.Get().(*[]byte)
+	buf := *bufPtr
+	defer mediaStreamBufferPool.Put(bufPtr)
 	var sent int64
 	for sent < length {
 		want := length - sent

--- a/backend/media/session.go
+++ b/backend/media/session.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 	"time"
 
@@ -271,8 +272,12 @@ func (s *Session) readAt(ctx context.Context, reader *RangeReader, p []byte, off
 }
 
 func (s *Session) segmentFor(off int64) (resolvedSegment, bool) {
-	for _, seg := range s.segments {
-		if off >= seg.start && off < seg.start+seg.size {
+	i := sort.Search(len(s.segments), func(i int) bool {
+		return s.segments[i].start+s.segments[i].size > off
+	})
+	if i < len(s.segments) {
+		seg := s.segments[i]
+		if off >= seg.start {
 			return seg, true
 		}
 	}

--- a/backend/media/video_thumbnails.go
+++ b/backend/media/video_thumbnails.go
@@ -81,10 +81,11 @@ type statefulVideoThumbnailGenerator interface {
 }
 
 type videoThumbnailer struct {
-	session   *Session
-	cache     *thumbnail.Cache
-	generator VideoThumbnailGenerator
-	dir       string
+	session        *Session
+	cache          *thumbnail.Cache
+	generator      VideoThumbnailGenerator
+	dir            string
+	cacheKeyPrefix string
 
 	ctx            context.Context
 	cancel         context.CancelFunc
@@ -118,6 +119,7 @@ func newVideoThumbnailer(session *Session, cache *thumbnail.Cache, generator Vid
 		session:        session,
 		cache:          cache,
 		generator:      generator,
+		cacheKeyPrefix: videoThumbnailCacheKeyPrefix(session.file),
 		ctx:            ctx,
 		cancel:         cancel,
 		wake:           make(chan struct{}, 1),
@@ -797,8 +799,14 @@ func thumbnailWorkDeferred(err error) bool {
 }
 
 func (t *videoThumbnailer) cacheKey(bucket int) string {
-	file := t.session.file
-	return fmt.Sprintf("video-thumb-v1-ch%d-file%d-size%d-t%d", file.ChannelID, file.FileID, file.StoredSize, bucket)
+	return t.cacheKeyPrefix + strconv.Itoa(bucket)
+}
+
+func videoThumbnailCacheKeyPrefix(file LogicalFile) string {
+	return "video-thumb-v1-ch" + strconv.FormatInt(file.ChannelID, 10) +
+		"-file" + strconv.FormatInt(file.FileID, 10) +
+		"-size" + strconv.FormatInt(file.StoredSize, 10) +
+		"-t"
 }
 
 func thumbnailBucket(seconds, duration float64) int {

--- a/backend/projection/log.go
+++ b/backend/projection/log.go
@@ -89,8 +89,8 @@ func ProjectFromOpTx(tx *sql.Tx, channelID int64, msgID int64, op Op, actorID in
 		INSERT INTO replay_log
 		  (channel_id, msg_id, op_type, op_payload_json, raw_header, first_seen_hash, actor_user_id, seen_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`,
-		channelID, msgID, string(op.Type), string(payload),
+		`,
+		channelID, msgID, string(op.Type), payload,
 		rawHeader, hash, actorID, time.Now().Unix())
 	if err != nil {
 		return false, fmt.Errorf("projection: insert replay_log: %w", err)

--- a/backend/projection/read.go
+++ b/backend/projection/read.go
@@ -224,6 +224,25 @@ func ListAllFolders(db *sql.DB, channelID int64) ([]FolderSlim, error) {
 	return out, rows.Err()
 }
 
+func FolderByID(db *sql.DB, channelID int64, folderID string) (FolderSlim, bool, error) {
+	folderID = strings.TrimSpace(folderID)
+	if folderID == "" || folderID == RootParent {
+		return FolderSlim{}, false, nil
+	}
+	var f FolderSlim
+	err := db.QueryRow(`
+		SELECT id, name, parent_id FROM folders
+		WHERE channel_id = ? AND id = ? AND tombstoned = 0
+	`, channelID, folderID).Scan(&f.ID, &f.Name, &f.ParentID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return FolderSlim{}, false, nil
+	}
+	if err != nil {
+		return FolderSlim{}, false, err
+	}
+	return f, true, nil
+}
+
 func FolderSubtreeFolders(db *sql.DB, channelID int64, folderID string) ([]FolderSlim, error) {
 	folderID = strings.TrimSpace(folderID)
 	if folderID == "" {
@@ -587,20 +606,33 @@ func FolderSiblingHasName(db *sql.DB, channelID int64, parentID, name string) (b
 // instead of merging into the existing folder. channelID/parentID semantics
 // match FolderSiblingHasName.
 func NextFreeFolderName(db *sql.DB, channelID int64, parentID, name string) (string, error) {
-	taken, err := FolderSiblingHasName(db, channelID, parentID, name)
+	rows, err := db.Query(`
+		SELECT name FROM folders
+		WHERE channel_id = ? AND parent_id = ? AND tombstoned = 0
+		  AND (name = ? OR name LIKE ?)
+	`, channelID, parentID, name, name+" (%)")
 	if err != nil {
 		return "", err
 	}
-	if !taken {
+	defer rows.Close()
+
+	taken := make(map[string]struct{})
+	for rows.Next() {
+		var existing string
+		if err := rows.Scan(&existing); err != nil {
+			return "", err
+		}
+		taken[existing] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if _, ok := taken[name]; !ok {
 		return name, nil
 	}
 	for k := 2; k <= 10000; k++ {
 		candidate := fmt.Sprintf("%s (%d)", name, k)
-		taken, err := FolderSiblingHasName(db, channelID, parentID, candidate)
-		if err != nil {
-			return "", err
-		}
-		if !taken {
+		if _, ok := taken[candidate]; !ok {
 			return candidate, nil
 		}
 	}
@@ -681,22 +713,30 @@ func CollectDescendants(db *sql.DB, channelID int64, folderID string) (folderIDs
 }
 
 func IsAncestor(db *sql.DB, channelID int64, ancestor, candidate string) (bool, error) {
-	cur := candidate
-	visited := make(map[string]bool)
-	for cur != RootParent {
-		if cur == ancestor {
-			return true, nil
-		}
-		if visited[cur] {
-			return false, nil
-		}
-		visited[cur] = true
-
-		next, err := FolderParent(db, channelID, cur)
-		if err != nil {
-			return false, nil
-		}
-		cur = next
+	if ancestor == "" || candidate == "" || candidate == RootParent {
+		return false, nil
 	}
-	return false, nil
+	var found int
+	err := db.QueryRow(`
+		WITH RECURSIVE ancestors(id, parent_id, path) AS (
+			SELECT id, parent_id, ',' || id || ','
+			FROM folders
+			WHERE channel_id = ?1 AND id = ?2 AND tombstoned = 0
+			UNION ALL
+			SELECT f.id, f.parent_id, ancestors.path || f.id || ','
+			FROM folders f
+			JOIN ancestors ON f.id = ancestors.parent_id
+			WHERE f.channel_id = ?1
+			  AND f.tombstoned = 0
+			  AND instr(ancestors.path, ',' || f.id || ',') = 0
+		)
+		SELECT 1 FROM ancestors WHERE id = ?3 LIMIT 1
+	`, channelID, candidate, ancestor).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/backend/services/file/service.go
+++ b/backend/services/file/service.go
@@ -985,6 +985,7 @@ func (s *Service) PreviewFile(ctx context.Context, channelID int64, msgID int) (
 			if _, err := tdcrypto.DecryptStream(&buf, &plain, masterKey); err != nil {
 				return errPreviewDownloadFailed
 			}
+			buf = bytes.Buffer{}
 			s.emitEvent("preview_progress", msgID, 100.0)
 			payload, err = previewPayloadFromBytes(plain.Bytes(), mimeType)
 			return err

--- a/backend/services/file/thumbnail.go
+++ b/backend/services/file/thumbnail.go
@@ -149,6 +149,7 @@ func (s *Service) generateThumbnail(ctx context.Context, channelID int64, msgID 
 		if _, err := tdcrypto.DecryptStream(&buf, &plain, masterKey); err != nil {
 			return nil, errPreviewDownloadFailed
 		}
+		buf = bytes.Buffer{}
 		source = plain.Bytes()
 	} else {
 		source = buf.Bytes()

--- a/backend/services/read/service.go
+++ b/backend/services/read/service.go
@@ -112,34 +112,32 @@ func (s *Service) Search(channelID int64, query string, limit int) ([]SearchResu
 		return []SearchResult{}, nil
 	}
 
-	allFolders, err := projection.ListAllFolders(s.DB, channelID)
-	if err != nil {
-		return nil, err
-	}
-	folderMap := make(map[string]projection.FolderSlim, len(allFolders))
-	for _, f := range allFolders {
-		if f.ID != "" {
-			folderMap[f.ID] = f
-		}
-	}
-
 	hits, err := projection.Search(s.DB, channelID, query, limit)
 	if err != nil {
 		return nil, err
 	}
 
+	pathCache := make(map[string]projection.FolderSlim, len(hits))
 	results := make([]SearchResult, 0, len(hits))
 	for _, h := range hits {
 		switch h.Type {
 		case "folder":
+			path, err := buildFolderPathLazy(s.DB, channelID, h.ID, pathCache)
+			if err != nil {
+				return nil, err
+			}
 			results = append(results, SearchResult{
 				Type:     "folder",
 				ID:       h.ID,
 				Name:     h.Name,
 				ParentID: h.ParentID,
-				Path:     buildFolderPath(folderMap, h.ID),
+				Path:     path,
 			})
 		case "file":
+			path, err := buildFolderPathLazy(s.DB, channelID, h.ParentID, pathCache)
+			if err != nil {
+				return nil, err
+			}
 			results = append(results, SearchResult{
 				Type:          "file",
 				ID:            fmt.Sprintf("%d", h.MsgID),
@@ -150,7 +148,7 @@ func (s *Service) Search(channelID int64, query string, limit int) ([]SearchResu
 				UploaderID:    h.UploaderID,
 				Encrypted:     h.Encrypted,
 				PlaintextSize: h.PlaintextSize,
-				Path:          buildFolderPath(folderMap, h.ParentID),
+				Path:          path,
 			})
 		}
 	}
@@ -335,4 +333,41 @@ func buildFolderPath(folders map[string]projection.FolderSlim, folderID string) 
 		names[i], names[j] = names[j], names[i]
 	}
 	return "My Drive / " + strings.Join(names, " / ")
+}
+
+func buildFolderPathLazy(db *sql.DB, channelID int64, folderID string, cache map[string]projection.FolderSlim) (string, error) {
+	folderID = strings.TrimSpace(folderID)
+	if folderID == projection.RootParent {
+		return "My Drive", nil
+	}
+	names := make([]string, 0, 8)
+	visited := make(map[string]bool)
+	cur := folderID
+	for cur != projection.RootParent && !visited[cur] {
+		visited[cur] = true
+		folder, ok := cache[cur]
+		if !ok {
+			var found bool
+			var err error
+			folder, found, err = projection.FolderByID(db, channelID, cur)
+			if err != nil {
+				return "", err
+			}
+			if !found {
+				break
+			}
+			cache[cur] = folder
+		}
+		if name := strings.TrimSpace(folder.Name); name != "" {
+			names = append(names, name)
+		}
+		cur = strings.TrimSpace(folder.ParentID)
+	}
+	if len(names) == 0 {
+		return "My Drive", nil
+	}
+	for i, j := 0, len(names)-1; i < j; i, j = i+1, j-1 {
+		names[i], names[j] = names[j], names[i]
+	}
+	return "My Drive / " + strings.Join(names, " / "), nil
 }

--- a/backend/sync/sync.go
+++ b/backend/sync/sync.go
@@ -27,6 +27,11 @@ const (
 	maxFloodWaitSleep   = 60 * time.Second
 )
 
+type historyPlan struct {
+	upperBounds []int64
+	highestSeen int64
+}
+
 type Engine struct {
 	db    *sql.DB
 	tg    tgclient.Client
@@ -111,57 +116,11 @@ func (e *Engine) Incremental(ctx context.Context, channelID int64) error {
 		return err
 	}
 
-	var allParsed []ParsedMessage
-	highestSeen := watermark
-	offsetID := int64(0)
-	for {
-		page, err := e.getHistory(ctx, channelID, peer, watermark, offsetID, defaultPageSize)
-		if err != nil {
-			return fmt.Errorf("sync: get history: %w", err)
-		}
-		if len(page) == 0 {
-			break
-		}
-		lowestInPage := page[0].MsgID
-		for _, m := range page {
-			if m.MsgID < lowestInPage {
-				lowestInPage = m.MsgID
-			}
-			if m.MsgID > highestSeen {
-				highestSeen = m.MsgID
-			}
-		}
-		allParsed = append(allParsed, ParseHistoryPage(page)...)
-		if len(page) < defaultPageSize {
-			break
-		}
-		if offsetID == lowestInPage {
-			break
-		}
-		offsetID = lowestInPage
+	plan, err := e.planHistory(ctx, channelID, peer, watermark)
+	if err != nil {
+		return err
 	}
-
-	SortAscending(allParsed)
-	applied := watermark
-	for _, p := range allParsed {
-		if _, err := projection.ProjectFromOp(e.db, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
-			// Persist progress so a re-run resumes past what already applied
-			// instead of re-fetching the whole channel from the old watermark.
-			if applied > watermark {
-				_ = writeWatermark(e.db, channelID, applied)
-			}
-			return fmt.Errorf("sync: project msg=%d: %w", p.MsgID, err)
-		}
-		if p.MsgID > applied {
-			applied = p.MsgID
-		}
-	}
-	if highestSeen > watermark {
-		if err := writeWatermark(e.db, channelID, highestSeen); err != nil {
-			return err
-		}
-	}
-	return nil
+	return e.applyHistoryPlan(ctx, channelID, peer, watermark, plan)
 }
 
 // InitialSyncEmptyChannel paginates the full history of a channel that has
@@ -180,24 +139,35 @@ func (e *Engine) InitialSyncEmptyChannel(ctx context.Context, channelID int64) e
 	if !empty {
 		return projection.ErrChannelNotEmpty
 	}
+	watermark := int64(0)
 
 	peer, err := e.peers.ResolvePeer(ctx, channelID)
 	if err != nil {
 		return fmt.Errorf("sync: resolve peer: %w", err)
 	}
 
-	var allParsed []ParsedMessage
-	var highestSeen int64
+	plan, err := e.planHistory(ctx, channelID, peer, watermark)
+	if err != nil {
+		return err
+	}
+	if len(plan.upperBounds) == 0 {
+		return markInitialSyncDone(e.db, channelID, watermark)
+	}
+	return e.applyInitialHistoryPlan(ctx, channelID, peer, watermark, plan)
+}
+
+func (e *Engine) planHistory(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64) (historyPlan, error) {
+	var lowestPerPage []int64
+	highestSeen := minID
 	offsetID := int64(0)
 	for {
-		page, err := e.getHistory(ctx, channelID, peer, 0, offsetID, defaultPageSize)
+		page, err := e.getHistory(ctx, channelID, peer, minID, offsetID, defaultPageSize)
 		if err != nil {
-			return fmt.Errorf("sync: get history: %w", err)
+			return historyPlan{}, fmt.Errorf("sync: get history: %w", err)
 		}
 		if len(page) == 0 {
 			break
 		}
-		// Backward paging: lowest msg_id is at the end of the page.
 		var lowestInPage int64 = page[0].MsgID
 		for _, m := range page {
 			if m.MsgID < lowestInPage {
@@ -207,28 +177,106 @@ func (e *Engine) InitialSyncEmptyChannel(ctx context.Context, channelID int64) e
 				highestSeen = m.MsgID
 			}
 		}
-		allParsed = append(allParsed, ParseHistoryPage(page)...)
+		lowestPerPage = append(lowestPerPage, lowestInPage)
 		if len(page) < defaultPageSize {
+			break
+		}
+		if offsetID == lowestInPage {
 			break
 		}
 		offsetID = lowestInPage
 	}
 
-	SortAscending(allParsed)
+	if len(lowestPerPage) == 0 {
+		return historyPlan{highestSeen: highestSeen}, nil
+	}
+	upperBounds := make([]int64, len(lowestPerPage))
+	upperBounds[0] = highestSeen + 1
+	for i := 1; i < len(lowestPerPage); i++ {
+		upperBounds[i] = lowestPerPage[i-1]
+	}
+	return historyPlan{upperBounds: upperBounds, highestSeen: highestSeen}, nil
+}
 
+func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan) error {
+	for i := len(plan.upperBounds) - 1; i >= 0; i-- {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, err := e.getHistory(ctx, channelID, peer, minID, plan.upperBounds[i], defaultPageSize)
+		if err != nil {
+			return fmt.Errorf("sync: get history: %w", err)
+		}
+		pageWatermark := minID
+		filtered := page[:0]
+		for _, m := range page {
+			if m.MsgID <= minID || m.MsgID > plan.highestSeen {
+				continue
+			}
+			filtered = append(filtered, m)
+			if m.MsgID > pageWatermark {
+				pageWatermark = m.MsgID
+			}
+		}
+		parsed := ParseHistoryPage(filtered)
+		SortAscending(parsed)
+
+		tx, err := e.db.Begin()
+		if err != nil {
+			return fmt.Errorf("sync: begin projection: %w", err)
+		}
+		for _, p := range parsed {
+			if _, err := projection.ProjectFromOpTx(tx, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("sync: project msg=%d: %w", p.MsgID, err)
+			}
+		}
+		if pageWatermark > minID {
+			if err := writeWatermarkTx(tx, channelID, pageWatermark); err != nil {
+				_ = tx.Rollback()
+				return err
+			}
+			minID = pageWatermark
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("sync: commit projection: %w", err)
+		}
+	}
+	return nil
+}
+
+func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan) error {
 	tx, err := e.db.Begin()
 	if err != nil {
 		return fmt.Errorf("sync: begin initial projection: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	for _, p := range allParsed {
-		if _, err := projection.ProjectFromOpTx(tx, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
-			return fmt.Errorf("sync: project msg=%d: %w", p.MsgID, err)
+	for i := len(plan.upperBounds) - 1; i >= 0; i-- {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		page, err := e.getHistory(ctx, channelID, peer, minID, plan.upperBounds[i], defaultPageSize)
+		if err != nil {
+			return fmt.Errorf("sync: get history: %w", err)
+		}
+		filtered := page[:0]
+		for _, m := range page {
+			if m.MsgID <= minID || m.MsgID > plan.highestSeen {
+				continue
+			}
+			filtered = append(filtered, m)
+		}
+		parsed := ParseHistoryPage(filtered)
+		SortAscending(parsed)
+		for _, p := range parsed {
+			if _, err := projection.ProjectFromOpTx(tx, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
+				return fmt.Errorf("sync: project msg=%d: %w", p.MsgID, err)
+			}
 		}
 	}
 
-	if err := markInitialSyncDoneTx(tx, channelID, highestSeen); err != nil {
+	if err := markInitialSyncDoneTx(tx, channelID, plan.highestSeen); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
@@ -251,6 +299,11 @@ func readWatermark(db *sql.DB, channelID int64) (int64, error) {
 
 func writeWatermark(db *sql.DB, channelID int64, msgID int64) error {
 	_, err := db.Exec(`UPDATE channels SET last_synced_msg = ? WHERE channel_id = ?`, msgID, channelID)
+	return err
+}
+
+func writeWatermarkTx(tx *sql.Tx, channelID int64, msgID int64) error {
+	_, err := tx.Exec(`UPDATE channels SET last_synced_msg = ? WHERE channel_id = ?`, msgID, channelID)
 	return err
 }
 

--- a/backend/tgclient/getfile_limiter.go
+++ b/backend/tgclient/getfile_limiter.go
@@ -74,16 +74,22 @@ func AcquireBackgroundGetFileSlots(ctx context.Context, n int) (func(), error) {
 
 func acquireGlobalGetFileSlotsNoQueue(ctx context.Context, weight int64) (func(), error) {
 	weight = int64(clampGetFileWeight(int(weight), MaxConcurrentGetFile))
+	timer := time.NewTimer(backgroundGlobalRetry)
+	defer timer.Stop()
+	first := true
 	for {
 		if getFileSlots.TryAcquire(weight) {
 			return func() {
 				getFileSlots.Release(weight)
 			}, nil
 		}
-		timer := time.NewTimer(backgroundGlobalRetry)
+		if first {
+			first = false
+		} else {
+			timer.Reset(backgroundGlobalRetry)
+		}
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			return nil, ctx.Err()
 		case <-timer.C:
 		}

--- a/backend/thumbnail/cache.go
+++ b/backend/thumbnail/cache.go
@@ -1,8 +1,10 @@
 package thumbnail
 
 import (
+	"container/list"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -31,12 +33,14 @@ type Cache struct {
 	maxBytes int64
 
 	mu      sync.Mutex
-	entries map[string]entry
+	entries map[string]*list.Element
+	lru     *list.List
 	used    int64
 	inited  bool
 }
 
 type entry struct {
+	name string
 	size int64
 	used time.Time
 }
@@ -47,7 +51,8 @@ func NewCache(dir string, maxBytes int64) *Cache {
 	return &Cache{
 		dir:      dir,
 		maxBytes: maxBytes,
-		entries:  make(map[string]entry),
+		entries:  make(map[string]*list.Element),
+		lru:      list.New(),
 	}
 }
 
@@ -79,10 +84,7 @@ func (c *Cache) Get(key string) ([]byte, bool) {
 
 	now := time.Now()
 	c.mu.Lock()
-	if e, ok := c.entries[name]; ok {
-		e.used = now
-		c.entries[name] = e
-	}
+	c.touchLocked(name, now)
 	c.mu.Unlock()
 	_ = os.Chtimes(path, now, now)
 	return data, true
@@ -103,10 +105,6 @@ func (c *Cache) Has(key string) bool {
 		c.mu.Unlock()
 		return false
 	}
-	now := time.Now()
-	e := c.entries[name]
-	e.used = now
-	c.entries[name] = e
 	c.mu.Unlock()
 
 	path := filepath.Join(c.dir, name)
@@ -116,6 +114,10 @@ func (c *Cache) Has(key string) bool {
 		c.mu.Unlock()
 		return false
 	}
+	now := time.Now()
+	c.mu.Lock()
+	c.touchLocked(name, now)
+	c.mu.Unlock()
 	_ = os.Chtimes(path, now, now)
 	return true
 }
@@ -164,10 +166,9 @@ func (c *Cache) Put(key string, data []byte) error {
 
 	c.mu.Lock()
 	c.ensureInitLocked()
-	if old, ok := c.entries[name]; ok {
-		c.used -= old.size
-	}
-	c.entries[name] = entry{size: int64(len(data)), used: now}
+	c.forgetLocked(name)
+	elem := c.lru.PushFront(entry{name: name, size: int64(len(data)), used: now})
+	c.entries[name] = elem
 	c.used += int64(len(data))
 	c.evictLocked()
 	c.mu.Unlock()
@@ -187,6 +188,7 @@ func (c *Cache) ensureInitLocked() {
 	if err != nil {
 		return // dir not created yet; nothing cached
 	}
+	var found []entry
 	for _, de := range dirEntries {
 		if de.IsDir() {
 			continue
@@ -203,8 +205,15 @@ func (c *Cache) ensureInitLocked() {
 		if err != nil {
 			continue
 		}
-		c.entries[fname] = entry{size: info.Size(), used: info.ModTime()}
-		c.used += info.Size()
+		found = append(found, entry{name: fname, size: info.Size(), used: info.ModTime()})
+	}
+	sort.Slice(found, func(i, j int) bool {
+		return found[i].used.After(found[j].used)
+	})
+	for _, e := range found {
+		elem := c.lru.PushBack(e)
+		c.entries[e.name] = elem
+		c.used += e.size
 	}
 	c.evictLocked()
 }
@@ -214,27 +223,34 @@ func (c *Cache) ensureInitLocked() {
 // thumbnail is kept rather than deleted on the spot. Must hold c.mu.
 func (c *Cache) evictLocked() {
 	for c.used > c.maxBytes && len(c.entries) > 1 {
-		oldestName := ""
-		var oldestUsed time.Time
-		for name, e := range c.entries {
-			if oldestName == "" || e.used.Before(oldestUsed) {
-				oldestName = name
-				oldestUsed = e.used
-			}
-		}
-		if oldestName == "" {
+		elem := c.lru.Back()
+		if elem == nil {
 			return
 		}
-		_ = os.Remove(filepath.Join(c.dir, oldestName))
-		c.forgetLocked(oldestName)
+		e := elem.Value.(entry)
+		_ = os.Remove(filepath.Join(c.dir, e.name))
+		c.forgetLocked(e.name)
 	}
 }
 
 func (c *Cache) forgetLocked(name string) {
-	if e, ok := c.entries[name]; ok {
+	if elem, ok := c.entries[name]; ok {
+		e := elem.Value.(entry)
 		c.used -= e.size
+		c.lru.Remove(elem)
 		delete(c.entries, name)
 	}
+}
+
+func (c *Cache) touchLocked(name string, now time.Time) {
+	elem, ok := c.entries[name]
+	if !ok {
+		return
+	}
+	e := elem.Value.(entry)
+	e.used = now
+	elem.Value = e
+	c.lru.MoveToFront(elem)
 }
 
 // fileName maps an arbitrary key to a safe cache filename. Keys are produced


### PR DESCRIPTION
- remove redundant media block-cache copies and pool HTTP range buffers
- make thumbnail disk cache eviction O(1) LRU
- chunk sync projection work instead of retaining full parsed history / one tx per message
- reduce preview buffer lifetime, search breadcrumb scans, folder-name/ancestor queries, replay-log copies, and small hot-path allocations

- cached media blocks are now owned by the block cache and treated as immutable
- initial sync remains atomic; incremental sync advances by page-sized transactions
