### PR TITLE
Finish declarative file-list row data

### DIFF
--- a/frontend/src/modules/file-list.ts
+++ b/frontend/src/modules/file-list.ts
@@ -15,12 +15,12 @@ import { getFolderContents as apiGetFolderContents } from '../api';
 import { calculateVisibleFolderBytes, getAllFsMsgIDs } from './drive-data';
 import { refreshFolderIndex, collectDescendants } from './folder-index';
 import { enqueueDownload } from './transfers';
-import { populateUploaderChips, uploaderChipHTML } from './uploaders';
+import { ensureUserNames, uploaderChipLabel } from './uploaders';
 import { renderGallery, setPhotosMode } from './gallery';
 import { isVideoFile } from './media-types';
 import { openVideoModal } from './modals/video';
 import FileList from '../ui/file-list/FileList.svelte';
-import { showFileListRows, showFileListState } from '../ui/file-list/file-list-store';
+import { showFileListRows, showFileListState, updateFileListRows } from '../ui/file-list/file-list-store';
 import { setActiveFileRowKey } from '../ui/file-list/row-state-store';
 import type { FileListAction, FileListFileRow, FileListRow, FolderListRow, PendingFolderListRow } from '../ui/file-list/types';
 import { mountSvelte, type SvelteMountHandle } from '../ui';
@@ -73,22 +73,6 @@ export function canOwnerActOnFile(file: any) {
     return uploader === me;
 }
 
-// fillUploaderSlot writes the uploader chip text into the [data-uploader-slot]
-// span of the given row. No-op if the chip wouldn't apply (personal drive,
-// uploader unknown, etc.) — uploaderChipHTML returns null in those cases
-// and the slot stays empty.
-//
-// Safe to call before the user-name cache is populated; the slot stays
-// empty and a follow-up populateUploaderChips pass fills it once names
-// resolve.
-export function fillUploaderSlot(row: HTMLElement | null, file: any) {
-    if (!row) return;
-    const slot = row.querySelector('[data-uploader-slot]');
-    if (!slot) return;
-    const html = uploaderChipHTML(file);
-    slot.innerHTML = html ?? '';
-}
-
 // Tracks the folder whose rows are currently rendered, so a same-folder
 // re-render can restore the scroll position instead of jumping to the top.
 let lastRenderedFolderId: string | null = null;
@@ -137,6 +121,38 @@ export function renderFileListRows(list: HTMLElement, rows: FileListRow[], after
     ensureFileListView(list);
     showFileListRows(rows);
     if (afterRender) afterFileListPaint(list, afterRender);
+}
+
+function chipForFileRow(row: FileListFileRow) {
+    const label = uploaderChipLabel({
+        uploaderID: row.uploaderID,
+        uploadTime: row.uploadTime,
+    });
+    return label ? { label } : null;
+}
+
+export function resolveUploaderChipsForRows(rows: FileListRow[], isCurrent: () => boolean) {
+    if (state.activeChannel?.kind !== "shared") return;
+    const uploaderIDs = rows
+        .filter((row): row is FileListFileRow => row.kind === "file")
+        .map((row) => row.uploaderID)
+        .filter((id) => Number.isFinite(id) && id > 0);
+    if (!uploaderIDs.length) return;
+
+    void ensureUserNames(uploaderIDs).then(() => {
+        if (state.activeChannel?.kind !== "shared" || !isCurrent()) return;
+        let changed = false;
+        updateFileListRows((currentRows) => {
+            const nextRows = currentRows.map((row) => {
+                if (row.kind !== "file") return row;
+                const uploaderChip = chipForFileRow(row);
+                if ((row.uploaderChip?.label ?? "") === (uploaderChip?.label ?? "")) return row;
+                changed = true;
+                return { ...row, uploaderChip };
+            });
+            return changed ? nextRows : currentRows;
+        });
+    });
 }
 
 function folderAction(): FileListAction {
@@ -216,6 +232,12 @@ export function buildFileRow(file: any, parentId: string, overrides: Partial<Fil
         encrypted,
         canDelete,
         canRename,
+        uploaderChip: overrides.uploaderChip !== undefined
+            ? overrides.uploaderChip
+            : (() => {
+                const label = uploaderChipLabel({ uploaderID, uploadTime });
+                return label ? { label } : null;
+            })(),
         actions: overrides.actions ?? fileActions(name),
         onClick: overrides.onClick,
         onDoubleClick: overrides.onDoubleClick,
@@ -547,10 +569,10 @@ export function refreshFiles() {
                     }
                 }
 
-                // Resolve any missing uploader names and inject chips. Fire-
-                // and-forget — rows are already shown without chips and will
-                // get them populated within ~one round-trip.
-                populateUploaderChips(list);
+                resolveUploaderChipsForRows(rows, () => (
+                    state.folderSizeEpoch === folderEpoch
+                    && state.currentFolderId === requestedFolderId
+                ));
             });
         };
 

--- a/frontend/src/modules/search.ts
+++ b/frontend/src/modules/search.ts
@@ -5,15 +5,14 @@ import { renderBreadcrumb } from './navigation';
 import {
     buildFileRow,
     buildFolderRow,
-    fillUploaderSlot,
     renderFileListRows,
     renderFileState,
     resetFileListScrollRestore,
+    resolveUploaderChipsForRows,
     syncDriveRowTabStops,
 } from './file-list';
 import { setPhotosMode } from './gallery';
 import { refreshFolderIndex } from './folder-index';
-import { populateUploaderChips } from './uploaders';
 import { isVideoFile } from './media-types';
 import type { FileListAction, FileListRow } from '../ui/file-list/types';
 
@@ -152,13 +151,7 @@ function renderSearchResults(results: any, query: any) {
     });
 
     renderFileListRows(list, rows, () => {
-        for (const row of list.querySelectorAll<HTMLElement>(".drive-row[data-type='file']")) {
-            fillUploaderSlot(row, {
-                uploaderID: Number(row.dataset.uploaderId || 0),
-                uploadTime: Number(row.dataset.uploadTime || 0),
-            });
-        }
-        populateUploaderChips(list);
+        resolveUploaderChipsForRows(rows, () => String(state.searchQuery || "").trim() === String(query || "").trim());
         syncDriveRowTabStops(list);
     });
 }

--- a/frontend/src/modules/uploaders.test.js
+++ b/frontend/src/modules/uploaders.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { formatRelative, uploaderChipHTML } from "./uploaders";
+import { formatRelative, uploaderChipLabel } from "./uploaders";
 import { state } from "../state";
 
 describe("formatRelative", () => {
@@ -15,7 +15,7 @@ describe("formatRelative", () => {
     });
 });
 
-describe("uploaderChipHTML", () => {
+describe("uploaderChipLabel", () => {
     beforeEach(() => {
         state.activeChannel = { kind: "shared" };
         state.userNames = new Map();
@@ -23,17 +23,17 @@ describe("uploaderChipHTML", () => {
 
     it("returns null outside shared drives", () => {
         state.activeChannel = { kind: "personal" };
-        expect(uploaderChipHTML({ uploaderID: 5, uploadTime: 0 })).toBeNull();
+        expect(uploaderChipLabel({ uploaderID: 5, uploadTime: 0 })).toBeNull();
     });
     it("returns null when uploader id is missing", () => {
-        expect(uploaderChipHTML({ uploaderID: 0 })).toBeNull();
+        expect(uploaderChipLabel({ uploaderID: 0 })).toBeNull();
     });
     it("returns null when the name is not yet resolved", () => {
-        expect(uploaderChipHTML({ uploaderID: 5 })).toBeNull();
+        expect(uploaderChipLabel({ uploaderID: 5 })).toBeNull();
     });
-    it("renders the resolved name, HTML-escaped", () => {
+    it("returns the resolved display label", () => {
         state.userNames.set("5", "A<b>");
-        const html = uploaderChipHTML({ uploaderID: 5, uploadTime: 0 });
-        expect(html).toContain("A&lt;b&gt;");
+        const label = uploaderChipLabel({ uploaderID: 5, uploadTime: 0 });
+        expect(label).toContain("A<b>");
     });
 });

--- a/frontend/src/modules/uploaders.ts
+++ b/frontend/src/modules/uploaders.ts
@@ -61,32 +61,6 @@ export async function ensureUserNames(userIDs: Array<number | string>): Promise<
     await Promise.allSettled(waitFor);
 }
 
-export async function populateUploaderChips(list: HTMLElement | null): Promise<void> {
-    if (!list) return;
-    if (state.activeChannel?.kind !== 'shared') return;
-
-    const slots = list.querySelectorAll('[data-uploader-slot]');
-    const ids: number[] = [];
-    slots.forEach((slot) => {
-        const row = slot.closest('.drive-row') as HTMLElement | null;
-        if (!row) return;
-        const uid = Number(row.dataset.uploaderId || 0);
-        if (uid > 0) ids.push(uid);
-    });
-    if (ids.length === 0) return;
-
-    await ensureUserNames(ids);
-
-    slots.forEach((slot) => {
-        const row = slot.closest('.drive-row') as HTMLElement | null;
-        if (!row) return;
-        const uid = Number(row.dataset.uploaderId || 0);
-        const ts = Number(row.dataset.uploadTime || 0);
-        const html = uploaderChipHTML({ uploaderID: uid, uploadTime: ts });
-        slot.innerHTML = html ?? '';
-    });
-}
-
 // formatRelative produces "2h ago" / "5m ago" / "just now" strings from a
 // unix-second timestamp. Returns "" for 0/invalid so callers hide the time.
 export function formatRelative(unixSec: number): string {
@@ -109,9 +83,9 @@ export function formatRelative(unixSec: number): string {
     return `${y}y ago`;
 }
 
-// Build the inner HTML of an uploader chip for a file row, or null if no chip
-// should show (shared drives only, uploaderID > 0, name resolved).
-export function uploaderChipHTML(file: ChipFile | null): string | null {
+// Build the display text for an uploader chip, or null if no chip should show
+// (shared drives only, uploaderID > 0, name resolved). Svelte owns escaping.
+export function uploaderChipLabel(file: ChipFile | null): string | null {
     if (!file) return null;
     if (state.activeChannel?.kind !== 'shared') return null;
     const uploaderID = Number(file.uploaderID ?? file.uploader_id ?? 0);
@@ -120,17 +94,5 @@ export function uploaderChipHTML(file: ChipFile | null): string | null {
     if (!name) return null;
     const when = formatRelative(file.uploadTime ?? file.upload_time ?? file.date ?? 0);
     const suffix = when ? ` · ${when}` : '';
-    return escapeForChip(name) + escapeForChip(suffix);
-}
-
-const CHIP_ESCAPES: Record<string, string> = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;',
-};
-
-function escapeForChip(s: string): string {
-    return String(s).replace(/[&<>"']/g, (c) => CHIP_ESCAPES[c]);
+    return `${name}${suffix}`;
 }

--- a/frontend/src/ui/file-list/FileList.svelte
+++ b/frontend/src/ui/file-list/FileList.svelte
@@ -105,7 +105,9 @@
                             </span>
                         {/if}
                         {row.baseName}
-                        <span class="uploader-chip" data-uploader-slot></span>
+                        {#if row.uploaderChip}
+                            <span class="uploader-chip">{row.uploaderChip.label}</span>
+                        {/if}
                     {/if}
                 </div>
                 <div class="row-meta">{row.metaLabel}</div>

--- a/frontend/src/ui/file-list/FileList.test.ts
+++ b/frontend/src/ui/file-list/FileList.test.ts
@@ -62,4 +62,16 @@ describe('FileList', () => {
         expect(body).toContain('aria-selected="false"');
         expect(body).toContain('tabindex="-1"');
     });
+
+    it('renders uploader chips as escaped text', () => {
+        showFileListRows([makeFileRow({
+            uploaderChip: { label: 'A<b> 2m ago' },
+        })]);
+
+        const { body } = render(FileList);
+
+        expect(body).toContain('<span class="uploader-chip">A&lt;b> 2m ago</span>');
+        expect(body).not.toContain('<span class="uploader-chip">A<b>');
+        expect(body).not.toContain('data-uploader-slot');
+    });
 });

--- a/frontend/src/ui/file-list/file-list-store.ts
+++ b/frontend/src/ui/file-list/file-list-store.ts
@@ -14,3 +14,11 @@ export function showFileListState(view: Omit<FileListStateView, 'kind'>) {
 export function showFileListRows(rows: FileListRow[]) {
     fileListView.set({ kind: 'rows', rows });
 }
+
+export function updateFileListRows(updater: (rows: FileListRow[]) => FileListRow[]) {
+    fileListView.update((view) => {
+        if (view.kind !== 'rows') return view;
+        const rows = updater(view.rows);
+        return rows === view.rows ? view : { kind: 'rows', rows };
+    });
+}

--- a/frontend/src/ui/file-list/types.ts
+++ b/frontend/src/ui/file-list/types.ts
@@ -8,6 +8,10 @@ export type FileListAction = {
     onClick?: (event: MouseEvent, row: FileListRow) => void;
 };
 
+export type FileListUploaderChip = {
+    label: string;
+};
+
 type BaseInteractiveRow = {
     key: string;
     selectionKey: string;
@@ -37,6 +41,7 @@ export type FileListFileRow = BaseInteractiveRow & {
     encrypted: boolean;
     canDelete: boolean;
     canRename: boolean;
+    uploaderChip?: FileListUploaderChip | null;
     actions: FileListAction[];
 };
 


### PR DESCRIPTION
This finishes the main cleanup left after the Svelte file-list migration: uploader chips no longer write HTML into Svelte-owned rows. File rows now carry chip display data in the row model, username resolution patches the file-list store only while the view is still current, and the Svelte template renders the chip as text.

That removes the last imperative post-render row mutation from the file-list path while keeping the lazy shared-drive username behavior. Search results use the same path as folder contents, so the row model stays consistent across both surfaces.

Validated with typecheck, eslint, vitest, production build, and git diff whitespace checks. The test suite now includes coverage that uploader chip text is escaped by Svelte and that the old data-uploader-slot path is gone.