### PR TITLE
Migrate file list rendering to Svelte

### DIFF
--- a/frontend/src/modules/file-list.ts
+++ b/frontend/src/modules/file-list.ts
@@ -1,8 +1,8 @@
 // File list rendering for TDrive frontend
 
 import { state, resetFolderCaches } from '../state';
-import { icons } from '../constants';
-import { escapeHtml, splitNameAndExt, formatDate, formatBytes } from '../utils';
+import { splitNameAndExt, formatDate, formatBytes } from '../utils';
+import { tick } from 'svelte';
 import { clearSelection, handleRowSelection, selectRow, getRowKey } from './selection';
 import { openRenameModal } from './modals/rename';
 import { openDeleteModal } from './modals/delete';
@@ -19,7 +19,10 @@ import { populateUploaderChips, uploaderChipHTML } from './uploaders';
 import { renderGallery, setPhotosMode } from './gallery';
 import { isVideoFile } from './media-types';
 import { openVideoModal } from './modals/video';
-import FileState from '../ui/file-list/FileState.svelte';
+import FileList from '../ui/file-list/FileList.svelte';
+import { showFileListRows, showFileListState } from '../ui/file-list/file-list-store';
+import { setActiveFileRowKey } from '../ui/file-list/row-state-store';
+import type { FileListAction, FileListFileRow, FileListRow, FolderListRow, PendingFolderListRow } from '../ui/file-list/types';
 import { mountSvelte, type SvelteMountHandle } from '../ui';
 
 // dragItemsFor returns the items to move for a drag started on `row`: the whole
@@ -89,53 +92,143 @@ export function fillUploaderSlot(row: HTMLElement | null, file: any) {
 // Tracks the folder whose rows are currently rendered, so a same-folder
 // re-render can restore the scroll position instead of jumping to the top.
 let lastRenderedFolderId: string | null = null;
-let fileStateHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
+let fileListHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
 
 export function resetFileListScrollRestore() {
     lastRenderedFolderId = null;
 }
 
-function destroyFileStateView() {
-    const handle = fileStateHandle;
-    if (!handle) return;
-    fileStateHandle = null;
-    void handle.destroy();
+function ensureFileListView(list: HTMLElement) {
+    if (fileListHandle) return;
+    list.replaceChildren();
+    fileListHandle = mountSvelte(FileList, {
+        target: list,
+        props: {},
+    });
 }
 
 type FileStateKind = "loading" | "empty" | "error";
 
-function renderFileState(
+export function renderFileState(
     list: HTMLElement,
     kind: FileStateKind,
     title: string,
     body = "",
     action?: { label: string; onClick: () => void },
 ) {
-    destroyFileStateView();
-    list.replaceChildren();
-    fileStateHandle = mountSvelte(FileState, {
-        target: list,
-        props: {
-            kind,
-            title,
-            body,
-            actionLabel: action?.label ?? '',
-            onAction: action?.onClick,
-        },
+    ensureFileListView(list);
+    showFileListState({
+        stateKind: kind,
+        title,
+        body,
+        actionLabel: action?.label ?? '',
+        onAction: action?.onClick,
     });
 }
 
-function rowLabel(row: HTMLElement) {
-    const type = row.dataset.type === "folder" ? "Folder" : "File";
-    const name = row.dataset.name || "Untitled";
-    return `${type}: ${name}`;
+function afterFileListPaint(list: HTMLElement, callback: () => void) {
+    void tick().then(() => {
+        if (!document.body.contains(list)) return;
+        callback();
+    });
 }
 
-export function prepareDriveRow(row: HTMLElement) {
-    row.setAttribute("role", "option");
-    row.setAttribute("aria-selected", row.classList.contains("is-selected") ? "true" : "false");
-    row.setAttribute("aria-label", rowLabel(row));
-    row.tabIndex = -1;
+export function renderFileListRows(list: HTMLElement, rows: FileListRow[], afterRender?: () => void) {
+    ensureFileListView(list);
+    showFileListRows(rows);
+    if (afterRender) afterFileListPaint(list, afterRender);
+}
+
+function folderAction(): FileListAction {
+    return {
+        kind: "open",
+        className: "open-folder",
+        title: "Open",
+        label: "Open folder",
+    };
+}
+
+function fileActions(name: string): FileListAction[] {
+    const actions: FileListAction[] = [];
+    if (isVideoFile(name || "")) {
+        actions.push({
+            kind: "play",
+            className: "play-video",
+            title: "Play",
+            label: "Play video",
+        });
+    }
+    actions.push({
+        kind: "download",
+        className: "download",
+        title: "Download",
+        label: "Download",
+    });
+    return actions;
+}
+
+export function buildFolderRow(folder: any, parentId: string, overrides: Partial<FolderListRow> = {}): FolderListRow {
+    const id = String(folder?.id || overrides.id || "");
+    const name = String(folder?.name || overrides.name || "Folder");
+    return {
+        kind: "folder",
+        key: overrides.key || `folder:${id}`,
+        selectionKey: overrides.selectionKey || `folder:${id}`,
+        id,
+        name,
+        parentId: String(overrides.parentId ?? parentId ?? ""),
+        metaLabel: overrides.metaLabel ?? "—",
+        sizeLabel: overrides.sizeLabel ?? "…",
+        ariaLabel: overrides.ariaLabel ?? `Folder: ${name}`,
+        actions: overrides.actions ?? [folderAction()],
+        onClick: overrides.onClick,
+        onDoubleClick: overrides.onDoubleClick,
+    };
+}
+
+export function buildFileRow(file: any, parentId: string, overrides: Partial<FileListFileRow> = {}): FileListFileRow {
+    const name = String(file?.name || overrides.name || "File");
+    const { base, ext } = splitNameAndExt(name);
+    const id = String(file?.id ?? overrides.id ?? "");
+    const size = Number(file?.size ?? overrides.size ?? 0);
+    const uploadTime = Number(file?.date ?? file?.uploadTime ?? overrides.uploadTime ?? 0);
+    const source = String(file?.source ?? overrides.source ?? "fs");
+    const uploaderID = Number(file?.uploaderID ?? file?.uploaderId ?? overrides.uploaderID ?? 0);
+    const encrypted = Boolean(file?.encrypted ?? overrides.encrypted ?? false);
+    const canDelete = Boolean(file?.canDelete ?? overrides.canDelete ?? canOwnerActOnFile(file));
+    const canRename = Boolean(file?.canRename ?? overrides.canRename ?? canDelete);
+    return {
+        kind: "file",
+        key: overrides.key || `file:${source}:${id}`,
+        selectionKey: overrides.selectionKey || `file:${id}`,
+        id,
+        name,
+        baseName: overrides.baseName ?? base,
+        ext: overrides.ext ?? ext,
+        source,
+        parentId: String(overrides.parentId ?? parentId ?? ""),
+        size,
+        metaLabel: overrides.metaLabel ?? formatDate(uploadTime),
+        sizeLabel: overrides.sizeLabel ?? formatBytes(size),
+        ariaLabel: overrides.ariaLabel ?? `File: ${name}`,
+        uploaderID,
+        uploadTime,
+        encrypted,
+        canDelete,
+        canRename,
+        actions: overrides.actions ?? fileActions(name),
+        onClick: overrides.onClick,
+        onDoubleClick: overrides.onDoubleClick,
+    };
+}
+
+function buildPendingFolderRow(tempId: string, name: string): PendingFolderListRow {
+    return {
+        kind: "pending-folder",
+        key: `pending-folder:${tempId}`,
+        tempId,
+        name,
+    };
 }
 
 function interactiveRows(list: HTMLElement = document.getElementById("file-list") as HTMLElement) {
@@ -146,21 +239,26 @@ function interactiveRows(list: HTMLElement = document.getElementById("file-list"
 function setFocusedRow(row: HTMLElement | null, { preventScroll = true } = {}) {
     const list = document.getElementById("file-list") as HTMLElement | null;
     if (!list || !row) return;
-    for (const item of interactiveRows(list)) {
-        item.tabIndex = item === row ? 0 : -1;
-        item.classList.toggle("is-keyboard-active", item === row);
-    }
-    row.focus({ preventScroll });
+    setActiveFileRowKey(getRowKey(row));
+    void tick().then(() => {
+        if (!document.body.contains(row)) return;
+        row.focus({ preventScroll });
+    });
 }
 
 export function syncDriveRowTabStops(list: HTMLElement, preferred?: HTMLElement | null) {
     const rows = interactiveRows(list);
-    if (!rows.length) return;
-    const target = preferred && rows.includes(preferred) ? preferred : rows[0];
-    for (const row of rows) {
-        row.tabIndex = row === target ? 0 : -1;
-        row.classList.toggle("is-keyboard-active", false);
+    if (!rows.length) {
+        setActiveFileRowKey("");
+        return;
     }
+    const current = list.querySelector<HTMLElement>('.drive-row[tabindex="0"]');
+    const target = preferred && rows.includes(preferred)
+        ? preferred
+        : current && rows.includes(current)
+            ? current
+            : rows[0];
+    setActiveFileRowKey(getRowKey(target));
 }
 
 function activeRowFromEventTarget(target: EventTarget | null) {
@@ -397,195 +495,63 @@ export function refreshFiles() {
                 return;
             }
 
-            const fragment = document.createDocumentFragment();
+            const rows: FileListRow[] = [];
 
             // Pending CreateFolder ghost rows: rendered before real folders
             // so the just-clicked entry shows up at the top until the
             // backend confirms it.
             for (const op of pendingForParent) {
-                fragment.appendChild(buildPendingFolderRow(op.tempId, op.name));
+                rows.push(buildPendingFolderRow(op.tempId, op.name));
             }
 
             folders.forEach((folder) => {
-                const row = document.createElement("div");
-                row.className = "file-row drive-row folder-row";
-                row.dataset.type = "folder";
-                row.dataset.id = folder.id;
-                row.dataset.name = folder.name;
-                row.dataset.parentId = requestedFolderId;
-                prepareDriveRow(row);
-
-                row.innerHTML = `
-                    <div class="row-name">
-                        <span class="folder-chip" aria-hidden="true">${icons.folder}</span>
-                        ${escapeHtml(folder.name)}
-                    </div>
-                    <div class="row-meta">—</div>
-                    <div class="row-meta folder-size">…</div>
-                    <div class="row-actions">
-                        <button class="action-icon open-folder" type="button" title="Open">${icons.open}</button>
-                    </div>
-                `;
-
-                const folderNameEl = row.querySelector(".row-name") as HTMLElement | null;
-                if (folderNameEl) {
-                    folderNameEl.draggable = true;
-                    folderNameEl.addEventListener("dragstart", (e) => {
-                        const selection = window.getSelection?.();
-                        if (selection) selection.removeAllRanges();
-
-                        if (e.dataTransfer) {
-                            e.dataTransfer.effectAllowed = "move";
-                            try {
-                                e.dataTransfer.setData("text/plain", "tdrive-move");
-                            } catch {}
-                        }
-
-                        const folderID = String(folder.id || row.dataset.id || "");
-                        startDrag(row, {
-                            type: "folder",
-                            id: folderID,
-                            name: folder.name || row.dataset.name || "Folder",
-                            parentId: requestedFolderId,
-                            row,
-                        }, requestedFolderId);
-                    });
-                    folderNameEl.addEventListener("dragend", endRowDrag);
-                }
-
-                row.addEventListener("dragover", (e) => {
-                    if (!state.dragState) return;
-                    const allowed = canDropOnFolder(folder.id);
-                    setDropHighlight(row, allowed);
-                    if (e.dataTransfer) e.dataTransfer.dropEffect = allowed ? "move" : "none";
-                    if (allowed) e.preventDefault();
-                });
-                row.addEventListener("dragleave", (e) => {
-                    if (e.relatedTarget && row.contains(e.relatedTarget as Node)) return;
-                    if (state.dragOverEl === row) {
-                        row.classList.remove("drop-target");
-                        row.classList.remove("drop-denied");
-                        state.dragOverEl = null;
-                    }
-                });
-                row.addEventListener("drop", async (e) => {
-                    if (!state.dragState) return;
-                    const allowed = canDropOnFolder(folder.id);
-                    if (!allowed) return;
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (state.dragOverEl === row) state.dragOverEl = null;
-                    row.classList.remove("drop-target");
-                    row.classList.remove("drop-denied");
-                    await performDropMove(folder.id);
-                });
-
-                fragment.appendChild(row);
-
+                rows.push(buildFolderRow(folder, requestedFolderId));
             });
 
             files.forEach((file: any) => {
-                const { base, ext } = splitNameAndExt(file.name);
-                const row = document.createElement("div");
-                row.className = "file-row drive-row";
-                row.dataset.type = "file";
-                row.dataset.id = String(file.id);
-                row.dataset.name = String(file.name || "");
-                row.dataset.source = String(file.source || "fs");
-                row.dataset.size = String(file.size || 0);
-                row.dataset.parentId = requestedFolderId;
-                row.dataset.uploaderId = String(file.uploaderID || 0);
-                row.dataset.uploadTime = String(file.date || 0);
-                row.dataset.encrypted = file.encrypted ? "true" : "false";
                 const ownerOnly = canOwnerActOnFile(file);
-                row.dataset.canDelete = ownerOnly ? "true" : "false";
-                row.dataset.canRename = ownerOnly ? "true" : "false";
-                const playable = isVideoFile(file.name || "");
-                prepareDriveRow(row);
-
-                const lockBadge = file.encrypted
-                    ? `<span class="file-lock-badge" title="Encrypted" aria-label="Encrypted"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 11h14a1 1 0 011 1v8a1 1 0 01-1 1H5a1 1 0 01-1-1v-8a1 1 0 011-1z"/><path stroke-linecap="round" stroke-linejoin="round" d="M8 11V7a4 4 0 118 0v4"/></svg></span>`
-                    : '';
-                row.innerHTML = `
-                    <div class="row-name">
-                        <span class="file-ext-text" aria-hidden="true">${escapeHtml(ext)}</span>
-                        ${lockBadge}${escapeHtml(base)}
-                        <span class="uploader-chip" data-uploader-slot></span>
-                    </div>
-                    <div class="row-meta">${formatDate(file.date)}</div>
-                    <div class="row-meta">${formatBytes(file.size)}</div>
-                    <div class="row-actions">
-                        ${playable ? `<button class="action-icon play-video" type="button" title="Play">${icons.play}</button>` : ""}
-                        <button class="action-icon download" type="button" title="Download">${icons.download}</button>
-                    </div>
-                `;
-                fillUploaderSlot(row, {
-                    uploaderID: file.uploaderID,
-                    uploadTime: file.date,
-                });
-
-                const nameEl = row.querySelector(".row-name") as HTMLElement | null;
-                if (nameEl) {
-                    nameEl.draggable = true;
-                    nameEl.addEventListener("dragstart", (e) => {
-                        const selection = window.getSelection?.();
-                        if (selection) selection.removeAllRanges();
-
-                        if (e.dataTransfer) {
-                            e.dataTransfer.effectAllowed = "move";
-                            try {
-                                e.dataTransfer.setData("text/plain", "tdrive-move");
-                            } catch {}
-                        }
-
-                        startDrag(row, {
-                            type: "file",
-                            id: Number(file.id),
-                            name: file.name || row.dataset.name || "File",
-                            size: Number(file.size || row.dataset.size || 0),
-                            parentId: requestedFolderId,
-                            source: file.source || row.dataset.source || "fs",
-                            row,
-                        }, requestedFolderId);
-                    });
-                    nameEl.addEventListener("dragend", endRowDrag);
-                }
-                fragment.appendChild(row);
+                rows.push(buildFileRow(file, requestedFolderId, {
+                    canDelete: ownerOnly,
+                    canRename: ownerOnly,
+                }));
             });
 
-            destroyFileStateView();
-            list.replaceChildren(fragment);
-            syncDriveRowTabStops(list);
-            fillVisibleFolderSizes(folders, requestedFolderId, folderEpoch, list);
+            renderFileListRows(list, rows, () => {
+                if (state.folderSizeEpoch !== folderEpoch) return;
+                if (state.currentFolderId !== requestedFolderId) return;
 
-            // Restore prior scroll on a same-folder re-render. Before
-            // pendingFocus so a just-uploaded/renamed file can still scroll
-            // itself into view and win.
-            lastRenderedFolderId = requestedFolderId;
-            if (keepScrollForRender && state.currentFolderId === requestedFolderId) {
-                list.scrollTop = scrollTopForRender;
-            }
+                syncDriveRowTabStops(list);
+                fillVisibleFolderSizes(folders, requestedFolderId, folderEpoch, list);
 
-            if (state.pendingFocus && state.pendingFocus.type === "file") {
-                const targetID = String(state.pendingFocus.id || "");
-                const targetRow = targetID ? list.querySelector(`.drive-row[data-type="file"][data-id="${targetID}"]`) : null;
-                state.pendingFocus = null;
-                if (targetRow) {
-                    const rows = Array.from(list.querySelectorAll(".drive-row"));
-                    const idx = rows.indexOf(targetRow);
-                    clearSelection();
-                    if (idx >= 0) selectRow(targetRow, idx);
-                    setFocusedRow(targetRow as HTMLElement);
-                    try {
-                        targetRow.scrollIntoView({ block: "center" });
-                    } catch {}
+                // Restore prior scroll on a same-folder re-render. Before
+                // pendingFocus so a just-uploaded/renamed file can still scroll
+                // itself into view and win.
+                lastRenderedFolderId = requestedFolderId;
+                if (keepScrollForRender && state.currentFolderId === requestedFolderId) {
+                    list.scrollTop = scrollTopForRender;
                 }
-            }
 
-            // Resolve any missing uploader names and inject chips. Fire-
-            // and-forget — rows are already shown without chips and will
-            // get them populated within ~one round-trip.
-            populateUploaderChips(list);
+                if (state.pendingFocus && state.pendingFocus.type === "file") {
+                    const targetID = String(state.pendingFocus.id || "");
+                    const targetRow = targetID ? list.querySelector(`.drive-row[data-type="file"][data-id="${CSS.escape(targetID)}"]`) : null;
+                    state.pendingFocus = null;
+                    if (targetRow) {
+                        const interactive = Array.from(list.querySelectorAll(".drive-row"));
+                        const idx = interactive.indexOf(targetRow);
+                        clearSelection();
+                        if (idx >= 0) selectRow(targetRow, idx);
+                        setFocusedRow(targetRow as HTMLElement);
+                        try {
+                            targetRow.scrollIntoView({ block: "center" });
+                        } catch {}
+                    }
+                }
+
+                // Resolve any missing uploader names and inject chips. Fire-
+                // and-forget — rows are already shown without chips and will
+                // get them populated within ~one round-trip.
+                populateUploaderChips(list);
+            });
         };
 
         await finalize();
@@ -606,32 +572,9 @@ export function refreshFiles() {
     });
 }
 
-// buildPendingFolderRow renders an in-flight CreateFolder as a ghost row.
-// It looks like a real folder row but is dimmed and has no actions; click
-// is a no-op. Removed from the list once the Wails call resolves and
-// refreshFiles re-renders.
-function buildPendingFolderRow(tempId: string, name: string) {
-    const row = document.createElement("div");
-    row.className = "file-row drive-row folder-row pending-folder";
-    row.dataset.type = "pending-folder";
-    row.dataset.tempId = tempId;
-    row.title = "Creating…";
-    row.innerHTML = `
-        <div class="row-name">
-            <span class="folder-chip" aria-hidden="true">${icons.folder}</span>
-            ${escapeHtml(name)}
-            <span class="pending-indicator" aria-hidden="true">·</span>
-        </div>
-        <div class="row-meta">Creating…</div>
-        <div class="row-meta">—</div>
-        <div class="row-actions"></div>
-    `;
-    return row;
-}
-
 // Delegated row interactions. Listeners live on the #file-list container and
-// read each row's data-* attributes, so re-rendering rows costs no click
-// listener churn. Drag handlers are still attached per row for now.
+// read each row's data-* attributes, so re-rendering rows costs no listener
+// churn and Svelte can freely replace keyed rows.
 function isSearchMode() {
     return String(state.searchQuery || "").trim() !== "";
 }
@@ -773,6 +716,78 @@ function handleListDblClick(e: MouseEvent) {
     }
 }
 
+function handleListDragStart(e: DragEvent) {
+    const handle = (e.target as HTMLElement | null)?.closest?.(".row-name[draggable='true']") as HTMLElement | null;
+    const row = handle?.closest(".drive-row[data-type='folder'], .drive-row[data-type='file']") as HTMLElement | null;
+    if (!row) return;
+
+    const selection = window.getSelection?.();
+    if (selection) selection.removeAllRanges();
+
+    if (e.dataTransfer) {
+        e.dataTransfer.effectAllowed = "move";
+        try {
+            e.dataTransfer.setData("text/plain", "tdrive-move");
+        } catch {}
+    }
+
+    if (row.dataset.type === "folder") {
+        startDrag(row, {
+            type: "folder",
+            id: String(row.dataset.id || ""),
+            name: row.dataset.name || "Folder",
+            parentId: row.dataset.parentId || state.currentFolderId,
+            row,
+        }, row.dataset.parentId || state.currentFolderId);
+        return;
+    }
+
+    startDrag(row, {
+        type: "file",
+        id: Number(row.dataset.id || 0),
+        name: row.dataset.name || "File",
+        size: Number(row.dataset.size || 0),
+        parentId: row.dataset.parentId || state.currentFolderId,
+        source: row.dataset.source || "fs",
+        row,
+    }, row.dataset.parentId || state.currentFolderId);
+}
+
+function handleListDragOver(e: DragEvent) {
+    if (!state.dragState) return;
+    const row = (e.target as HTMLElement | null)?.closest?.(".drive-row[data-type='folder']") as HTMLElement | null;
+    if (!row) return;
+    const allowed = canDropOnFolder(row.dataset.id || "");
+    setDropHighlight(row, allowed);
+    if (e.dataTransfer) e.dataTransfer.dropEffect = allowed ? "move" : "none";
+    if (allowed) e.preventDefault();
+}
+
+function handleListDragLeave(e: DragEvent) {
+    const row = (e.target as HTMLElement | null)?.closest?.(".drive-row[data-type='folder']") as HTMLElement | null;
+    if (!row) return;
+    if (e.relatedTarget && row.contains(e.relatedTarget as Node)) return;
+    if (state.dragOverEl === row) {
+        row.classList.remove("drop-target");
+        row.classList.remove("drop-denied");
+        state.dragOverEl = null;
+    }
+}
+
+async function handleListDrop(e: DragEvent) {
+    if (!state.dragState) return;
+    const row = (e.target as HTMLElement | null)?.closest?.(".drive-row[data-type='folder']") as HTMLElement | null;
+    if (!row) return;
+    const folderID = row.dataset.id || "";
+    if (!canDropOnFolder(folderID)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    if (state.dragOverEl === row) state.dragOverEl = null;
+    row.classList.remove("drop-target");
+    row.classList.remove("drop-denied");
+    await performDropMove(folderID);
+}
+
 export function setupFileListWindowBindings() {
     window.refreshFiles = refreshFiles;
 
@@ -794,6 +809,13 @@ export function setupFileListWindowBindings() {
         list.addEventListener("click", handleListClick);
         list.addEventListener("dblclick", handleListDblClick);
         list.addEventListener("keydown", handleListKeyDown);
+        list.addEventListener("dragstart", handleListDragStart);
+        list.addEventListener("dragend", endRowDrag);
+        list.addEventListener("dragover", handleListDragOver);
+        list.addEventListener("dragleave", handleListDragLeave);
+        list.addEventListener("drop", (event) => {
+            void handleListDrop(event);
+        });
     }
 
     // Note: window.initDelete and window.initDeleteFolder are set up in main.js

--- a/frontend/src/modules/search.ts
+++ b/frontend/src/modules/search.ts
@@ -1,13 +1,21 @@
 import { state } from '../state';
-import { icons } from '../constants';
-import { escapeHtml, splitNameAndExt, formatBytes } from '../utils';
+import { formatBytes } from '../utils';
 import { clearSelection, handleRowSelection } from './selection';
 import { renderBreadcrumb } from './navigation';
-import { fillUploaderSlot, prepareDriveRow, resetFileListScrollRestore, syncDriveRowTabStops } from './file-list';
+import {
+    buildFileRow,
+    buildFolderRow,
+    fillUploaderSlot,
+    renderFileListRows,
+    renderFileState,
+    resetFileListScrollRestore,
+    syncDriveRowTabStops,
+} from './file-list';
 import { setPhotosMode } from './gallery';
 import { refreshFolderIndex } from './folder-index';
 import { populateUploaderChips } from './uploaders';
 import { isVideoFile } from './media-types';
+import type { FileListAction, FileListRow } from '../ui/file-list/types';
 
 let activeToken = 0;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -49,61 +57,41 @@ function renderSearchResults(results: any, query: any) {
     const list = document.getElementById("file-list");
     if (!list) return;
 
-    const rows = Array.isArray(results) ? results : [];
-    if (!rows.length) {
-        list.innerHTML = `<div class="search-empty" role="status">No results for "${escapeHtml(query)}"</div>`;
+    const resultRows = Array.isArray(results) ? results : [];
+    if (!resultRows.length) {
+        renderFileState(list, "empty", `No results for "${String(query || "")}"`);
         return;
     }
 
-    list.innerHTML = "";
-
-    rows.forEach((result) => {
+    const rows: FileListRow[] = [];
+    resultRows.forEach((result) => {
         const type = String(result?.type || "");
         if (type === "folder") {
-            const row = document.createElement("div");
-            row.className = "file-row drive-row folder-row";
-            row.dataset.type = "folder";
-            row.dataset.id = String(result.id || "");
-            row.dataset.name = String(result.name || "");
-            row.dataset.parentId = String(result.parent_id || "");
-            prepareDriveRow(row);
-
-            row.innerHTML = `
-                <div class="row-name">
-                    <span class="folder-chip" aria-hidden="true">${icons.folder}</span>
-                    ${escapeHtml(result.name || "Folder")}
-                </div>
-                <div class="row-meta">${escapeHtml(result.path || "My Drive")}</div>
-                <div class="row-meta">—</div>
-                <div class="row-actions">
-                    <button class="action-icon open-folder" type="button" title="Open">${icons.open}</button>
-                </div>
-            `;
-
-            row.addEventListener("dblclick", () => openFolderResult(String(result.id || "")));
-            row.addEventListener("click", (e) => {
-                if ((e.target as HTMLElement).closest("button.open-folder")) return openFolderResult(String(result.id || ""));
-                handleRowSelection(row, e);
-            });
-
-            list.appendChild(row);
+            const id = String(result.id || "");
+            rows.push(buildFolderRow(result, String(result.parent_id || ""), {
+                key: `search:folder:${id}`,
+                metaLabel: String(result.path || "My Drive"),
+                sizeLabel: "—",
+                actions: [{
+                    kind: "open",
+                    className: "open-folder",
+                    title: "Open",
+                    label: "Open folder",
+                    onClick: () => openFolderResult(id),
+                }],
+                onDoubleClick: () => openFolderResult(id),
+                onClick: (event) => {
+                    const target = event.target as HTMLElement;
+                    if (target.closest("button.open-folder")) return;
+                    const row = target.closest(".drive-row");
+                    if (row) handleRowSelection(row, event);
+                },
+            }));
             return;
         }
 
         if (type === "file") {
             const name = String(result.name || "");
-            const { base, ext } = splitNameAndExt(name);
-            const row = document.createElement("div");
-            row.className = "file-row drive-row";
-            row.dataset.type = "file";
-            row.dataset.id = String(result.id || "");
-            row.dataset.name = name;
-            row.dataset.size = String(result.size || 0);
-            row.dataset.parentId = String(result.parent_id || "");
-            row.dataset.source = String(result.source || "fs");
-            row.dataset.uploaderId = String(result.uploader_id || 0);
-            row.dataset.uploadTime = String(result.upload_time || 0);
-            row.dataset.encrypted = result.encrypted ? "true" : "false";
             // Search results may not be in the active drive; keep
             // owner-only gating consistent: same canOwnerAct heuristic as
             // file-list. We approximate by reading state.activeChannel
@@ -111,57 +99,68 @@ function renderSearchResults(results: any, query: any) {
             const ownerOnly = (state.activeChannel?.kind !== "shared")
                 || (Number(result.uploader_id || 0) > 0
                     && Number(result.uploader_id) === Number(state.myUserID || 0));
-            row.dataset.canDelete = ownerOnly ? "true" : "false";
-            row.dataset.canRename = ownerOnly ? "true" : "false";
-            prepareDriveRow(row);
-
-            row.innerHTML = `
-                <div class="row-name">
-                    <span class="file-ext-text" aria-hidden="true">${escapeHtml(ext)}</span>
-                    ${escapeHtml(base)}
-                    <span class="uploader-chip" data-uploader-slot></span>
-                </div>
-                <div class="row-meta">${escapeHtml(result.path || "My Drive")}</div>
-                <div class="row-meta">${formatBytes(Number(result.size || 0))}</div>
-                <div class="row-actions">
-                    ${isVideoFile(name) ? `<button class="action-icon play-video" type="button" title="Play">${icons.play}</button>` : ""}
-                    <button class="action-icon download" type="button" title="Download">${icons.download}</button>
-                </div>
-            `;
-            fillUploaderSlot(row, {
-                uploaderID: Number(result.uploader_id || 0),
-                uploadTime: Number(result.upload_time || 0),
-            });
-
-            const downloadBtn = row.querySelector("button.download");
-            if (downloadBtn) {
-                downloadBtn.addEventListener("click", () => window.initDownload(Number(result.id || 0), name, Number(result.size || 0)));
-            }
-            const playBtn = row.querySelector("button.play-video");
-            if (playBtn) {
-                playBtn.addEventListener("click", () => {
-                    window.initVideoPlayback(Number(result.id || 0), name, Number(result.size || 0), Boolean(result.encrypted));
+            const id = Number(result.id || 0);
+            const size = Number(result.size || 0);
+            const encrypted = Boolean(result.encrypted);
+            const actions: FileListAction[] = [];
+            if (isVideoFile(name)) {
+                actions.push({
+                    kind: "play",
+                    className: "play-video",
+                    title: "Play",
+                    label: "Play video",
+                    onClick: () => window.initVideoPlayback(id, name, size, encrypted),
                 });
             }
-
-            row.addEventListener("dblclick", () => {
-                if (isVideoFile(name)) {
-                    window.initVideoPlayback(Number(result.id || 0), name, Number(result.size || 0), Boolean(result.encrypted));
-                    return;
-                }
-                openFileResult(String(result.id || ""), String(result.parent_id || ""));
+            actions.push({
+                kind: "download",
+                className: "download",
+                title: "Download",
+                label: "Download",
+                onClick: () => window.initDownload(id, name, size),
             });
-            row.addEventListener("click", (e) => {
-                if ((e.target as HTMLElement).closest("button")) return;
-                handleRowSelection(row, e);
-            });
-
-            list.appendChild(row);
+            rows.push(buildFileRow({
+                id,
+                name,
+                size,
+                source: String(result.source || "fs"),
+                uploaderID: Number(result.uploader_id || 0),
+                date: Number(result.upload_time || 0),
+                encrypted,
+                canDelete: ownerOnly,
+                canRename: ownerOnly,
+            }, String(result.parent_id || ""), {
+                key: `search:file:${String(result.source || "fs")}:${id}`,
+                metaLabel: String(result.path || "My Drive"),
+                sizeLabel: formatBytes(size),
+                actions,
+                onDoubleClick: () => {
+                    if (isVideoFile(name)) {
+                        window.initVideoPlayback(id, name, size, encrypted);
+                        return;
+                    }
+                    openFileResult(String(id || ""), String(result.parent_id || ""));
+                },
+                onClick: (event) => {
+                    const target = event.target as HTMLElement;
+                    if (target.closest("button")) return;
+                    const row = target.closest(".drive-row");
+                    if (row) handleRowSelection(row, event);
+                },
+            }));
         }
     });
 
-    populateUploaderChips(list);
-    syncDriveRowTabStops(list);
+    renderFileListRows(list, rows, () => {
+        for (const row of list.querySelectorAll<HTMLElement>(".drive-row[data-type='file']")) {
+            fillUploaderSlot(row, {
+                uploaderID: Number(row.dataset.uploaderId || 0),
+                uploadTime: Number(row.dataset.uploadTime || 0),
+            });
+        }
+        populateUploaderChips(list);
+        syncDriveRowTabStops(list);
+    });
 }
 
 export function clearSearch({ refresh = true } = {}) {
@@ -245,7 +244,7 @@ export async function runGlobalSearch() {
     const token = ++activeToken;
     setHeaderMode(true);
     clearSelection();
-    list.innerHTML = `<div class="search-empty" role="status">Searching…</div>`;
+    renderFileState(list, "loading", "Searching files");
 
     try {
         const [fsResults, tgFiles] = await Promise.all([
@@ -281,7 +280,7 @@ export async function runGlobalSearch() {
         renderSearchResults([...fs, ...tgMatches], query);
     } catch (err) {
         if (token !== activeToken) return;
-        list.innerHTML = `<div class="search-empty" role="alert">Search failed</div>`;
+        renderFileState(list, "error", "Search failed", "Try again or refine your query.");
         console.error("Search failed:", err);
     }
 }

--- a/frontend/src/modules/selection.ts
+++ b/frontend/src/modules/selection.ts
@@ -60,10 +60,6 @@ export function rowToSelectionItem(row: any) {
     };
 }
 
-export function setRowSelected(_row: any, _selected: any) {
-    syncSelectedRowKeys();
-}
-
 export function updateSelectionBar() {
     syncSelectedRowKeys();
     if (!state.selectionBarEl) {

--- a/frontend/src/modules/selection.ts
+++ b/frontend/src/modules/selection.ts
@@ -5,6 +5,7 @@ import { openDeleteModal } from './modals/delete';
 import { openMoveModal } from './modals/move';
 import SelectionBar from '../ui/selection/SelectionBar.svelte';
 import { setSelectionCount } from '../ui/selection/selection-bar-store';
+import { setSelectedFileRowKeys } from '../ui/file-list/row-state-store';
 import { mountSvelte } from '../ui';
 
 const SELECTABLE_ROW_SELECTOR = '.drive-row[data-type="folder"], .drive-row[data-type="file"]';
@@ -16,10 +17,21 @@ function emitSelectionChange() {
 
 export function getRowKey(row: any) {
     if (!row) return "";
+    const explicitKey = String(row.dataset.rowKey || "");
+    if (explicitKey) return explicitKey;
     const type = String(row.dataset.type || "");
     const id = String(row.dataset.id || "");
     if (!type || !id) return "";
     return `${type}:${id}`;
+}
+
+function syncSelectedRowKeys() {
+    setSelectedFileRowKeys(state.selectedItems.keys());
+}
+
+export function isRowSelected(row: any) {
+    const key = getRowKey(row);
+    return Boolean(key && state.selectedItems.has(key));
 }
 
 export function rowToSelectionItem(row: any) {
@@ -48,13 +60,12 @@ export function rowToSelectionItem(row: any) {
     };
 }
 
-export function setRowSelected(row: any, selected: any) {
-    if (!row) return;
-    row.classList.toggle("is-selected", Boolean(selected));
-    row.setAttribute("aria-selected", selected ? "true" : "false");
+export function setRowSelected(_row: any, _selected: any) {
+    syncSelectedRowKeys();
 }
 
 export function updateSelectionBar() {
+    syncSelectedRowKeys();
     if (!state.selectionBarEl) {
         emitSelectionChange();
         return;
@@ -72,9 +83,6 @@ export function updateSelectionBar() {
 }
 
 export function clearSelection({ keepAnchor = false } = {}) {
-    for (const item of state.selectedItems.values()) {
-        if (item?.row) setRowSelected(item.row, false);
-    }
     state.selectedItems.clear();
     if (!keepAnchor) state.selectionAnchorIndex = -1;
     updateSelectionBar();
@@ -85,7 +93,6 @@ export function selectRow(row: any, rowIndex: any) {
     if (!key) return;
     const item = rowToSelectionItem(row);
     state.selectedItems.set(key, item);
-    setRowSelected(row, true);
     state.selectionAnchorIndex = rowIndex;
     updateSelectionBar();
 }
@@ -94,7 +101,6 @@ export function deselectRow(row: any) {
     const key = getRowKey(row);
     if (!key) return;
     state.selectedItems.delete(key);
-    setRowSelected(row, false);
     updateSelectionBar();
 }
 
@@ -123,7 +129,6 @@ export function handleRowSelection(row: any, e: any) {
             if (state.selectedItems.has(key)) continue;
             const item = rowToSelectionItem(r);
             state.selectedItems.set(key, item);
-            setRowSelected(r, true);
         }
 
         updateSelectionBar();
@@ -131,12 +136,13 @@ export function handleRowSelection(row: any, e: any) {
     }
 
     if (isToggle) {
-        if (row.classList.contains("is-selected")) {
+        if (isRowSelected(row)) {
             deselectRow(row);
         } else {
+            const key = getRowKey(row);
+            if (!key) return;
             const item = rowToSelectionItem(row);
-            state.selectedItems.set(getRowKey(row), item);
-            setRowSelected(row, true);
+            state.selectedItems.set(key, item);
             state.selectionAnchorIndex = idx;
             updateSelectionBar();
         }
@@ -154,7 +160,7 @@ export function ensureRowSelectedForContextMenu(row: any) {
     const idx = rows.indexOf(row);
     if (idx === -1) return;
 
-    if (!row.classList.contains("is-selected") || !state.selectedItems.size) {
+    if (!isRowSelected(row) || !state.selectedItems.size) {
         clearSelection({ keepAnchor: true });
         selectRow(row, idx);
         return;

--- a/frontend/src/ui/file-list/FileList.svelte
+++ b/frontend/src/ui/file-list/FileList.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+    import FileState from './FileState.svelte';
+    import { fileListView } from './file-list-store';
+    import { activeFileRowKey, selectedFileRowKeys } from './row-state-store';
+    import type { FileListAction, FileListFileRow, FileListRow, FolderListRow } from './types';
+
+    type InteractiveRow = FolderListRow | FileListFileRow;
+
+    function dataType(row: FileListRow) {
+        return row.kind === 'pending-folder' ? 'pending-folder' : row.kind;
+    }
+
+    function onActionClick(event: MouseEvent, row: FileListRow, action: FileListAction) {
+        if (!action.onClick) return;
+        event.stopPropagation();
+        action.onClick(event, row);
+    }
+
+    function onRowClick(event: MouseEvent, row: InteractiveRow) {
+        row.onClick?.(event, row);
+    }
+
+    function onRowDoubleClick(event: MouseEvent, row: InteractiveRow) {
+        row.onDoubleClick?.(event, row);
+    }
+
+    // Keyboard handling is delegated once on #file-list. Keeping this no-op on
+    // the row makes Svelte's a11y contract explicit without adding per-row
+    // behavior or fighting the existing roving-focus controller.
+    function onDelegatedKeydown() {}
+</script>
+
+{#if $fileListView.kind === 'state'}
+    <FileState
+        kind={$fileListView.stateKind}
+        title={$fileListView.title}
+        body={$fileListView.body ?? ''}
+        actionLabel={$fileListView.actionLabel ?? ''}
+        onAction={$fileListView.onAction}
+    />
+{:else}
+    {#each $fileListView.rows as row (row.key)}
+        {#if row.kind === 'pending-folder'}
+            <div
+                class="file-row drive-row folder-row pending-folder"
+                data-type="pending-folder"
+                data-temp-id={row.tempId}
+                title="Creating..."
+            >
+                <div class="row-name">
+                    <span class="folder-chip" aria-hidden="true">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
+                        </svg>
+                    </span>
+                    {row.name}
+                    <span class="pending-indicator" aria-hidden="true"></span>
+                </div>
+                <div class="row-meta">Creating...</div>
+                <div class="row-meta">—</div>
+                <div class="row-actions"></div>
+            </div>
+        {:else}
+            <!-- Events stay delegated on #file-list, but selected/focused row
+                 visuals are model-driven here so keyed Svelte updates cannot
+                 clobber accessibility state. -->
+            <div
+                class={`file-row drive-row${row.kind === 'folder' ? ' folder-row' : ''}${$selectedFileRowKeys.has(row.selectionKey) ? ' is-selected' : ''}${$activeFileRowKey === row.selectionKey ? ' is-keyboard-active' : ''}`}
+                data-type={dataType(row)}
+                data-row-key={row.selectionKey}
+                data-id={row.id}
+                data-name={row.name}
+                data-parent-id={row.parentId}
+                data-source={row.kind === 'file' ? row.source : undefined}
+                data-size={row.kind === 'file' ? String(row.size) : undefined}
+                data-uploader-id={row.kind === 'file' ? String(row.uploaderID) : undefined}
+                data-upload-time={row.kind === 'file' ? String(row.uploadTime) : undefined}
+                data-encrypted={row.kind === 'file' ? String(row.encrypted) : undefined}
+                data-can-delete={row.kind === 'file' ? String(row.canDelete) : undefined}
+                data-can-rename={row.kind === 'file' ? String(row.canRename) : undefined}
+                role="option"
+                aria-selected={$selectedFileRowKeys.has(row.selectionKey) ? 'true' : 'false'}
+                aria-label={row.ariaLabel}
+                tabindex={$activeFileRowKey === row.selectionKey ? 0 : -1}
+                onclick={(event) => onRowClick(event, row)}
+                ondblclick={(event) => onRowDoubleClick(event, row)}
+                onkeydown={onDelegatedKeydown}
+            >
+                <div class="row-name" draggable="true">
+                    {#if row.kind === 'folder'}
+                        <span class="folder-chip" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
+                            </svg>
+                        </span>
+                        {row.name}
+                    {:else}
+                        <span class="file-ext-text" aria-hidden="true">{row.ext}</span>
+                        {#if row.encrypted}
+                            <span class="file-lock-badge" title="Encrypted" aria-label="Encrypted">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 11h14a1 1 0 011 1v8a1 1 0 01-1 1H5a1 1 0 01-1-1v-8a1 1 0 011-1z" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 11V7a4 4 0 118 0v4" />
+                                </svg>
+                            </span>
+                        {/if}
+                        {row.baseName}
+                        <span class="uploader-chip" data-uploader-slot></span>
+                    {/if}
+                </div>
+                <div class="row-meta">{row.metaLabel}</div>
+                <div class={`row-meta ${row.kind === 'folder' ? 'folder-size' : ''}`}>{row.sizeLabel}</div>
+                <div class="row-actions">
+                    {#each row.actions as action (action.kind)}
+                        <button
+                            class={`action-icon ${action.className}`}
+                            type="button"
+                            title={action.title}
+                            aria-label={action.label}
+                            onclick={(event) => onActionClick(event, row, action)}
+                        >
+                            {#if action.kind === 'open'}
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-2" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M14 3h7v7" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M10 14L21 3" />
+                                </svg>
+                            {:else if action.kind === 'play'}
+                                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                    <path d="M8 5.8c0-.9.98-1.45 1.74-.98l9.08 5.67a1.15 1.15 0 010 1.96l-9.08 5.67A1.15 1.15 0 018 17.14V5.8z" />
+                                </svg>
+                            {:else}
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                    <path d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                </svg>
+                            {/if}
+                        </button>
+                    {/each}
+                </div>
+            </div>
+        {/if}
+    {/each}
+{/if}

--- a/frontend/src/ui/file-list/FileList.test.ts
+++ b/frontend/src/ui/file-list/FileList.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import FileList from './FileList.svelte';
+import { showFileListRows, showFileListState } from './file-list-store';
+import { setActiveFileRowKey, setSelectedFileRowKeys } from './row-state-store';
+import type { FileListFileRow } from './types';
+
+function makeFileRow(overrides: Partial<FileListFileRow> = {}): FileListFileRow {
+    return {
+        kind: 'file',
+        key: 'file:fs:42',
+        selectionKey: 'file:42',
+        id: '42',
+        name: 'clip.mp4',
+        baseName: 'clip',
+        ext: 'MP4',
+        source: 'fs',
+        parentId: '',
+        size: 128,
+        metaLabel: 'Today',
+        sizeLabel: '128 B',
+        ariaLabel: 'File: clip.mp4',
+        uploaderID: 0,
+        uploadTime: 0,
+        encrypted: false,
+        canDelete: true,
+        canRename: true,
+        actions: [],
+        ...overrides,
+    };
+}
+
+afterEach(() => {
+    showFileListState({
+        stateKind: 'loading',
+        title: 'Loading files',
+    });
+    setSelectedFileRowKeys([]);
+    setActiveFileRowKey('');
+});
+
+describe('FileList', () => {
+    it('renders selected and active row state from stores', () => {
+        showFileListRows([makeFileRow()]);
+        setSelectedFileRowKeys(['file:42']);
+        setActiveFileRowKey('file:42');
+
+        const { body } = render(FileList);
+
+        expect(body).toContain('class="file-row drive-row is-selected is-keyboard-active"');
+        expect(body).toContain('data-row-key="file:42"');
+        expect(body).toContain('aria-selected="true"');
+        expect(body).toContain('tabindex="0"');
+    });
+
+    it('renders unselected rows as unfocused options', () => {
+        showFileListRows([makeFileRow()]);
+
+        const { body } = render(FileList);
+
+        expect(body).toContain('class="file-row drive-row"');
+        expect(body).toContain('aria-selected="false"');
+        expect(body).toContain('tabindex="-1"');
+    });
+});

--- a/frontend/src/ui/file-list/file-list-store.ts
+++ b/frontend/src/ui/file-list/file-list-store.ts
@@ -1,0 +1,16 @@
+import { writable } from 'svelte/store';
+import type { FileListView, FileListRow, FileListStateView } from './types';
+
+export const fileListView = writable<FileListView>({
+    kind: 'state',
+    stateKind: 'loading',
+    title: 'Loading files',
+});
+
+export function showFileListState(view: Omit<FileListStateView, 'kind'>) {
+    fileListView.set({ kind: 'state', ...view });
+}
+
+export function showFileListRows(rows: FileListRow[]) {
+    fileListView.set({ kind: 'rows', rows });
+}

--- a/frontend/src/ui/file-list/row-state-store.ts
+++ b/frontend/src/ui/file-list/row-state-store.ts
@@ -1,0 +1,12 @@
+import { writable } from 'svelte/store';
+
+export const selectedFileRowKeys = writable<ReadonlySet<string>>(new Set());
+export const activeFileRowKey = writable('');
+
+export function setSelectedFileRowKeys(keys: Iterable<string>) {
+    selectedFileRowKeys.set(new Set(keys));
+}
+
+export function setActiveFileRowKey(key: string) {
+    activeFileRowKey.set(key);
+}

--- a/frontend/src/ui/file-list/types.ts
+++ b/frontend/src/ui/file-list/types.ts
@@ -1,0 +1,66 @@
+export type FileListActionKind = 'open' | 'play' | 'download';
+
+export type FileListAction = {
+    kind: FileListActionKind;
+    className: string;
+    title: string;
+    label: string;
+    onClick?: (event: MouseEvent, row: FileListRow) => void;
+};
+
+type BaseInteractiveRow = {
+    key: string;
+    selectionKey: string;
+    id: string;
+    name: string;
+    parentId: string;
+    metaLabel: string;
+    sizeLabel: string;
+    ariaLabel: string;
+    onClick?: (event: MouseEvent, row: FileListRow) => void;
+    onDoubleClick?: (event: MouseEvent, row: FileListRow) => void;
+};
+
+export type FolderListRow = BaseInteractiveRow & {
+    kind: 'folder';
+    actions: FileListAction[];
+};
+
+export type FileListFileRow = BaseInteractiveRow & {
+    kind: 'file';
+    baseName: string;
+    ext: string;
+    source: string;
+    size: number;
+    uploaderID: number;
+    uploadTime: number;
+    encrypted: boolean;
+    canDelete: boolean;
+    canRename: boolean;
+    actions: FileListAction[];
+};
+
+export type PendingFolderListRow = {
+    kind: 'pending-folder';
+    key: string;
+    tempId: string;
+    name: string;
+};
+
+export type FileListRow = FolderListRow | FileListFileRow | PendingFolderListRow;
+
+export type FileListStateView = {
+    kind: 'state';
+    stateKind: 'loading' | 'empty' | 'error';
+    title: string;
+    body?: string;
+    actionLabel?: string;
+    onAction?: () => void;
+};
+
+export type FileListRowsView = {
+    kind: 'rows';
+    rows: FileListRow[];
+};
+
+export type FileListView = FileListStateView | FileListRowsView;

--- a/frontend/src/ui/index.ts
+++ b/frontend/src/ui/index.ts
@@ -3,6 +3,7 @@ export { default as IconButton } from './IconButton.svelte';
 export { default as ProgressBar } from './ProgressBar.svelte';
 export { default as StateView } from './StateView.svelte';
 export { default as ContextMenu } from './menus/ContextMenu.svelte';
+export { default as FileList } from './file-list/FileList.svelte';
 export { default as FileState } from './file-list/FileState.svelte';
 export { default as DriveList } from './sidebar/DriveList.svelte';
 export { default as FolderModal } from './modals/FolderModal.svelte';

--- a/frontend/src/ui/primitives.test.ts
+++ b/frontend/src/ui/primitives.test.ts
@@ -3,6 +3,7 @@ import {
     Button,
     ContextMenu,
     DriveList,
+    FileList,
     FileState,
     FolderModal,
     IconButton,
@@ -21,6 +22,7 @@ describe('Svelte UI primitives', () => {
         expect(ProgressBar).toBeTruthy();
         expect(StateView).toBeTruthy();
         expect(ContextMenu).toBeTruthy();
+        expect(FileList).toBeTruthy();
         expect(FileState).toBeTruthy();
         expect(DriveList).toBeTruthy();
         expect(ModalShell).toBeTruthy();


### PR DESCRIPTION
This moves the drive file list and search results onto a mounted Svelte renderer while keeping the existing delegated interaction model intact. The point is to kill the old innerHTML row path without taking a risky rewrite of drag/drop, selection, keyboard navigation, uploader chips, pending-folder state, and search behavior all at once. Rows are keyed, filenames render as text instead of HTML, and row selection/focus now flow through a small store so Svelte owns the accessibility state it paints.

The visible behavior should stay the same: normal folders/files, search results, pending create rows, row actions, bulk selection, keyboard movement, drag/drop, uploader chips, and file states all keep their existing contracts. The implementation is now safer to extend, cheaper to update, and ready for the next Svelte migration slice.

Validated locally with typecheck, eslint, vitest, production build, and git diff whitespace checks. This is draft until the live smoke confirms row selection survives async folder-size/uploader-chip updates and the search/list interaction paths still feel identical.