### PR TITLE
svelte notifications + header chrome

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -123,7 +123,8 @@
 	                    </div>
 
                     <div class="header-actions">
-                         <button id="notif-bell" class="notif-bell" type="button"></button>
+                         <!-- Svelte-owned (see src/ui/notifications/NotifBell.svelte). -->
+                         <div id="notif-bell-root" style="display: contents;"></div>
                          
 	                        <button class="icon-btn" onclick="triggerRefresh()" title="Refresh">
 	                            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -135,57 +135,17 @@
                             Folder
                         </button>
                         
-                        <div class="upload-menu-wrap">
-                            <button id="upload-btn" class="primary-btn upload-btn" type="button" aria-haspopup="menu" aria-expanded="false" aria-controls="upload-menu">
-                                <svg class="btn-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
-                                Upload
-                            </button>
-                            <div id="upload-menu" class="upload-menu" role="menu" style="display: none;">
-                                <button id="upload-menu-files" class="upload-menu-item" type="button" role="menuitem">
-                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 13h6m-6 4h6m2 4H7a2 2 0 01-2-2V5a2 2 0 012-2h7l5 5v11a2 2 0 01-2 2z"/></svg>
-                                    Files
-                                </button>
-                                <button id="upload-menu-folder" class="upload-menu-item" type="button" role="menuitem">
-                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"/></svg>
-                                    Folder
-                                </button>
-                            </div>
-                        </div>
+                        <!-- Svelte-owned (see src/ui/chrome/UploadMenu.svelte). -->
+                        <div class="upload-menu-wrap" id="upload-menu-root"></div>
 
-                        <button id="profile-trigger" class="profile-trigger" type="button"
-                                aria-haspopup="menu" aria-expanded="false" aria-controls="profile-menu"
-                                title="Account">
-                            <span id="profile-avatar" class="profile-avatar" aria-hidden="true"></span>
-                            <svg class="profile-chevron" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6"/></svg>
-                        </button>
-
-                        <div id="profile-menu" class="profile-menu" role="menu" aria-labelledby="profile-trigger" hidden>
-                            <div class="profile-menu-header">
-                                <span id="profile-menu-avatar" class="profile-avatar profile-avatar-lg" aria-hidden="true"></span>
-                                <div class="profile-menu-meta">
-                                    <div id="profile-menu-name" class="profile-menu-name">…</div>
-                                    <div id="profile-menu-handle" class="profile-menu-handle"></div>
-                                </div>
-                            </div>
-                            <div class="profile-menu-divider" role="separator"></div>
-                            <button id="profile-menu-encryption-settings" class="profile-menu-item" type="button" role="menuitem" hidden>
-                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path stroke-linecap="round" stroke-linejoin="round" d="M8 11V7a4 4 0 018 0v4"/></svg>
-                                <span>Encryption settings</span>
-                            </button>
-                            <div id="profile-menu-encryption-settings-divider" class="profile-menu-divider" role="separator" hidden></div>
-                            <button id="profile-menu-logout" class="profile-menu-item danger-text" type="button" role="menuitem">
-                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/></svg>
-                                <span>Log out</span>
-                            </button>
-                        </div>
+                        <!-- Svelte-owned (see src/ui/chrome/ProfileMenu.svelte). -->
+                        <div id="profile-root" style="display: contents;"></div>
                     </div>
                 </header>
 
                 <div class="drive-breadcrumb">
-                    <button id="breadcrumb-back" class="icon-btn back-btn" title="Back" aria-label="Back">
-                        <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
-                    </button>
-                    <div id="breadcrumb-path" class="breadcrumb-path"></div>
+                    <!-- Svelte-owned (see src/ui/chrome/Breadcrumb.svelte). -->
+                    <div id="breadcrumb-root" style="display: contents;"></div>
                     <div id="gallery-title" class="gallery-title">Photos</div>
                 </div>
 

--- a/frontend/src/modules/avatar.ts
+++ b/frontend/src/modules/avatar.ts
@@ -1,11 +1,18 @@
-// Avatar rendering. Draws a circular profile photo if available, otherwise
-// initials on a deterministic accent color derived from the user id.
+// Avatar view model. Resolves to a profile photo when available, otherwise
+// initials on a deterministic accent color derived from the user id. Pure
+// data so Svelte components can render it declaratively.
 
-interface AvatarUser {
+export interface AvatarUser {
     photo_base64?: string;
     display_name?: string;
     username?: string;
     user_id?: number;
+}
+
+export interface AvatarView {
+    photoUrl?: string;
+    initials?: string;
+    color?: string;
 }
 
 const AVATAR_PALETTE = [
@@ -13,29 +20,14 @@ const AVATAR_PALETTE = [
     '#e0af68', '#f7768e', '#73daca', '#ff9e64',
 ];
 
-export function renderAvatar(el: HTMLElement | null, user: AvatarUser | null): void {
-    if (!el) return;
-    el.textContent = '';
-    el.style.removeProperty('background');
-    el.style.removeProperty('background-image');
-    el.style.removeProperty('background-size');
-    el.style.removeProperty('background-position');
-
-    if (!user) {
-        el.style.background = 'var(--surface-2, rgba(255,255,255,0.06))';
-        return;
-    }
+export function avatarViewFor(user: AvatarUser | null): AvatarView {
+    if (!user) return {};
 
     const photo = String(user.photo_base64 || '').trim();
     if (photo) {
-        el.style.backgroundImage = `url("data:image/jpeg;base64,${photo}")`;
-        el.style.backgroundSize = 'cover';
-        el.style.backgroundPosition = 'center';
-        return;
+        return { photoUrl: `data:image/jpeg;base64,${photo}` };
     }
-
-    el.textContent = initialsFor(user);
-    el.style.background = paletteFor(user);
+    return { initials: initialsFor(user), color: paletteFor(user) };
 }
 
 function initialsFor(user: AvatarUser): string {

--- a/frontend/src/modules/encryption.ts
+++ b/frontend/src/modules/encryption.ts
@@ -5,6 +5,7 @@
 import { state } from '../state';
 import { EncryptionStatus } from '../../wailsjs/go/main/App';
 import { openEncryptionPasswordModal } from './modals/encryption-password';
+import { encryptionEntryVisible } from '../ui/chrome/profile-store';
 
 export async function loadEncryptionStatus(): Promise<void> {
     try {
@@ -20,12 +21,14 @@ export async function loadEncryptionStatus(): Promise<void> {
         console.warn('EncryptionStatus failed:', err);
         state.encryption = { available: false, passwordSet: false, passwordRemembered: false, hint: '', loaded: true };
     }
-    try {
-        const { renderEncryptionSettingsEntry } = await import('./profile-menu.js');
-        renderEncryptionSettingsEntry();
-    } catch {
-        // profile menu not mounted yet — non-fatal
-    }
+    renderEncryptionSettingsEntry();
+}
+
+// renderEncryptionSettingsEntry lives here (not in profile-menu.ts) so this
+// module never imports the profile menu, whose modal imports circle back to
+// loadEncryptionStatus.
+export function renderEncryptionSettingsEntry() {
+    encryptionEntryVisible.set(Boolean(state.encryption?.passwordSet));
 }
 
 // requireEncryptionPassword is the gate used by download/preview when an

--- a/frontend/src/modules/navigation.ts
+++ b/frontend/src/modules/navigation.ts
@@ -2,103 +2,76 @@
 
 import { state } from '../state';
 import { canDropOnFolder, setDropHighlight, performDropMove } from './drag-drop';
+import Breadcrumb from '../ui/chrome/Breadcrumb.svelte';
+import { breadcrumbPath, type BreadcrumbDrag } from '../ui/chrome/breadcrumb-store';
+import { mountSvelte, type SvelteMountHandle } from '../ui/mount';
 
+let breadcrumbHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
+
+// renderBreadcrumb mirrors state.folderPath (the source of truth, mutated by
+// several modules) into the breadcrumb store.
 export function renderBreadcrumb() {
-    const backBtn = document.getElementById("breadcrumb-back") as HTMLButtonElement | null;
-    const path = document.getElementById("breadcrumb-path");
-    if (!backBtn || !path) return;
+    breadcrumbPath.set(state.folderPath.map((f) => ({ id: f.id, name: f.name })));
+}
 
-    backBtn.disabled = state.folderPath.length === 0;
-    backBtn.style.opacity = state.folderPath.length === 0 ? "0.35" : "1";
-
-    const items = [
-        { id: "", name: "My Drive", index: -1 },
-        ...state.folderPath.map((f, i) => ({ id: f.id, name: f.name, index: i })),
-    ];
-    path.innerHTML = "";
-
-    items.forEach((item, idx) => {
-        if (idx > 0) {
-            const sep = document.createElement("span");
-            sep.className = "breadcrumb-sep";
-            sep.textContent = "/";
-            path.appendChild(sep);
+const drag: BreadcrumbDrag = {
+    isActive: () => Boolean(state.dragState),
+    canDrop: (folderId) => canDropOnFolder(folderId),
+    highlight: (el, allowed) => setDropHighlight(el, allowed),
+    leave: (el) => {
+        if (state.dragOverEl === el) {
+            el.classList.remove('drop-target');
+            el.classList.remove('drop-denied');
+            state.dragOverEl = null;
         }
+    },
+    dropOn: (el, folderId) => {
+        if (state.dragOverEl === el) state.dragOverEl = null;
+        el.classList.remove('drop-target');
+        el.classList.remove('drop-denied');
+        void performDropMove(folderId);
+    },
+    registerRoot: (el) => {
+        state.dragRootEl = el;
+    },
+};
 
-        const btn = document.createElement("button");
-        btn.type = "button";
-        btn.className = "breadcrumb-link";
-        btn.dataset.index = String(item.index);
-        btn.textContent = item.name;
-        btn.addEventListener("dragover", (e) => {
-            if (!state.dragState) return;
-            const allowed = canDropOnFolder(item.id);
-            setDropHighlight(btn, allowed);
-            if (e.dataTransfer) e.dataTransfer.dropEffect = allowed ? "move" : "none";
-            if (allowed) e.preventDefault();
-        });
-        btn.addEventListener("dragleave", (e) => {
-            if (e.relatedTarget && btn.contains(e.relatedTarget as Node)) return;
-            if (state.dragOverEl === btn) {
-                btn.classList.remove("drop-target");
-                btn.classList.remove("drop-denied");
-                state.dragOverEl = null;
-            }
-        });
-        btn.addEventListener("drop", async (e) => {
-            if (!state.dragState) return;
-            const allowed = canDropOnFolder(item.id);
-            if (!allowed) return;
-            e.preventDefault();
-            e.stopPropagation();
-            if (state.dragOverEl === btn) state.dragOverEl = null;
-            btn.classList.remove("drop-target");
-            btn.classList.remove("drop-denied");
-            await performDropMove(item.id);
-        });
+function navigateToIndex(index: number) {
+    if (index < 0) {
+        state.folderPath = [];
+        state.currentFolderId = '';
+    } else {
+        state.folderPath = state.folderPath.slice(0, index + 1);
+        state.currentFolderId = state.folderPath[index]?.id || '';
+    }
+    // Breadcrumb navigation always exits any virtual view (e.g. Photos).
+    state.virtualView = null;
+    renderBreadcrumb();
+    window.refreshFiles();
+}
 
-        if (item.index === -1) {
-            state.dragRootEl = btn;
-        }
-        path.appendChild(btn);
-    });
+function navigateBack() {
+    if (state.folderPath.length === 0) return;
+    state.folderPath = state.folderPath.slice(0, -1);
+    state.currentFolderId = state.folderPath.length ? state.folderPath[state.folderPath.length - 1].id : '';
+    state.virtualView = null;
+    renderBreadcrumb();
+    window.refreshFiles();
 }
 
 export function setupBreadcrumb() {
-    const backBtn = document.getElementById("breadcrumb-back") as HTMLButtonElement | null;
-    const path = document.getElementById("breadcrumb-path");
-    if (!backBtn || !path) return;
+    const host = document.getElementById('breadcrumb-root');
+    if (!host || breadcrumbHandle) return;
 
-    backBtn.addEventListener("click", () => {
-        if (state.folderPath.length === 0) return;
-        state.folderPath = state.folderPath.slice(0, -1);
-        state.currentFolderId = state.folderPath.length ? state.folderPath[state.folderPath.length - 1].id : "";
-        // Parity with breadcrumb-link / navigateToFolder: folder navigation
-        // exits virtual views such as Photos.
-        state.virtualView = null;
-        renderBreadcrumb();
-        window.refreshFiles();
+    host.replaceChildren();
+    breadcrumbHandle = mountSvelte(Breadcrumb, {
+        target: host,
+        props: {
+            onNavigate: navigateToIndex,
+            onBack: navigateBack,
+            drag,
+        },
     });
-
-    path.addEventListener("click", (e) => {
-        const btn = (e.target as HTMLElement).closest("button.breadcrumb-link") as HTMLElement | null;
-        if (!btn) return;
-        const idx = parseInt(btn.dataset.index as string, 10);
-        if (Number.isNaN(idx)) return;
-
-        if (idx < 0) {
-            state.folderPath = [];
-            state.currentFolderId = "";
-        } else {
-            state.folderPath = state.folderPath.slice(0, idx + 1);
-            state.currentFolderId = state.folderPath[idx]?.id || "";
-        }
-        // Breadcrumb navigation always exits any virtual view.
-        state.virtualView = null;
-        renderBreadcrumb();
-        window.refreshFiles();
-    });
-
     renderBreadcrumb();
 }
 
@@ -117,6 +90,6 @@ export function ensureNotInsideDeletedFolder(deletedFolderID: string) {
     if (idx === -1) return;
 
     state.folderPath = state.folderPath.slice(0, idx);
-    state.currentFolderId = state.folderPath.length ? state.folderPath[state.folderPath.length - 1].id : "";
+    state.currentFolderId = state.folderPath.length ? state.folderPath[state.folderPath.length - 1].id : '';
     renderBreadcrumb();
 }

--- a/frontend/src/modules/notif-bell.dom.test.ts
+++ b/frontend/src/modules/notif-bell.dom.test.ts
@@ -1,0 +1,126 @@
+// Behavior tests for the notification bell: history mutations drive the bell
+// mode, the panel opens with sections and clears the unread badge, and
+// terminal transfer updates are idempotent.
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { flushSync } from 'svelte';
+import { get } from 'svelte/store';
+import {
+    clearHistory,
+    markTransferDone,
+    pushHistoryEvent,
+    pushTransferStart,
+    setupNotifBell,
+    updateTransferProgress,
+} from './notif-bell';
+import {
+    historyEvents,
+    notifPanelOpen,
+    notifUnreadErrors,
+    type TransferEvent,
+} from '../ui/notifications/notif-store';
+
+// happy-dom has no Web Animations API; Svelte outros call element.animate.
+// Stub it so out-transitions complete immediately.
+if (!Element.prototype.animate) {
+    (Element.prototype as any).animate = function () {
+        const anim: any = { cancel() {}, finish() {}, finished: Promise.resolve() };
+        Object.defineProperty(anim, 'onfinish', {
+            set(cb: (() => void) | null) {
+                if (cb) queueMicrotask(cb);
+            },
+        });
+        return anim;
+    };
+}
+
+function bell(): HTMLElement {
+    const el = document.getElementById('notif-bell');
+    if (!el) throw new Error('bell not rendered');
+    return el;
+}
+
+function reset(): void {
+    notifPanelOpen.set(false);
+    notifUnreadErrors.set(0);
+    historyEvents.set([]);
+    flushSync();
+}
+
+beforeAll(() => {
+    const host = document.createElement('div');
+    host.id = 'notif-bell-root';
+    document.body.appendChild(host);
+    setupNotifBell();
+    flushSync();
+});
+
+afterEach(reset);
+
+describe('notif-bell', () => {
+    it('reflects transfer and error state in the bell mode', () => {
+        expect(bell().dataset.mode).toBe('idle');
+
+        pushTransferStart({ id: 1, direction: 'up', name: 'a.bin', total: 100 });
+        flushSync();
+        expect(bell().dataset.mode).toBe('active');
+
+        markTransferDone({ id: 1, direction: 'up', status: 'failed' });
+        flushSync();
+        expect(bell().dataset.mode).toBe('error'); // unread error badge
+
+        clearHistory();
+        flushSync();
+        expect(bell().dataset.mode).toBe('idle');
+    });
+
+    it('keeps terminal transfers immutable and byte math consistent', () => {
+        pushTransferStart({ id: 2, direction: 'down', name: 'b.bin', total: 1000 });
+        updateTransferProgress({ id: 2, direction: 'down', progress: 50 });
+
+        let entry = get(historyEvents)[0] as TransferEvent;
+        expect(entry.progress).toBe(50);
+        expect(entry.bytes).toBe(500);
+
+        markTransferDone({ id: 2, direction: 'down', status: 'canceled' });
+        // A late 'done' from a safety sweep must not resurrect or upgrade it.
+        markTransferDone({ id: 2, direction: 'down', status: 'done' });
+        updateTransferProgress({ id: 2, direction: 'down', progress: 90 });
+
+        entry = get(historyEvents)[0] as TransferEvent;
+        expect(entry.status).toBe('canceled');
+        expect(entry.progress).toBe(50);
+    });
+
+    it('opens the panel on click, renders sections, and clears unread errors', () => {
+        pushTransferStart({ id: 3, direction: 'up', name: 'c.bin', total: 10 });
+        pushHistoryEvent({ level: 'error', title: 'Could not join drive', body: 'expired' });
+        flushSync();
+        expect(get(notifUnreadErrors)).toBe(1);
+
+        bell().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        flushSync();
+
+        expect(get(notifPanelOpen)).toBe(true);
+        expect(get(notifUnreadErrors)).toBe(0);
+        const panel = document.body.querySelector('.notif-panel');
+        expect(panel).not.toBeNull();
+        expect(panel?.textContent).toContain('Active');
+        expect(panel?.textContent).toContain('Recent');
+        expect(panel?.textContent).toContain('Could not join drive');
+
+        // Escape closes the panel.
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        flushSync();
+        expect(get(notifPanelOpen)).toBe(false);
+    });
+
+    it('caps history at 100 entries, newest first', () => {
+        for (let i = 0; i < 120; i++) {
+            pushHistoryEvent({ level: 'info', title: `event ${i}` });
+        }
+        const events = get(historyEvents);
+        expect(events).toHaveLength(100);
+        expect((events[0] as { title: string }).title).toBe('event 119');
+    });
+});

--- a/frontend/src/modules/notif-bell.ts
+++ b/frontend/src/modules/notif-bell.ts
@@ -6,95 +6,48 @@
 //   • Click panel — full history. Active transfers + Recent (notifications
 //     and completed transfers, merged chronologically).
 //
-// History lives in state.historyEvents (capped at 100, ephemeral). Modules
-// elsewhere call `pushHistoryEvent(...)` and `pushTransferStart()` /
-// `updateTransferProgress()` / `markTransferDone()` to feed the bell.
+// History lives in the ui/notifications stores (capped at 100, ephemeral).
+// Modules elsewhere call `pushHistoryEvent(...)` and `pushTransferStart()` /
+// `updateTransferProgress()` / `markTransferDone()` to feed the bell. This
+// module owns every history mutation (cap, dedupe, idempotency); the Svelte
+// components only render the stores and drive the open/close UI state.
 
+import { get } from 'svelte/store';
 import { state } from '../state';
-import { formatBytes } from '../utils';
+import NotifBell from '../ui/notifications/NotifBell.svelte';
+import {
+    historyEvents,
+    notifPanelOpen,
+    notifUnreadErrors,
+    type NoticeEvent,
+    type TransferDirection,
+    type TransferEvent,
+    type TransferStatus,
+} from '../ui/notifications/notif-store';
+import { mountSvelte, type SvelteMountHandle } from '../ui/mount';
 
 const HISTORY_CAP = 100;
-const HOVER_GRACE_MS = 280;
 
-let bellEl: HTMLElement | null = null;
-let popoverEl: HTMLElement | null = null;
-let panelEl: HTMLElement | null = null;
-let hoverGraceTimer: any = null;
-let pulseTickerHandle: any = null;
+let bellHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
 
-// ─── ICON LIBRARY ────────────────────────────────────────────────────────────
-
-const ICONS = {
-    bell: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 1112 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 003.4 0"/></svg>',
-    upload: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg>',
-    download: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12l7 7 7-7"/></svg>',
-    success: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>',
-    error:   '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
-    info:    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
-    warning: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
-    cancel:  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="8" y1="12" x2="16" y2="12"/></svg>',
-};
-
-// ─── PUBLIC API ──────────────────────────────────────────────────────────────
+// Per-transfer speed sampling. Progress events arrive far more often than the
+// rounded percent changes; samples land in this O(1) sidecar on every tick,
+// and the visible entry (which notifies every store subscriber) only updates
+// when the percent actually moves.
+const speedSamples = new Map<string, { at: number; bytes: number; speed: number }>();
 
 export function setupNotifBell() {
-    bellEl = document.getElementById('notif-bell');
-    if (!bellEl) return;
+    const host = document.getElementById('notif-bell-root');
+    if (!host || bellHandle) return;
 
-    bellEl.innerHTML = `<span class="notif-bell-icon" aria-hidden="true">${ICONS.bell}</span><span class="notif-bell-dot" data-mode="idle" aria-hidden="true"></span>`;
-    bellEl.setAttribute('aria-haspopup', 'dialog');
-    bellEl.setAttribute('aria-expanded', 'false');
-    bellEl.setAttribute('aria-label', 'Notifications');
-
-    bellEl.addEventListener('click', (e) => {
-        e.stopPropagation();
-        togglePanel();
+    host.replaceChildren();
+    bellHandle = mountSvelte(NotifBell, {
+        target: host,
+        props: {
+            onCancelDirection: cancelTransfersInDirection,
+            onClearHistory: clearHistory,
+        },
     });
-    bellEl.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            togglePanel();
-        }
-    });
-
-    bellEl.addEventListener('mouseenter', () => {
-        if (state.notifPanelOpen) return;
-        clearTimeout(hoverGraceTimer);
-        if (hasActiveTransfers()) openHoverPopover();
-    });
-    bellEl.addEventListener('mouseleave', () => {
-        clearTimeout(hoverGraceTimer);
-        hoverGraceTimer = setTimeout(() => {
-            if (popoverEl && !popoverEl.matches(':hover')) closeHoverPopover();
-        }, HOVER_GRACE_MS);
-    });
-
-    // Outside-click and Esc close the panel.
-    document.addEventListener('mousedown', (e) => {
-        if (!state.notifPanelOpen) return;
-        if (panelEl && (panelEl.contains(e.target as Node) || bellEl!.contains(e.target as Node))) return;
-        closePanel();
-    });
-    window.addEventListener('keydown', (e) => {
-        if (e.key !== 'Escape') return;
-        if (state.notifPanelOpen) closePanel();
-        else if (state.notifHoverOpen) closeHoverPopover();
-    });
-
-    // Cancel button on an active transfer row. pointerdown in the capture phase:
-    // the panel re-renders on every progress tick (which would eat a click
-    // landing between mousedown and mouseup), and capture runs before the row's
-    // own click-to-copy handler can stop the event.
-    document.addEventListener('pointerdown', (e) => {
-        const btn = (e.target as HTMLElement)?.closest?.('.notif-row-cancel') as HTMLElement | null;
-        if (!btn) return;
-        e.preventDefault();
-        e.stopPropagation();
-        cancelTransfersInDirection(btn.dataset.cancelDir || 'up');
-    }, true);
-
-    renderBell();
-    startPulseTicker();
 }
 
 // pushHistoryEvent enqueues a non-transfer event (folder created, drive
@@ -102,410 +55,137 @@ export function setupNotifBell() {
 // reusing the same id, though that's rarely needed.
 export function pushHistoryEvent({ level = 'info', title = '', body = '', ts }: { level?: string; title?: string; body?: string; ts?: number } = {}) {
     const id = `evt:${Date.now()}:${Math.random().toString(36).slice(2, 7)}`;
-    state.historyEvents.unshift({
+    const entry: NoticeEvent = {
         kind: 'event',
         id,
         level,
         title: String(title || ''),
         body: String(body || ''),
         ts: ts || Date.now(),
-    });
-    if (level === 'error' && !state.notifPanelOpen) {
-        state.notifUnreadErrors += 1;
+    };
+    historyEvents.update((events) => [entry, ...events].slice(0, HISTORY_CAP));
+    if (level === 'error' && !get(notifPanelOpen)) {
+        notifUnreadErrors.update((n) => n + 1);
     }
-    capHistory();
-    renderAll();
     return id;
 }
 
 // pushTransferStart begins tracking an upload or download. id should be
 // unique per transfer (msg_id, upload id, etc.). id=0 is valid — upload
 // IDs are zero-based, so don't reject falsy.
-export function pushTransferStart({ id, direction, name, total = 0 }: any) {
+export function pushTransferStart({ id, direction, name, total = 0 }: { id: string | number; direction: TransferDirection; name?: string; total?: number }) {
     if (id == null || !direction) return;
-    const key = `xfer:${direction}:${id}`;
-    // De-dup: if an entry with this key already exists, replace it.
-    removeFromHistory(key);
-    state.historyEvents.unshift({
+    const key = transferKey(direction, id);
+    speedSamples.delete(key);
+    const entry: TransferEvent = {
         kind: 'transfer',
         id: key,
         direction,
         name: String(name || ''),
         progress: 0,
         total: Number(total) || 0,
+        bytes: 0,
+        speed: 0,
         status: 'active',
         startedAt: Date.now(),
         finishedAt: 0,
-    });
-    capHistory();
-    renderAll();
+    };
+    // De-dup: an entry with this key is replaced, not duplicated.
+    historyEvents.update((events) => [entry, ...events.filter((e) => e.id !== key)].slice(0, HISTORY_CAP));
     return key;
 }
 
-export function updateTransferProgress({ id, direction, progress }: any) {
-    const key = `xfer:${direction}:${id}`;
-    const entry = state.historyEvents.find((e) => e.id === key);
-    if (!entry || entry.status !== 'active') return;
+export function updateTransferProgress({ id, direction, progress }: { id: string | number; direction: TransferDirection; progress: number }) {
+    const key = transferKey(direction, id);
+    const entry = findActiveTransfer(key);
+    if (!entry) return;
     const value = Math.max(0, Math.min(100, Number(progress) || 0));
 
     // Track transferred bytes and a smoothed speed for the row meta.
-    const total = Number(entry.total) || 0;
-    if (total > 0) {
-        const bytes = (value / 100) * total;
+    let bytes = entry.bytes;
+    let speed = entry.speed;
+    if (entry.total > 0) {
+        bytes = (value / 100) * entry.total;
         const now = Date.now();
-        if (entry.speedAt && now > entry.speedAt) {
-            const inst = (bytes - (entry.speedBytes || 0)) / ((now - entry.speedAt) / 1000);
+        const prev = speedSamples.get(key);
+        if (prev && now > prev.at) {
+            const inst = (bytes - prev.bytes) / ((now - prev.at) / 1000);
             if (Number.isFinite(inst) && inst >= 0) {
-                entry.speed = entry.speed ? entry.speed * 0.6 + inst * 0.4 : inst;
+                speed = prev.speed ? prev.speed * 0.6 + inst * 0.4 : inst;
             }
         }
-        entry.speedAt = now;
-        entry.speedBytes = bytes;
-        entry.bytes = bytes;
+        speedSamples.set(key, { at: now, bytes, speed });
     }
 
     if (Math.round(entry.progress) === Math.round(value)) return; // skip render noise
-    entry.progress = value;
-    renderAll();
+    historyEvents.update((events) =>
+        events.map((e) => (e.id === key && e.kind === 'transfer' ? { ...e, progress: value, bytes, speed } : e)),
+    );
 }
 
 // updateTransferName changes an active transfer's title in place (no progress
 // reset), used to show an import's live phase: extracting, adding folders, etc.
-export function updateTransferName({ id, direction, name }: any) {
-    const key = `xfer:${direction}:${id}`;
-    const entry = state.historyEvents.find((e) => e.id === key);
-    if (!entry || entry.status !== 'active') return;
+export function updateTransferName({ id, direction, name }: { id: string | number; direction: TransferDirection; name: string }) {
+    const key = transferKey(direction, id);
+    const entry = findActiveTransfer(key);
+    if (!entry) return;
     const next = String(name || '');
     if (entry.name === next) return;
-    entry.name = next;
-    renderAll();
+    historyEvents.update((events) =>
+        events.map((e) => (e.id === key && e.kind === 'transfer' ? { ...e, name: next } : e)),
+    );
 }
 
-export function markTransferDone({ id, direction, status = 'done' }: any) {
-    const key = `xfer:${direction}:${id}`;
-    const entry = state.historyEvents.find((e) => e.id === key);
-    if (!entry) return;
+export function markTransferDone({ id, direction, status = 'done' }: { id: string | number; direction: TransferDirection; status?: TransferStatus }) {
+    const key = transferKey(direction, id);
     // Idempotent: don't downgrade or rewrite an already-terminal entry
     // (e.g. a safety sweep firing 'done' on an entry that already failed).
-    if (entry.status !== 'active') return;
-    entry.status = status;
-    entry.progress = status === 'done' ? 100 : entry.progress;
-    entry.finishedAt = Date.now();
-    if (status === 'failed' && !state.notifPanelOpen) {
-        state.notifUnreadErrors += 1;
+    const entry = findActiveTransfer(key);
+    if (!entry) return;
+    speedSamples.delete(key);
+    historyEvents.update((events) =>
+        events.map((e) =>
+            e.id === key && e.kind === 'transfer'
+                ? { ...e, status, progress: status === 'done' ? 100 : e.progress, finishedAt: Date.now() }
+                : e,
+        ),
+    );
+    if (status === 'failed' && !get(notifPanelOpen)) {
+        notifUnreadErrors.update((n) => n + 1);
     }
-    renderAll();
-}
-
-// cancelTransfersInDirection cancels the active upload/import or download and
-// marks its rows canceled immediately; backend abort events that arrive on the
-// now-terminal rows are no-ops.
-function cancelTransfersInDirection(direction: string) {
-    const app = (window as any)?.go?.main?.App;
-    try {
-        if (direction === 'down') { app?.CancelDownload?.(); state.cancelingDownload = true; }
-        else { app?.CancelUpload?.(); state.cancelingUpload = true; }
-    } catch { /* binding optional */ }
-    // Don't mark rows here. The backend reports the real per-file outcome, so a
-    // file that already finished (and committed) ends as Done while aborted ones
-    // end as Canceled (see the upload_error / download handlers).
 }
 
 export function clearHistory() {
     // Keep active transfers. Drop everything else.
-    state.historyEvents = state.historyEvents.filter(
-        (e) => e.kind === 'transfer' && e.status === 'active'
+    historyEvents.update((events) =>
+        events.filter((e) => e.kind === 'transfer' && e.status === 'active'),
     );
-    state.notifUnreadErrors = 0;
-    renderAll();
+    notifUnreadErrors.set(0);
 }
 
-// ─── INTERNAL: STATE ─────────────────────────────────────────────────────────
-
-function capHistory() {
-    if (state.historyEvents.length <= HISTORY_CAP) return;
-    state.historyEvents = state.historyEvents.slice(0, HISTORY_CAP);
+// cancelTransfersInDirection cancels the active upload/import or download.
+// Rows are not marked here: the backend reports the real per-file outcome, so
+// a file that already finished (and committed) ends as Done while aborted
+// ones end as Canceled (see the upload_error / download handlers).
+function cancelTransfersInDirection(direction: TransferDirection) {
+    const app = (window as any)?.go?.main?.App;
+    try {
+        if (direction === 'down') {
+            app?.CancelDownload?.();
+            state.cancelingDownload = true;
+        } else {
+            app?.CancelUpload?.();
+            state.cancelingUpload = true;
+        }
+    } catch { /* binding optional */ }
 }
 
-function removeFromHistory(id: any) {
-    const idx = state.historyEvents.findIndex((e) => e.id === id);
-    if (idx >= 0) state.historyEvents.splice(idx, 1);
+function transferKey(direction: TransferDirection, id: string | number): string {
+    return `xfer:${direction}:${id}`;
 }
 
-function hasActiveTransfers() {
-    return state.historyEvents.some((e) => e.kind === 'transfer' && e.status === 'active');
+function findActiveTransfer(key: string): TransferEvent | null {
+    const entry = get(historyEvents).find((e) => e.id === key);
+    if (!entry || entry.kind !== 'transfer' || entry.status !== 'active') return null;
+    return entry;
 }
-
-// ─── INTERNAL: RENDER ────────────────────────────────────────────────────────
-
-function renderAll() {
-    renderBell();
-    if (state.notifHoverOpen) renderHoverPopover();
-    if (state.notifPanelOpen) renderPanel();
-}
-
-function renderBell() {
-    if (!bellEl) return;
-    const dot = bellEl.querySelector('.notif-bell-dot') as HTMLElement | null;
-    if (!dot) return;
-    let mode = 'idle';
-    if (state.notifUnreadErrors > 0) mode = 'error';
-    else if (hasActiveTransfers()) mode = 'active';
-    dot.dataset.mode = mode;
-    bellEl.dataset.mode = mode;
-}
-
-function startPulseTicker() {
-    if (pulseTickerHandle) cancelAnimationFrame(pulseTickerHandle);
-    pulseTickerHandle = requestAnimationFrame(() => {
-        pulseTickerHandle = null;
-        renderBell();
-    });
-}
-
-// ─── HOVER POPOVER ───────────────────────────────────────────────────────────
-
-function openHoverPopover() {
-    if (state.notifPanelOpen) return;
-    if (!hasActiveTransfers()) return;
-    state.notifHoverOpen = true;
-    if (!popoverEl) {
-        popoverEl = document.createElement('div');
-        popoverEl.className = 'notif-popover';
-        popoverEl.setAttribute('role', 'dialog');
-        popoverEl.setAttribute('aria-label', 'Active transfers');
-        popoverEl.addEventListener('mouseenter', () => clearTimeout(hoverGraceTimer));
-        popoverEl.addEventListener('mouseleave', () => {
-            clearTimeout(hoverGraceTimer);
-            hoverGraceTimer = setTimeout(closeHoverPopover, HOVER_GRACE_MS);
-        });
-        popoverEl.addEventListener('click', (e) => {
-            // Click into the popover → upgrade to full panel.
-            e.stopPropagation();
-            closeHoverPopover();
-            openPanel();
-        });
-        document.body.appendChild(popoverEl);
-    }
-    positionAnchored(popoverEl);
-    renderHoverPopover();
-}
-
-function closeHoverPopover() {
-    state.notifHoverOpen = false;
-    if (!popoverEl) return;
-    popoverEl.classList.add('notif-leaving');
-    const node = popoverEl;
-    popoverEl = null;
-    setTimeout(() => node.remove(), 160);
-}
-
-function renderHoverPopover() {
-    if (!popoverEl) return;
-    const active = state.historyEvents.filter(
-        (e) => e.kind === 'transfer' && e.status === 'active'
-    );
-    if (active.length === 0) {
-        closeHoverPopover();
-        return;
-    }
-    popoverEl.innerHTML = `
-        <div class="notif-popover-list">
-            ${active.slice(0, 4).map(transferRowHTML).join('')}
-        </div>
-        ${active.length > 4 ? `<div class="notif-popover-more">+ ${active.length - 4} more</div>` : ''}
-    `;
-}
-
-// ─── FULL PANEL ──────────────────────────────────────────────────────────────
-
-function togglePanel() {
-    if (state.notifPanelOpen) closePanel();
-    else openPanel();
-}
-
-function openPanel() {
-    closeHoverPopover();
-    state.notifPanelOpen = true;
-    state.notifUnreadErrors = 0; // opening clears the unread badge
-    if (!panelEl) {
-        panelEl = document.createElement('div');
-        panelEl.className = 'notif-panel';
-        panelEl.setAttribute('role', 'dialog');
-        panelEl.setAttribute('aria-modal', 'false');
-        panelEl.setAttribute('aria-label', 'Notifications');
-        panelEl.addEventListener('click', (e) => e.stopPropagation());
-        document.body.appendChild(panelEl);
-    }
-    positionAnchored(panelEl);
-    renderPanel();
-    bellEl?.setAttribute('aria-expanded', 'true');
-    renderBell();
-}
-
-function closePanel() {
-    state.notifPanelOpen = false;
-    bellEl?.setAttribute('aria-expanded', 'false');
-    if (!panelEl) return;
-    panelEl.classList.add('notif-leaving');
-    const node = panelEl;
-    panelEl = null;
-    setTimeout(() => node.remove(), 160);
-    renderBell();
-}
-
-function renderPanel() {
-    if (!panelEl) return;
-    const active = state.historyEvents.filter(
-        (e) => e.kind === 'transfer' && e.status === 'active'
-    );
-    const recent = state.historyEvents.filter(
-        (e) => !(e.kind === 'transfer' && e.status === 'active')
-    );
-
-    panelEl.innerHTML = `
-        <div class="notif-panel-header">
-            <div class="notif-panel-title">Notifications</div>
-            <button class="notif-panel-clear" type="button" ${recent.length === 0 ? 'disabled' : ''}>Clear</button>
-        </div>
-        <div class="notif-panel-body">
-            ${active.length > 0 ? `
-                <div class="notif-section-label">Active</div>
-                <div class="notif-section">
-                    ${active.map(transferRowHTML).join('')}
-                </div>
-            ` : ''}
-            ${recent.length > 0 ? `
-                <div class="notif-section-label" style="margin-top:${active.length > 0 ? '14px' : '0'}">Recent</div>
-                <div class="notif-section">
-                    ${recent.slice(0, 50).map(eventRowHTML).join('')}
-                </div>
-            ` : (active.length === 0 ? `
-                <div class="notif-empty">
-                    <div class="notif-empty-glyph">${ICONS.bell}</div>
-                    <div class="notif-empty-title">All caught up</div>
-                    <div class="notif-empty-body">Folder activity, uploads, and shared-drive events will show up here.</div>
-                </div>
-            ` : '')}
-        </div>
-    `;
-    const clearBtn = panelEl.querySelector('.notif-panel-clear');
-    if (clearBtn) clearBtn.addEventListener('click', clearHistory);
-
-    // Click an error row to copy its body to clipboard.
-    panelEl.querySelectorAll('.notif-row[data-clipable="1"]').forEach((row: any) => {
-        row.addEventListener('click', async () => {
-            const text = row.dataset.copyText || '';
-            if (!text) return;
-            try { await navigator.clipboard.writeText(text); } catch {}
-            row.classList.add('notif-copied');
-            setTimeout(() => row.classList.remove('notif-copied'), 800);
-        });
-    });
-}
-
-// ─── ROW TEMPLATES ───────────────────────────────────────────────────────────
-
-// transferMetaHTML is the right-side meta: a status word once terminal, else the
-// transferred size (e.g. "2.1 MB / 37 MB") with the current speed under it.
-function transferMetaHTML(t: any): string {
-    if (t.status === 'done') return 'Done';
-    if (t.status === 'failed') return 'Failed';
-    if (t.status === 'canceled') return 'Canceled';
-    const total = Number(t.total) || 0;
-    if (total <= 0) return `${Math.round(t.progress || 0)}%`;
-    const done = Math.min(total, (Number(t.progress) || 0) / 100 * total);
-    const speed = Number(t.speed) > 0
-        ? `<div class="notif-row-speed">${escapeHTML(formatBytes(t.speed))}/s</div>`
-        : '';
-    return `<div class="notif-row-size">${escapeHTML(`${formatBytes(done)} / ${formatBytes(total)}`)}</div>${speed}`;
-}
-
-function transferRowHTML(t: any) {
-    const direction = t.direction === 'up' ? 'upload' : 'download';
-    const dirLabel = t.direction === 'up' ? 'Uploading' : 'Downloading';
-    const statusClass =
-        t.status === 'done' ? 'is-done' :
-        t.status === 'failed' ? 'is-failed' :
-        t.status === 'canceled' ? 'is-canceled' :
-        'is-active';
-    const metaHTML = transferMetaHTML(t);
-    const cancelBtn = t.status === 'active'
-        ? `<button class="notif-row-cancel" type="button" data-cancel-dir="${t.direction}" aria-label="Cancel transfer" title="Cancel">&times;</button>`
-        : '';
-    return `
-        <div class="notif-row notif-row-transfer ${statusClass}">
-            <span class="notif-row-icon" data-kind="${direction}" aria-hidden="true">${ICONS[direction]}</span>
-            <div class="notif-row-body">
-                <div class="notif-row-title" title="${escapeHTML(t.name)}">${escapeHTML(t.name || dirLabel)}</div>
-                <div class="notif-row-progress">
-                    <div class="notif-row-progress-fill" style="width:${Math.max(0, Math.min(100, t.progress || 0))}%"></div>
-                </div>
-            </div>
-            <div class="notif-row-meta">${metaHTML}</div>
-            ${cancelBtn}
-        </div>
-    `;
-}
-
-function eventRowHTML(e: any) {
-    if (e.kind === 'transfer') {
-        // Completed/failed transfer in Recent — render compactly.
-        return transferRowHTML(e);
-    }
-    const level = e.level || 'info';
-    const icon = ICONS[level as keyof typeof ICONS] || ICONS.info;
-    const clipable = level === 'error' && e.body ? '1' : '0';
-    const copyText = clipable === '1' ? `${e.title}\n${e.body}` : '';
-    return `
-        <div class="notif-row notif-row-event level-${level}"
-             data-clipable="${clipable}" data-copy-text="${escapeHTML(copyText)}">
-            <span class="notif-row-icon" data-kind="${level}" aria-hidden="true">${icon}</span>
-            <div class="notif-row-body">
-                <div class="notif-row-title">${escapeHTML(e.title)}</div>
-                ${e.body ? `<div class="notif-row-sub">${escapeHTML(e.body)}</div>` : ''}
-            </div>
-            <div class="notif-row-meta">${escapeHTML(formatRelative(e.ts))}</div>
-        </div>
-    `;
-}
-
-// ─── POSITIONING ─────────────────────────────────────────────────────────────
-
-function positionAnchored(node: any) {
-    if (!bellEl || !node) return;
-    const rect = bellEl.getBoundingClientRect();
-    const right = Math.max(12, window.innerWidth - rect.right);
-    const top = rect.bottom + 10;
-    node.style.right = `${right}px`;
-    node.style.top = `${top}px`;
-}
-
-// ─── UTILS ───────────────────────────────────────────────────────────────────
-
-function escapeHTML(s: any) {
-    return String(s).replace(/[&<>"']/g, (c) => ({
-        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
-    } as Record<string, string>)[c]);
-}
-
-function formatRelative(ts: any) {
-    const t = Number(ts);
-    if (!t) return '';
-    const diffSec = Math.floor((Date.now() - t) / 1000);
-    if (diffSec < 30) return 'just now';
-    if (diffSec < 60) return `${diffSec}s ago`;
-    const m = Math.floor(diffSec / 60);
-    if (m < 60) return `${m} min ago`;
-    const h = Math.floor(m / 60);
-    if (h < 24) return `${h} hr ago`;
-    const d = Math.floor(h / 24);
-    if (d < 7) return `${d}d ago`;
-    return new Date(t).toLocaleDateString();
-}
-
-// Reposition open surfaces on viewport resize.
-window.addEventListener('resize', () => {
-    if (popoverEl) positionAnchored(popoverEl);
-    if (panelEl) positionAnchored(panelEl);
-});

--- a/frontend/src/modules/notifications.ts
+++ b/frontend/src/modules/notifications.ts
@@ -16,42 +16,50 @@
 //
 //   // Errors are sticky by default; user dismisses or clicks to copy.
 //   notify({ level: 'error', title: 'Could not join drive', body: String(err) });
+//
+// This module owns the queue: capping, replace-by-id, and the expiry ticker
+// with its hover-pause rules. ToastStack.svelte only renders the store.
 
-import { state } from '../state';
+import { get } from 'svelte/store';
 import { pushHistoryEvent } from './notif-bell';
+import ToastStack from '../ui/notifications/ToastStack.svelte';
+import { toasts, type ToastItem, type ToastLevel } from '../ui/notifications/toast-store';
+import { mountSvelte, type SvelteMountHandle } from '../ui/mount';
 
 const MAX_VISIBLE = 5;
 const DEFAULT_DURATION = 4000;
-const ICONS = {
-    info: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>',
-    success: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>',
-    warning: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
-    error: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>',
-    spinner: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" class="toast-spinner"><circle cx="12" cy="12" r="9" stroke-opacity="0.25"/><path d="M12 3 a9 9 0 0 1 9 9"/></svg>',
-};
+const LEVELS: readonly ToastLevel[] = ['info', 'success', 'warning', 'error'];
 
-let stackEl: HTMLElement | null = null;
+let stackHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
 let timer: number | null = null;
 
 export function setupNotifications() {
-    if (stackEl) return;
-    stackEl = document.createElement('div');
+    if (stackHandle) return;
+
+    const stackEl = document.createElement('div');
     stackEl.id = 'toast-stack';
     stackEl.className = 'toast-stack';
     stackEl.setAttribute('role', 'status');
     stackEl.setAttribute('aria-live', 'polite');
     document.body.appendChild(stackEl);
 
-    // Pause auto-dismiss while the stack is hovered (per-toast pausing
-    // happens via the data attribute too; this is the broad gesture).
-    stackEl.addEventListener('mouseenter', () => setAllPaused(true));
-    stackEl.addEventListener('mouseleave', () => setAllPaused(false));
+    stackHandle = mountSvelte(ToastStack, {
+        target: stackEl,
+        props: {
+            onDismiss: dismissNotification,
+            onPauseToast: pauseToast,
+            onResumeToast: resumeToast,
+            onPauseAll: () => setAllPaused(true),
+            onResumeAll: () => setAllPaused(false),
+        },
+    });
 
     // Esc clears the most recent error toast (sticky errors otherwise
-    // require a manual click).
+    // require a manual click). A modal's own Escape handling runs in the
+    // capture phase and stops propagation, so this never fires behind one.
     window.addEventListener('keydown', (e) => {
         if (e.key !== 'Escape') return;
-        const lastError = [...state.toasts].reverse().find((t) => t.level === 'error');
+        const lastError = [...get(toasts)].reverse().find((t) => t.level === 'error');
         if (lastError) dismissNotification(lastError.id);
     });
 
@@ -62,12 +70,12 @@ export function setupNotifications() {
 // `notify({ id })` to replace an existing entry in place (used for
 // long-running operations).
 export function notify(opts: any = {}) {
-    const level = ['info', 'success', 'warning', 'error'].includes(opts.level) ? opts.level : 'info';
+    const level: ToastLevel = LEVELS.includes(opts.level) ? opts.level : 'info';
     const id = opts.id || `t${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
     const sticky = opts.sticky === true || level === 'error' || opts.durationMs === 0;
     const duration = sticky ? 0 : (Number.isFinite(opts.durationMs) ? opts.durationMs : DEFAULT_DURATION);
     const now = Date.now();
-    const entry = {
+    const entry: ToastItem = {
         id,
         level,
         title: String(opts.title || ''),
@@ -79,11 +87,10 @@ export function notify(opts: any = {}) {
         spinner: opts.spinner === true,
     };
 
-    // Mirror non-spinner / non-progress toasts into the bell history. We
-    // skip in-progress sticky toasts (spinners) because their final
-    // success/failure version replaces them; the panel doesn't need both.
-    const isProgress = entry.spinner === true;
-    if (!isProgress && entry.title) {
+    // Mirror non-spinner toasts into the bell history. In-progress sticky
+    // toasts (spinners) are skipped because their final success/failure
+    // version replaces them; the panel doesn't need both.
+    if (!entry.spinner && entry.title) {
         pushHistoryEvent({
             level: entry.level,
             title: entry.title,
@@ -92,64 +99,88 @@ export function notify(opts: any = {}) {
         });
     }
 
-    const idx = state.toasts.findIndex((t) => t.id === id);
-    if (idx >= 0) {
-        // Preserve element identity if the level is unchanged, so the
-        // replacement morphs in place instead of slide-in/slide-out.
-        const existing = state.toasts[idx];
-        const morph = existing.level === level;
-        state.toasts[idx] = entry;
-        renderStack({ keepNode: morph ? id : null });
-    } else {
+    toasts.update((list) => {
+        const idx = list.findIndex((t) => t.id === id);
+        if (idx >= 0) {
+            // Replace in place; the keyed each block morphs the same node.
+            const next = [...list];
+            next[idx] = entry;
+            return next;
+        }
         // Cap the visible queue; if exceeded, the oldest non-sticky entry
         // is dismissed early so urgent ones aren't drowned.
-        if (state.toasts.length >= MAX_VISIBLE) {
-            const stalest = state.toasts.findIndex((t) => !t.sticky);
-            if (stalest >= 0) state.toasts.splice(stalest, 1);
-            else state.toasts.shift();
+        const next = [...list];
+        if (next.length >= MAX_VISIBLE) {
+            const stalest = next.findIndex((t) => !t.sticky);
+            next.splice(stalest >= 0 ? stalest : 0, 1);
         }
-        state.toasts.push(entry);
-        renderStack();
-    }
+        next.push(entry);
+        return next;
+    });
     ensureTimer();
     return id;
 }
 
-export function dismissNotification(id: any) {
-    const idx = state.toasts.findIndex((t) => t.id === id);
-    if (idx < 0) return;
-    state.toasts.splice(idx, 1);
-    renderStack();
+export function dismissNotification(id: string) {
+    toasts.update((list) => {
+        const idx = list.findIndex((t) => t.id === id);
+        if (idx < 0) return list;
+        const next = [...list];
+        next.splice(idx, 1);
+        return next;
+    });
     ensureTimer();
 }
 
 export function clearAllNotifications() {
-    state.toasts = [];
-    renderStack();
+    toasts.set([]);
     if (timer) {
         cancelAnimationFrame(timer);
         timer = null;
     }
 }
 
-function setAllPaused(paused: boolean) {
-    if (!state.toasts.length) return;
+// pauseToast freezes one toast's countdown while it is hovered; resumeToast
+// restarts it from the captured remainder (or a fresh window when the broad
+// stack-level pause didn't capture one).
+function pauseToast(id: string) {
+    toasts.update((list) =>
+        list.map((t) => (t.id === id && !t.paused ? { ...t, paused: true } : t)),
+    );
+}
+
+function resumeToast(id: string) {
     const now = Date.now();
-    for (const t of state.toasts) {
-        if (t.sticky) continue;
-        if (paused && !t.paused) {
-            t.paused = true;
-            t.remainingMs = Math.max(0, (t.expiresAt || now) - now);
-        } else if (!paused && t.paused) {
-            t.paused = false;
-            t.expiresAt = now + (t.remainingMs || 0);
-        }
-    }
+    toasts.update((list) =>
+        list.map((t) => {
+            if (t.id !== id || t.sticky || !t.paused) return t;
+            const remaining = t.remainingMs || t.durationMs || DEFAULT_DURATION;
+            return { ...t, paused: false, expiresAt: now + remaining };
+        }),
+    );
+    ensureTimer();
+}
+
+function setAllPaused(paused: boolean) {
+    const now = Date.now();
+    toasts.update((list) => {
+        if (!list.length) return list;
+        return list.map((t) => {
+            if (t.sticky) return t;
+            if (paused && !t.paused) {
+                return { ...t, paused: true, remainingMs: Math.max(0, (t.expiresAt || now) - now) };
+            }
+            if (!paused && t.paused) {
+                return { ...t, paused: false, expiresAt: now + (t.remainingMs || 0) };
+            }
+            return t;
+        });
+    });
     ensureTimer();
 }
 
 function hasExpiringToasts() {
-    return state.toasts.some((t) => !t.sticky && !t.paused && t.expiresAt);
+    return get(toasts).some((t) => !t.sticky && !t.paused && t.expiresAt);
 }
 
 function ensureTimer() {
@@ -160,111 +191,11 @@ function ensureTimer() {
 function tick() {
     timer = null;
     const now = Date.now();
-    let changed = false;
-    for (let i = state.toasts.length - 1; i >= 0; i--) {
-        const t = state.toasts[i];
-        if (t.sticky || t.paused) continue;
-        if (t.expiresAt && now >= t.expiresAt) {
-            state.toasts.splice(i, 1);
-            changed = true;
-        }
+    // The rAF loop runs every frame while a countdown is live; only touch the
+    // store (and wake its subscribers) when something actually expired.
+    const survives = (t: ToastItem) => t.sticky || t.paused || !t.expiresAt || now < t.expiresAt;
+    if (!get(toasts).every(survives)) {
+        toasts.update((list) => list.filter(survives));
     }
-    if (changed) renderStack();
     ensureTimer();
-}
-
-function renderStack({ keepNode = null } = {}) {
-    if (!stackEl) return;
-
-    // Build a quick map of existing nodes by id so we can preserve
-    // identity for entries that didn't change (avoids reflow / animation
-    // restart on every render).
-    const existing = new Map();
-    for (const node of stackEl.querySelectorAll('.toast')) {
-        existing.set((node as HTMLElement).dataset.id, node);
-    }
-
-    const fragment = document.createDocumentFragment();
-    for (const t of state.toasts) {
-        let node = existing.get(t.id);
-        if (node && (t.id !== keepNode)) {
-            // Re-attach existing node if the underlying entry hasn't
-            // structurally changed. We always rebuild content for safety
-            // (cheap and keeps title/body in sync if a notify() call
-            // updated them).
-        }
-        if (!node) {
-            node = buildToastNode(t);
-        } else {
-            updateToastNode(node, t);
-        }
-        existing.delete(t.id);
-        fragment.appendChild(node);
-    }
-
-    // Animate-out any nodes whose entries were removed.
-    for (const stale of existing.values()) {
-        stale.classList.add('toast-leaving');
-        // After the CSS transition (~180ms) drop it from the DOM.
-        stale.addEventListener('transitionend', () => stale.remove(), { once: true });
-        // Safety net in case transitionend doesn't fire.
-        setTimeout(() => { if (stale.isConnected) stale.remove(); }, 240);
-    }
-
-    stackEl.appendChild(fragment);
-}
-
-function buildToastNode(t: any) {
-    const node = document.createElement('div');
-    node.className = `toast toast-${t.level}`;
-    node.dataset.id = t.id;
-    node.setAttribute('role', t.level === 'error' ? 'alert' : 'status');
-    node.setAttribute('tabindex', '0');
-
-    node.addEventListener('mouseenter', () => { t.paused = true; });
-    node.addEventListener('mouseleave', () => {
-        if (!t.sticky && t.paused) {
-            t.paused = false;
-            // resume from where we paused — use the remaining time stored
-            // on entry; fall back to a fresh timeout if absent.
-            const remaining = t.remainingMs || t.durationMs || DEFAULT_DURATION;
-            t.expiresAt = Date.now() + remaining;
-        }
-    });
-
-    updateToastNode(node, t);
-    return node;
-}
-
-function updateToastNode(node: HTMLElement, t: any) {
-    const iconKey = (t.spinner ? 'spinner' : t.level) as keyof typeof ICONS;
-    node.innerHTML = `
-        <span class="toast-icon" aria-hidden="true">${ICONS[iconKey] || ICONS.info}</span>
-        <div class="toast-content">
-            <div class="toast-title">${escapeHTML(t.title)}</div>
-            ${t.body ? `<div class="toast-body">${escapeHTML(t.body)}</div>` : ''}
-        </div>
-        <button class="toast-close" type="button" aria-label="Dismiss">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-        </button>
-    `;
-    const closeBtn = node.querySelector('.toast-close');
-    if (closeBtn) {
-        closeBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            dismissNotification(t.id);
-        });
-    }
-    // Click body to dismiss errors (lets users clear them quickly without
-    // hunting for the X).
-    node.addEventListener('click', (e) => {
-        if ((e.target as HTMLElement).closest('.toast-close')) return;
-        if (t.level === 'error') dismissNotification(t.id);
-    });
-}
-
-function escapeHTML(s: any) {
-    return String(s).replace(/[&<>"']/g, (c) => ({
-        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
-    } as Record<string, string>)[c]);
 }

--- a/frontend/src/modules/profile-menu.ts
+++ b/frontend/src/modules/profile-menu.ts
@@ -2,17 +2,12 @@
 // account/settings actions belong here too.
 
 import { get } from 'svelte/store';
-import { state } from '../state';
 import { Me } from '../../wailsjs/go/main/App';
+import { renderEncryptionSettingsEntry } from './encryption';
 import { openLogoutModal } from './modals/logout';
 import { openEncryptionSettingsModal } from './modals/encryption-settings';
 import ProfileMenu from '../ui/chrome/ProfileMenu.svelte';
-import {
-    encryptionEntryVisible,
-    profileLoaded,
-    profileUser,
-    type ProfileUser,
-} from '../ui/chrome/profile-store';
+import { profileLoaded, profileUser, type ProfileUser } from '../ui/chrome/profile-store';
 import { mountSvelte, type SvelteMountHandle } from '../ui/mount';
 
 let profileMenuHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
@@ -60,8 +55,4 @@ export async function loadSelfUser(): Promise<ProfileUser | null> {
 async function ensureProfileLoaded(): Promise<void> {
     if (get(profileUser)) return; // already hydrated; menu opens use the cache
     await loadSelfUser();
-}
-
-export function renderEncryptionSettingsEntry() {
-    encryptionEntryVisible.set(Boolean(state.encryption?.passwordSet));
 }

--- a/frontend/src/modules/profile-menu.ts
+++ b/frontend/src/modules/profile-menu.ts
@@ -1,189 +1,67 @@
 // Top-right avatar dropdown. Currently hosts the logout entry; future
 // account/settings actions belong here too.
 
+import { get } from 'svelte/store';
 import { state } from '../state';
 import { Me } from '../../wailsjs/go/main/App';
-import { renderAvatar } from './avatar';
 import { openLogoutModal } from './modals/logout';
 import { openEncryptionSettingsModal } from './modals/encryption-settings';
+import ProfileMenu from '../ui/chrome/ProfileMenu.svelte';
+import {
+    encryptionEntryVisible,
+    profileLoaded,
+    profileUser,
+    type ProfileUser,
+} from '../ui/chrome/profile-store';
+import { mountSvelte, type SvelteMountHandle } from '../ui/mount';
 
-let trigger: HTMLElement | null = null;
-let menu: HTMLElement | null = null;
-let outsideClickBound = false;
-let selfUserPromise: Promise<any> | null = null;
+let profileMenuHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
+let selfUserPromise: Promise<ProfileUser | null> | null = null;
 
 export function setupProfileMenu() {
-    trigger = document.getElementById('profile-trigger');
-    menu = document.getElementById('profile-menu');
-    const logoutItem = document.getElementById('profile-menu-logout');
-    const encryptionItem = document.getElementById('profile-menu-encryption-settings');
-    if (!trigger || !menu || !logoutItem) return;
+    const host = document.getElementById('profile-root');
+    if (!host || profileMenuHandle) return;
 
-    renderProfileLoading();
-
-    trigger.addEventListener('click', (e) => {
-        e.stopPropagation();
-        toggleMenu();
+    host.replaceChildren();
+    profileMenuHandle = mountSvelte(ProfileMenu, {
+        target: host,
+        props: {
+            onOpen: () => {
+                void ensureProfileLoaded();
+            },
+            onEncryptionSettings: openEncryptionSettingsModal,
+            onLogout: openLogoutModal,
+        },
     });
-
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && isOpen()) {
-            closeMenu();
-            trigger!.focus();
-        }
-    });
-
-    menu.addEventListener('keydown', (e) => {
-        if (!isOpen()) return;
-        if (e.key === 'Escape') {
-            e.preventDefault();
-            closeMenu();
-            trigger!.focus();
-            return;
-        }
-        if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key)) return;
-
-        const items = menuItems();
-        if (!items.length) return;
-
-        e.preventDefault();
-        const current = document.activeElement as HTMLElement | null;
-        const index = current ? items.indexOf(current) : -1;
-
-        if (e.key === 'Home') {
-            items[0].focus();
-            return;
-        }
-        if (e.key === 'End') {
-            items[items.length - 1].focus();
-            return;
-        }
-
-        const direction = e.key === 'ArrowDown' ? 1 : -1;
-        const next = index >= 0
-            ? (index + direction + items.length) % items.length
-            : direction > 0 ? 0 : items.length - 1;
-        items[next].focus();
-    });
-
-    logoutItem.addEventListener('click', () => {
-        closeMenu();
-        openLogoutModal();
-    });
-    if (encryptionItem) {
-        encryptionItem.addEventListener('click', () => {
-            closeMenu();
-            openEncryptionSettingsModal();
-        });
-    }
 
     renderEncryptionSettingsEntry();
 }
 
 // loadSelfUser fetches the logged-in user once after dashboard mount and
-// hydrates both avatars + the menu header. Called from auth.js after
+// hydrates both avatars + the menu header. Called from auth.ts after
 // InitDrive succeeds. Failures fall back silently to initials/blank.
-export async function loadSelfUser() {
+export async function loadSelfUser(): Promise<ProfileUser | null> {
     if (selfUserPromise) return selfUserPromise;
     selfUserPromise = (async () => {
+        let user: ProfileUser | null = null;
         try {
-            const user = await Me();
-            state.selfUser = user || null;
+            user = ((await Me()) as ProfileUser) || null;
         } catch (err) {
             console.warn('Me failed:', err);
-            state.selfUser = null;
         }
-        renderProfile();
+        profileUser.set(user);
+        profileLoaded.set(true);
         selfUserPromise = null;
-        return state.selfUser;
+        return user;
     })();
     return selfUserPromise;
 }
 
-function renderProfileLoading() {
-    renderAvatar(document.getElementById('profile-avatar'), null);
-    renderAvatar(document.getElementById('profile-menu-avatar'), null);
-    const name = document.getElementById('profile-menu-name');
-    const handle = document.getElementById('profile-menu-handle');
-    if (name) name.textContent = 'Loading account…';
-    if (handle) {
-        handle.textContent = '';
-        handle.style.display = 'none';
-    }
-}
-
-async function ensureProfileLoaded() {
-    if (state.selfUser) return;
-    renderProfileLoading();
-    try {
-        await loadSelfUser();
-    } catch {}
-}
-
-function renderProfile() {
-    const user = state.selfUser;
-    renderAvatar(document.getElementById('profile-avatar'), user);
-    renderAvatar(document.getElementById('profile-menu-avatar'), user);
-
-    const name = document.getElementById('profile-menu-name');
-    const handle = document.getElementById('profile-menu-handle');
-
-    if (name) name.textContent = user?.display_name || 'Telegram account';
-    if (handle) {
-        const u = String(user?.username || '').trim();
-        handle.textContent = u ? `@${u}` : '';
-        handle.style.display = u ? '' : 'none';
-    }
+async function ensureProfileLoaded(): Promise<void> {
+    if (get(profileUser)) return; // already hydrated; menu opens use the cache
+    await loadSelfUser();
 }
 
 export function renderEncryptionSettingsEntry() {
-    const item = document.getElementById('profile-menu-encryption-settings');
-    const divider = document.getElementById('profile-menu-encryption-settings-divider');
-    const show = !!state.encryption?.passwordSet;
-    if (item) item.hidden = !show;
-    if (divider) divider.hidden = !show;
-}
-
-function toggleMenu() {
-    if (isOpen()) closeMenu();
-    else openMenu();
-}
-
-function openMenu() {
-    if (!trigger || !menu) return;
-    menu.hidden = false;
-    trigger.setAttribute('aria-expanded', 'true');
-    ensureProfileLoaded();
-    if (!outsideClickBound) {
-        document.addEventListener('click', onDocumentClick, true);
-        outsideClickBound = true;
-    }
-    const first = menuItems()[0];
-    if (first) first.focus();
-}
-
-function closeMenu() {
-    if (!trigger || !menu) return;
-    menu.hidden = true;
-    trigger.setAttribute('aria-expanded', 'false');
-    if (outsideClickBound) {
-        document.removeEventListener('click', onDocumentClick, true);
-        outsideClickBound = false;
-    }
-}
-
-function isOpen() {
-    return menu && !menu.hidden;
-}
-
-function onDocumentClick(e: MouseEvent) {
-    if (!menu || !trigger) return;
-    if (menu.contains(e.target as Node) || trigger.contains(e.target as Node)) return;
-    closeMenu();
-}
-
-function menuItems(): HTMLElement[] {
-    if (!menu) return [];
-    return Array.from(menu.querySelectorAll<HTMLElement>('[role="menuitem"]'))
-        .filter((item) => !item.hidden && item.offsetParent !== null && !item.hasAttribute('disabled'));
+    encryptionEntryVisible.set(Boolean(state.encryption?.passwordSet));
 }

--- a/frontend/src/modules/transfers.ts
+++ b/frontend/src/modules/transfers.ts
@@ -19,6 +19,10 @@ import {
     updateTransferName,
     markTransferDone,
 } from './notif-bell';
+import UploadMenu from '../ui/chrome/UploadMenu.svelte';
+import { mountSvelte, type SvelteMountHandle } from '../ui/mount';
+
+let uploadMenuHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
 
 const DOWNLOAD_TERMINAL_STATES = new Set(["done", "failed", "canceled"]);
 
@@ -630,46 +634,21 @@ function notifyBindingsMissing(name: string) {
 // dialogs cannot select files and folders together, so the entry point splits
 // them; drag-drop covers truly mixed selections.
 export function setupUploadMenu() {
-    const btn = document.getElementById('upload-btn');
-    const menu = document.getElementById('upload-menu');
-    if (!btn || !menu) return;
-    const filesItem = document.getElementById('upload-menu-files');
-    const folderItem = document.getElementById('upload-menu-folder');
+    const host = document.getElementById('upload-menu-root');
+    if (!host || uploadMenuHandle) return;
 
-    const close = (returnFocus = false) => {
-        menu.style.display = 'none';
-        btn.setAttribute('aria-expanded', 'false');
-        if (returnFocus) (btn as HTMLElement).focus();
-    };
-    const open = () => {
-        menu.style.display = 'flex';
-        btn.setAttribute('aria-expanded', 'true');
-        (filesItem as HTMLElement | null)?.focus();
-    };
-
-    btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        if (menu.style.display === 'none') open(); else close();
+    host.replaceChildren();
+    uploadMenuHandle = mountSvelte(UploadMenu, {
+        target: host,
+        props: {
+            onFiles: () => {
+                void uploadWithParentID(state.currentFolderId);
+            },
+            onFolder: () => {
+                void importFolderWithParentID(state.currentFolderId);
+            },
+        },
     });
-    document.addEventListener('click', (e) => {
-        if (menu.style.display !== 'none' && e.target !== btn && !menu.contains(e.target as Node)) close();
-    });
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && menu.style.display !== 'none') close(true);
-    });
-    // Arrow-key navigation between the menu items.
-    menu.addEventListener('keydown', (e) => {
-        if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
-        e.preventDefault();
-        const items = [filesItem, folderItem].filter(Boolean) as HTMLElement[];
-        if (!items.length) return;
-        const idx = items.indexOf(document.activeElement as HTMLElement);
-        const next = e.key === 'ArrowDown' ? (idx + 1) % items.length : (idx - 1 + items.length) % items.length;
-        items[next].focus();
-    });
-
-    filesItem?.addEventListener('click', () => { close(); void uploadWithParentID(state.currentFolderId); });
-    folderItem?.addEventListener('click', () => { close(); void importFolderWithParentID(state.currentFolderId); });
 }
 
 // setupFileDrop handles native OS file drops (mixed files + folders) forwarded

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -84,13 +84,6 @@ export interface State {
     userNames: Map<string, string>;
     userNameFailures: Set<string>;
     userNameRequests: Map<string, Promise<void>>;
-
-    toasts: any[];
-    historyEvents: any[];
-
-    notifPanelOpen: boolean;
-    notifHoverOpen: boolean;
-    notifUnreadErrors: number;
 }
 
 export const state: State = {
@@ -152,13 +145,6 @@ export const state: State = {
     userNames: new Map(),
     userNameFailures: new Set(),
     userNameRequests: new Map(),
-
-    toasts: [],
-    historyEvents: [],
-
-    notifPanelOpen: false,
-    notifHoverOpen: false,
-    notifUnreadErrors: 0,
 };
 
 // Helper to reset folder caches (called on refresh)

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -73,7 +73,6 @@ export interface State {
     pendingJoins: any[];
     channelSwitchInProgress: boolean;
     myUserID: number;
-    selfUser: any;
 
     encryption: EncryptionState;
 
@@ -128,7 +127,6 @@ export const state: State = {
     pendingJoins: [],
     channelSwitchInProgress: false,
     myUserID: 0,
-    selfUser: null,
 
     encryption: {
         available: false,

--- a/frontend/src/ui/chrome/Avatar.svelte
+++ b/frontend/src/ui/chrome/Avatar.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+    import { avatarViewFor, type AvatarUser } from '../../modules/avatar';
+
+    interface Props {
+        user: AvatarUser | null;
+        large?: boolean;
+    }
+
+    let { user, large = false }: Props = $props();
+
+    const view = $derived(avatarViewFor(user));
+    const style = $derived(
+        view.photoUrl
+            ? `background-image: url("${view.photoUrl}"); background-size: cover; background-position: center;`
+            : view.color
+                ? `background: ${view.color};`
+                : 'background: var(--surface-2, rgba(255,255,255,0.06));',
+    );
+</script>
+
+<span class={`profile-avatar${large ? ' profile-avatar-lg' : ''}`} aria-hidden="true" {style}>{view.initials ?? ''}</span>

--- a/frontend/src/ui/chrome/Breadcrumb.svelte
+++ b/frontend/src/ui/chrome/Breadcrumb.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+    import { breadcrumbPath, type BreadcrumbDrag } from './breadcrumb-store';
+
+    interface Props {
+        // index -1 targets the root ("My Drive"), otherwise a folderPath index.
+        onNavigate: (index: number) => void;
+        onBack: () => void;
+        drag: BreadcrumbDrag;
+    }
+
+    let { onNavigate, onBack, drag }: Props = $props();
+
+    interface CrumbItem {
+        id: string;
+        name: string;
+        index: number;
+    }
+
+    const items = $derived<CrumbItem[]>([
+        { id: '', name: 'My Drive', index: -1 },
+        ...$breadcrumbPath.map((f, i) => ({ id: f.id, name: f.name, index: i })),
+    ]);
+    const atRoot = $derived($breadcrumbPath.length === 0);
+
+    function registerRoot(el: HTMLElement) {
+        drag.registerRoot(el);
+    }
+
+    function onDragOver(event: DragEvent, item: CrumbItem): void {
+        if (!drag.isActive()) return;
+        const el = event.currentTarget as HTMLElement;
+        const allowed = drag.canDrop(item.id);
+        drag.highlight(el, allowed);
+        if (event.dataTransfer) event.dataTransfer.dropEffect = allowed ? 'move' : 'none';
+        if (allowed) event.preventDefault();
+    }
+
+    function onDragLeave(event: DragEvent): void {
+        const el = event.currentTarget as HTMLElement;
+        if (event.relatedTarget && el.contains(event.relatedTarget as Node)) return;
+        drag.leave(el);
+    }
+
+    function onDrop(event: DragEvent, item: CrumbItem): void {
+        if (!drag.isActive() || !drag.canDrop(item.id)) return;
+        event.preventDefault();
+        event.stopPropagation();
+        drag.dropOn(event.currentTarget as HTMLElement, item.id);
+    }
+</script>
+
+<button
+    id="breadcrumb-back"
+    class="icon-btn back-btn"
+    type="button"
+    title="Back"
+    aria-label="Back"
+    disabled={atRoot}
+    style={`opacity: ${atRoot ? '0.35' : '1'}`}
+    onclick={onBack}
+>
+    <svg fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
+</button>
+<div id="breadcrumb-path" class="breadcrumb-path">
+    {#each items as item, idx (item.index === -1 ? 'root' : item.id)}
+        {#if idx > 0}
+            <span class="breadcrumb-sep">/</span>
+        {/if}
+        {#if item.index === -1}
+            <button
+                type="button"
+                class="breadcrumb-link"
+                data-index="-1"
+                use:registerRoot
+                onclick={() => onNavigate(-1)}
+                ondragover={(event) => onDragOver(event, item)}
+                ondragleave={onDragLeave}
+                ondrop={(event) => onDrop(event, item)}
+            >
+                {item.name}
+            </button>
+        {:else}
+            <button
+                type="button"
+                class="breadcrumb-link"
+                data-index={String(item.index)}
+                onclick={() => onNavigate(item.index)}
+                ondragover={(event) => onDragOver(event, item)}
+                ondragleave={onDragLeave}
+                ondrop={(event) => onDrop(event, item)}
+            >
+                {item.name}
+            </button>
+        {/if}
+    {/each}
+</div>

--- a/frontend/src/ui/chrome/ProfileMenu.svelte
+++ b/frontend/src/ui/chrome/ProfileMenu.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+    import { tick } from 'svelte';
+    import Avatar from './Avatar.svelte';
+    import { encryptionEntryVisible, profileLoaded, profileUser } from './profile-store';
+
+    interface Props {
+        // Called when the menu opens, so the module can lazily fetch Me().
+        onOpen: () => void;
+        onEncryptionSettings: () => void;
+        onLogout: () => void;
+    }
+
+    let { onOpen, onEncryptionSettings, onLogout }: Props = $props();
+
+    let open = $state(false);
+    let triggerEl = $state<HTMLButtonElement | null>(null);
+    let menuEl = $state<HTMLElement | null>(null);
+
+    const displayName = $derived(
+        !$profileLoaded ? 'Loading account…' : $profileUser?.display_name || 'Telegram account',
+    );
+    const handle = $derived(($profileUser?.username || '').trim());
+
+    function menuItems(): HTMLElement[] {
+        if (!menuEl) return [];
+        return Array.from(menuEl.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+            .filter((item) => !item.hidden && !item.hasAttribute('disabled'));
+    }
+
+    async function openMenu(): Promise<void> {
+        open = true;
+        onOpen();
+        await tick();
+        menuItems()[0]?.focus();
+    }
+
+    function closeMenu(returnFocus = false): void {
+        open = false;
+        if (returnFocus) triggerEl?.focus();
+    }
+
+    function toggleMenu(): void {
+        if (open) closeMenu();
+        else void openMenu();
+    }
+
+    function activate(action: () => void): void {
+        closeMenu();
+        action();
+    }
+
+    function onMenuKeydown(event: KeyboardEvent): void {
+        if (!open) return;
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closeMenu(true);
+            return;
+        }
+        if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
+
+        const items = menuItems();
+        if (!items.length) return;
+
+        event.preventDefault();
+        const current = document.activeElement as HTMLElement | null;
+        const index = current ? items.indexOf(current) : -1;
+
+        if (event.key === 'Home') {
+            items[0].focus();
+            return;
+        }
+        if (event.key === 'End') {
+            items[items.length - 1].focus();
+            return;
+        }
+
+        const direction = event.key === 'ArrowDown' ? 1 : -1;
+        const next = index >= 0
+            ? (index + direction + items.length) % items.length
+            : direction > 0 ? 0 : items.length - 1;
+        items[next].focus();
+    }
+
+    function onWindowKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Escape' && open) {
+            closeMenu(true);
+        }
+    }
+
+    function onDocumentClick(event: MouseEvent): void {
+        if (!open) return;
+        const target = event.target as Node;
+        if (menuEl?.contains(target) || triggerEl?.contains(target)) return;
+        closeMenu();
+    }
+</script>
+
+<svelte:window onkeydown={onWindowKeydown} />
+<svelte:document onclickcapture={onDocumentClick} />
+
+<button
+    bind:this={triggerEl}
+    id="profile-trigger"
+    class="profile-trigger"
+    type="button"
+    aria-haspopup="menu"
+    aria-expanded={open ? 'true' : 'false'}
+    aria-controls="profile-menu"
+    title="Account"
+    onclick={(event) => {
+        event.stopPropagation();
+        toggleMenu();
+    }}
+>
+    <Avatar user={$profileUser} />
+    <svg class="profile-chevron" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" /></svg>
+</button>
+
+<div
+    bind:this={menuEl}
+    id="profile-menu"
+    class="profile-menu"
+    role="menu"
+    aria-labelledby="profile-trigger"
+    tabindex="-1"
+    hidden={!open}
+    onkeydown={onMenuKeydown}
+>
+    <div class="profile-menu-header">
+        <Avatar user={$profileUser} large />
+        <div class="profile-menu-meta">
+            <div id="profile-menu-name" class="profile-menu-name">{displayName}</div>
+            {#if handle}
+                <div id="profile-menu-handle" class="profile-menu-handle">@{handle}</div>
+            {/if}
+        </div>
+    </div>
+    <div class="profile-menu-divider" role="separator"></div>
+    {#if $encryptionEntryVisible}
+        <button
+            id="profile-menu-encryption-settings"
+            class="profile-menu-item"
+            type="button"
+            role="menuitem"
+            onclick={() => activate(onEncryptionSettings)}
+        >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path stroke-linecap="round" stroke-linejoin="round" d="M8 11V7a4 4 0 018 0v4"/></svg>
+            <span>Encryption settings</span>
+        </button>
+        <div class="profile-menu-divider" role="separator"></div>
+    {/if}
+    <button
+        id="profile-menu-logout"
+        class="profile-menu-item danger-text"
+        type="button"
+        role="menuitem"
+        onclick={() => activate(onLogout)}
+    >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/></svg>
+        <span>Log out</span>
+    </button>
+</div>

--- a/frontend/src/ui/chrome/UploadMenu.svelte
+++ b/frontend/src/ui/chrome/UploadMenu.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+    import { tick } from 'svelte';
+
+    interface Props {
+        onFiles: () => void;
+        onFolder: () => void;
+    }
+
+    let { onFiles, onFolder }: Props = $props();
+
+    let open = $state(false);
+    let buttonEl = $state<HTMLButtonElement | null>(null);
+    let menuEl = $state<HTMLElement | null>(null);
+    let filesEl = $state<HTMLButtonElement | null>(null);
+    let folderEl = $state<HTMLButtonElement | null>(null);
+
+    async function openMenu(): Promise<void> {
+        open = true;
+        await tick();
+        filesEl?.focus();
+    }
+
+    function closeMenu(returnFocus = false): void {
+        open = false;
+        if (returnFocus) buttonEl?.focus();
+    }
+
+    function activate(action: () => void): void {
+        closeMenu();
+        action();
+    }
+
+    function onWindowKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Escape' && open) closeMenu(true);
+    }
+
+    function onDocumentClick(event: MouseEvent): void {
+        if (!open) return;
+        const target = event.target as Node;
+        if (buttonEl?.contains(target) || menuEl?.contains(target)) return;
+        closeMenu();
+    }
+
+    // Arrow-key navigation between the two menu items.
+    function onMenuKeydown(event: KeyboardEvent): void {
+        if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+        event.preventDefault();
+        const items = [filesEl, folderEl].filter(Boolean) as HTMLElement[];
+        if (!items.length) return;
+        const idx = items.indexOf(document.activeElement as HTMLElement);
+        const next = event.key === 'ArrowDown' ? (idx + 1) % items.length : (idx - 1 + items.length) % items.length;
+        items[next].focus();
+    }
+</script>
+
+<svelte:window onkeydown={onWindowKeydown} />
+<svelte:document onclick={onDocumentClick} />
+
+<button
+    bind:this={buttonEl}
+    id="upload-btn"
+    class="primary-btn upload-btn"
+    type="button"
+    aria-haspopup="menu"
+    aria-expanded={open ? 'true' : 'false'}
+    aria-controls="upload-menu"
+    onclick={(event) => {
+        event.stopPropagation();
+        if (open) closeMenu();
+        else void openMenu();
+    }}
+>
+    <svg class="btn-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
+    Upload
+</button>
+<div
+    bind:this={menuEl}
+    id="upload-menu"
+    class="upload-menu"
+    role="menu"
+    tabindex="-1"
+    style={`display: ${open ? 'flex' : 'none'};`}
+    onkeydown={onMenuKeydown}
+>
+    <button bind:this={filesEl} id="upload-menu-files" class="upload-menu-item" type="button" role="menuitem" onclick={() => activate(onFiles)}>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 13h6m-6 4h6m2 4H7a2 2 0 01-2-2V5a2 2 0 012-2h7l5 5v11a2 2 0 01-2 2z"/></svg>
+        Files
+    </button>
+    <button bind:this={folderEl} id="upload-menu-folder" class="upload-menu-item" type="button" role="menuitem" onclick={() => activate(onFolder)}>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"/></svg>
+        Folder
+    </button>
+</div>

--- a/frontend/src/ui/chrome/breadcrumb-store.ts
+++ b/frontend/src/ui/chrome/breadcrumb-store.ts
@@ -1,0 +1,22 @@
+import { writable } from 'svelte/store';
+
+export interface BreadcrumbEntry {
+    id: string;
+    name: string;
+}
+
+// Drag-to-move plumbing stays in modules (navigation + drag-drop); the
+// component only forwards DOM events with the crumb's folder id.
+export interface BreadcrumbDrag {
+    isActive: () => boolean;
+    canDrop: (folderId: string) => boolean;
+    highlight: (el: HTMLElement, allowed: boolean) => void;
+    leave: (el: HTMLElement) => void;
+    dropOn: (el: HTMLElement, folderId: string) => void;
+    registerRoot: (el: HTMLElement) => void;
+}
+
+// Render bridge for the breadcrumb. state.folderPath stays the source of
+// truth (several modules mutate it); modules/navigation.ts mirrors it here
+// on every renderBreadcrumb() call.
+export const breadcrumbPath = writable<BreadcrumbEntry[]>([]);

--- a/frontend/src/ui/chrome/chrome.test.ts
+++ b/frontend/src/ui/chrome/chrome.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import Avatar from './Avatar.svelte';
+import Breadcrumb from './Breadcrumb.svelte';
+import ProfileMenu from './ProfileMenu.svelte';
+import UploadMenu from './UploadMenu.svelte';
+import { breadcrumbPath, type BreadcrumbDrag } from './breadcrumb-store';
+import { encryptionEntryVisible, profileLoaded, profileUser } from './profile-store';
+
+const noop = () => {};
+
+const drag: BreadcrumbDrag = {
+    isActive: () => false,
+    canDrop: () => false,
+    highlight: noop,
+    leave: noop,
+    dropOn: noop,
+    registerRoot: noop,
+};
+
+const breadcrumbProps = { onNavigate: noop, onBack: noop, drag };
+const profileProps = { onOpen: noop, onEncryptionSettings: noop, onLogout: noop };
+const uploadProps = { onFiles: noop, onFolder: noop };
+
+afterEach(() => {
+    breadcrumbPath.set([]);
+    profileUser.set(null);
+    profileLoaded.set(false);
+    encryptionEntryVisible.set(false);
+});
+
+describe('Breadcrumb', () => {
+    it('renders only a disabled root at the drive root', () => {
+        const { body } = render(Breadcrumb, { props: breadcrumbProps });
+
+        expect(body).toContain('My Drive');
+        expect(body).not.toContain('breadcrumb-sep');
+        expect(body).toContain('opacity: 0.35'); // back button dimmed
+    });
+
+    it('renders crumbs with separators and an enabled back button', () => {
+        breadcrumbPath.set([
+            { id: 'd:a', name: 'Docs' },
+            { id: 'd:b', name: 'Taxes & <stuff>' },
+        ]);
+
+        const { body } = render(Breadcrumb, { props: breadcrumbProps });
+
+        expect(body).toContain('Docs');
+        expect(body).toContain('Taxes &amp; &lt;stuff>');
+        expect((body.match(/breadcrumb-sep/g) || [])).toHaveLength(2);
+        expect(body).toContain('opacity: 1');
+        expect(body).toContain('data-index="1"');
+    });
+});
+
+describe('Avatar', () => {
+    it('renders a photo background when available', () => {
+        const { body } = render(Avatar, { props: { user: { photo_base64: 'Zm9v' } } });
+        expect(body).toContain('data:image/jpeg;base64,Zm9v');
+    });
+
+    it('falls back to initials on the deterministic palette', () => {
+        const { body } = render(Avatar, { props: { user: { display_name: 'Ada Lovelace', user_id: 1 } } });
+        expect(body).toContain('>AL</span>');
+        expect(body).toContain('background: #bb9af7'); // 1 % 8 -> palette[1]
+    });
+});
+
+describe('ProfileMenu', () => {
+    it('shows the loading header until the profile hydrates', () => {
+        const { body } = render(ProfileMenu, { props: profileProps });
+
+        expect(body).toContain('Loading account…');
+        expect(body).not.toContain('profile-menu-encryption-settings');
+        expect(body).toContain('Log out');
+    });
+
+    it('renders name, handle, and the encryption entry when enabled', () => {
+        profileUser.set({ display_name: 'Ada L.', username: 'ada', user_id: 7 });
+        profileLoaded.set(true);
+        encryptionEntryVisible.set(true);
+
+        const { body } = render(ProfileMenu, { props: profileProps });
+
+        expect(body).toContain('Ada L.');
+        expect(body).toContain('@ada');
+        expect(body).toContain('Encryption settings');
+    });
+});
+
+describe('UploadMenu', () => {
+    it('renders the trigger and a hidden menu with both items', () => {
+        const { body } = render(UploadMenu, { props: uploadProps });
+
+        expect(body).toContain('id="upload-btn"');
+        expect(body).toContain('aria-expanded="false"');
+        expect(body).toContain('display: none');
+        expect(body).toContain('id="upload-menu-files"');
+        expect(body).toContain('id="upload-menu-folder"');
+    });
+});

--- a/frontend/src/ui/chrome/profile-store.ts
+++ b/frontend/src/ui/chrome/profile-store.ts
@@ -1,0 +1,13 @@
+import { writable } from 'svelte/store';
+import type { AvatarUser } from '../../modules/avatar';
+
+export interface ProfileUser extends AvatarUser {
+    display_name?: string;
+    username?: string;
+}
+
+// null means "not loaded yet"; the menu shows its loading header until the
+// first Me() resolves (or fails, which falls back to the generic label).
+export const profileUser = writable<ProfileUser | null>(null);
+export const profileLoaded = writable(false);
+export const encryptionEntryVisible = writable(false);

--- a/frontend/src/ui/notifications/EventRow.svelte
+++ b/frontend/src/ui/notifications/EventRow.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+    import type { NoticeEvent } from './notif-store';
+
+    interface Props {
+        event: NoticeEvent;
+    }
+
+    let { event }: Props = $props();
+    let copied = $state(false);
+    let copiedTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clipable = $derived(event.level === 'error' && Boolean(event.body));
+
+    function formatRelative(ts: number): string {
+        if (!ts) return '';
+        const diffSec = Math.floor((Date.now() - ts) / 1000);
+        if (diffSec < 30) return 'just now';
+        if (diffSec < 60) return `${diffSec}s ago`;
+        const m = Math.floor(diffSec / 60);
+        if (m < 60) return `${m} min ago`;
+        const h = Math.floor(m / 60);
+        if (h < 24) return `${h} hr ago`;
+        const d = Math.floor(h / 24);
+        if (d < 7) return `${d}d ago`;
+        return new Date(ts).toLocaleDateString();
+    }
+
+    async function copyBody(): Promise<void> {
+        if (!clipable) return;
+        try {
+            await navigator.clipboard.writeText(`${event.title}\n${event.body}`);
+        } catch {
+            return;
+        }
+        copied = true;
+        if (copiedTimer) clearTimeout(copiedTimer);
+        copiedTimer = setTimeout(() => {
+            copied = false;
+            copiedTimer = null;
+        }, 800);
+    }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+<div
+    class={`notif-row notif-row-event level-${event.level}${copied ? ' notif-copied' : ''}`}
+    data-clipable={clipable ? '1' : '0'}
+    onclick={() => void copyBody()}
+>
+    <span class="notif-row-icon" data-kind={event.level} aria-hidden="true">
+        {#if event.level === 'success'}
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        {:else if event.level === 'error'}
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+        {:else if event.level === 'warning'}
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        {:else}
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+        {/if}
+    </span>
+    <div class="notif-row-body">
+        <div class="notif-row-title">{event.title}</div>
+        {#if event.body}
+            <div class="notif-row-sub">{event.body}</div>
+        {/if}
+    </div>
+    <div class="notif-row-meta">{formatRelative(event.ts)}</div>
+</div>

--- a/frontend/src/ui/notifications/NotifBell.svelte
+++ b/frontend/src/ui/notifications/NotifBell.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+    import EventRow from './EventRow.svelte';
+    import TransferRow from './TransferRow.svelte';
+    import { portal } from './portal';
+    import {
+        activeTransfers,
+        bellMode,
+        notifHoverOpen,
+        notifPanelOpen,
+        notifUnreadErrors,
+        recentEvents,
+        type TransferDirection,
+    } from './notif-store';
+
+    interface Props {
+        onCancelDirection: (direction: TransferDirection) => void;
+        onClearHistory: () => void;
+    }
+
+    let { onCancelDirection, onClearHistory }: Props = $props();
+
+    const HOVER_GRACE_MS = 280;
+
+    let bellEl = $state<HTMLButtonElement | null>(null);
+    let anchor = $state({ top: 0, right: 0 });
+    let hoverGraceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function surfaceOut(_node: Element) {
+        // Mirrors the legacy .notif-leaving fade.
+        return { duration: 160, css: (t: number) => `opacity: ${t};` };
+    }
+
+    function reanchor(): void {
+        if (!bellEl) return;
+        const rect = bellEl.getBoundingClientRect();
+        anchor = {
+            top: rect.bottom + 10,
+            right: Math.max(12, window.innerWidth - rect.right),
+        };
+    }
+
+    function clearGraceTimer(): void {
+        if (hoverGraceTimer) {
+            clearTimeout(hoverGraceTimer);
+            hoverGraceTimer = null;
+        }
+    }
+
+    function openPanel(): void {
+        closeHover();
+        reanchor();
+        notifPanelOpen.set(true);
+        notifUnreadErrors.set(0); // opening clears the unread badge
+    }
+
+    function closePanel(): void {
+        notifPanelOpen.set(false);
+    }
+
+    function togglePanel(): void {
+        if ($notifPanelOpen) closePanel();
+        else openPanel();
+    }
+
+    function openHover(): void {
+        if ($notifPanelOpen || $activeTransfers.length === 0) return;
+        reanchor();
+        notifHoverOpen.set(true);
+    }
+
+    function closeHover(): void {
+        clearGraceTimer();
+        notifHoverOpen.set(false);
+    }
+
+    function onBellEnter(): void {
+        if ($notifPanelOpen) return;
+        clearGraceTimer();
+        openHover();
+    }
+
+    function onBellLeave(): void {
+        clearGraceTimer();
+        hoverGraceTimer = setTimeout(() => closeHover(), HOVER_GRACE_MS);
+    }
+
+    function onBellKeydown(event: KeyboardEvent): void {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            togglePanel();
+        }
+    }
+
+    function onWindowKeydown(event: KeyboardEvent): void {
+        if (event.key !== 'Escape') return;
+        if ($notifPanelOpen) closePanel();
+        else if ($notifHoverOpen) closeHover();
+    }
+
+    function onDocumentMousedown(event: MouseEvent): void {
+        if (!$notifPanelOpen) return;
+        const target = event.target as Node;
+        if (bellEl?.contains(target)) return;
+        if ((target as HTMLElement).closest?.('.notif-panel')) return;
+        closePanel();
+    }
+
+    // The hover popover only exists while transfers run; drop it the moment
+    // the last active transfer settles.
+    $effect(() => {
+        if ($notifHoverOpen && $activeTransfers.length === 0) closeHover();
+    });
+</script>
+
+<svelte:window onkeydown={onWindowKeydown} onresize={reanchor} />
+<svelte:document onmousedown={onDocumentMousedown} />
+
+<button
+    bind:this={bellEl}
+    id="notif-bell"
+    class="notif-bell"
+    type="button"
+    data-mode={$bellMode}
+    aria-haspopup="dialog"
+    aria-expanded={$notifPanelOpen ? 'true' : 'false'}
+    aria-label="Notifications"
+    onclick={(event) => {
+        event.stopPropagation();
+        togglePanel();
+    }}
+    onkeydown={onBellKeydown}
+    onmouseenter={onBellEnter}
+    onmouseleave={onBellLeave}
+>
+    <span class="notif-bell-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 1112 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 003.4 0"/></svg>
+    </span>
+    <span class="notif-bell-dot" data-mode={$bellMode} aria-hidden="true"></span>
+</button>
+
+{#if $notifHoverOpen}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+        class="notif-popover"
+        role="dialog"
+        aria-label="Active transfers"
+        tabindex="-1"
+        style={`top:${anchor.top}px; right:${anchor.right}px;`}
+        use:portal
+        out:surfaceOut
+        onmouseenter={clearGraceTimer}
+        onmouseleave={onBellLeave}
+        onclick={(event) => {
+            // Click into the popover upgrades it to the full panel.
+            event.stopPropagation();
+            openPanel();
+        }}
+    >
+        <div class="notif-popover-list">
+            {#each $activeTransfers.slice(0, 4) as transfer (transfer.id)}
+                <TransferRow {transfer} onCancel={onCancelDirection} />
+            {/each}
+        </div>
+        {#if $activeTransfers.length > 4}
+            <div class="notif-popover-more">+ {$activeTransfers.length - 4} more</div>
+        {/if}
+    </div>
+{/if}
+
+{#if $notifPanelOpen}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+        class="notif-panel"
+        role="dialog"
+        aria-modal="false"
+        aria-label="Notifications"
+        tabindex="-1"
+        style={`top:${anchor.top}px; right:${anchor.right}px;`}
+        use:portal
+        out:surfaceOut
+        onclick={(event) => event.stopPropagation()}
+    >
+        <div class="notif-panel-header">
+            <div class="notif-panel-title">Notifications</div>
+            <button
+                class="notif-panel-clear"
+                type="button"
+                disabled={$recentEvents.length === 0}
+                onclick={onClearHistory}
+            >
+                Clear
+            </button>
+        </div>
+        <div class="notif-panel-body">
+            {#if $activeTransfers.length > 0}
+                <div class="notif-section-label">Active</div>
+                <div class="notif-section">
+                    {#each $activeTransfers as transfer (transfer.id)}
+                        <TransferRow {transfer} onCancel={onCancelDirection} />
+                    {/each}
+                </div>
+            {/if}
+            {#if $recentEvents.length > 0}
+                <div class="notif-section-label" style={`margin-top:${$activeTransfers.length > 0 ? '14px' : '0'}`}>Recent</div>
+                <div class="notif-section">
+                    {#each $recentEvents.slice(0, 50) as entry (entry.id)}
+                        {#if entry.kind === 'transfer'}
+                            <TransferRow transfer={entry} />
+                        {:else}
+                            <EventRow event={entry} />
+                        {/if}
+                    {/each}
+                </div>
+            {:else if $activeTransfers.length === 0}
+                <div class="notif-empty">
+                    <div class="notif-empty-glyph">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 1112 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 003.4 0"/></svg>
+                    </div>
+                    <div class="notif-empty-title">All caught up</div>
+                    <div class="notif-empty-body">Folder activity, uploads, and shared-drive events will show up here.</div>
+                </div>
+            {/if}
+        </div>
+    </div>
+{/if}

--- a/frontend/src/ui/notifications/ToastStack.svelte
+++ b/frontend/src/ui/notifications/ToastStack.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+    import { toasts, type ToastItem } from './toast-store';
+
+    interface Props {
+        onDismiss: (id: string) => void;
+        onPauseToast: (id: string) => void;
+        onResumeToast: (id: string) => void;
+        onPauseAll: () => void;
+        onResumeAll: () => void;
+    }
+
+    let { onDismiss, onPauseToast, onResumeToast, onPauseAll, onResumeAll }: Props = $props();
+
+    // Mirrors the legacy .toast-leaving exit: fade and slide while the stack
+    // collapses underneath.
+    function toastOut(_node: Element) {
+        return {
+            duration: 180,
+            css: (t: number) => `opacity: ${t}; transform: translateY(${(1 - t) * 6}px);`,
+        };
+    }
+
+    function onToastClick(event: MouseEvent, toast: ToastItem): void {
+        if ((event.target as HTMLElement).closest('.toast-close')) return;
+        // Click anywhere on an error to clear it quickly.
+        if (toast.level === 'error') onDismiss(toast.id);
+    }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    class="toast-stack-inner"
+    style="display: contents;"
+    onmouseenter={onPauseAll}
+    onmouseleave={onResumeAll}
+>
+    {#each $toasts as toast (toast.id)}
+        <div
+            class={`toast toast-${toast.level}`}
+            data-id={toast.id}
+            role={toast.level === 'error' ? 'alert' : 'status'}
+            out:toastOut
+            onmouseenter={() => onPauseToast(toast.id)}
+            onmouseleave={() => onResumeToast(toast.id)}
+            onclick={(event) => onToastClick(event, toast)}
+        >
+            <span class="toast-icon" aria-hidden="true">
+                {#if toast.spinner}
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" class="toast-spinner"><circle cx="12" cy="12" r="9" stroke-opacity="0.25"/><path d="M12 3 a9 9 0 0 1 9 9"/></svg>
+                {:else if toast.level === 'success'}
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>
+                {:else if toast.level === 'warning'}
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                {:else if toast.level === 'error'}
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
+                {:else}
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+                {/if}
+            </span>
+            <div class="toast-content">
+                <div class="toast-title">{toast.title}</div>
+                {#if toast.body}
+                    <div class="toast-body">{toast.body}</div>
+                {/if}
+            </div>
+            <button
+                class="toast-close"
+                type="button"
+                aria-label="Dismiss"
+                onclick={(event) => {
+                    event.stopPropagation();
+                    onDismiss(toast.id);
+                }}
+            >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            </button>
+        </div>
+    {/each}
+</div>

--- a/frontend/src/ui/notifications/TransferRow.svelte
+++ b/frontend/src/ui/notifications/TransferRow.svelte
@@ -36,6 +36,15 @@
         event.stopPropagation();
         onCancel?.(transfer.direction);
     }
+
+    // Keyboard activation: pointerdown never fires for Enter/Space, and the
+    // native click those keys synthesize is not handled either.
+    function onCancelKeydown(event: KeyboardEvent): void {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        event.stopPropagation();
+        onCancel?.(transfer.direction);
+    }
 </script>
 
 <div class={`notif-row notif-row-transfer ${statusClass}`}>
@@ -72,6 +81,7 @@
             aria-label="Cancel transfer"
             title="Cancel"
             onpointerdown={onCancelPointerDown}
+            onkeydown={onCancelKeydown}
         >
             &times;
         </button>

--- a/frontend/src/ui/notifications/TransferRow.svelte
+++ b/frontend/src/ui/notifications/TransferRow.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+    import { formatBytes } from '../../utils';
+    import type { TransferEvent } from './notif-store';
+
+    interface Props {
+        transfer: TransferEvent;
+        onCancel?: (direction: TransferEvent['direction']) => void;
+    }
+
+    let { transfer, onCancel }: Props = $props();
+
+    const direction = $derived(transfer.direction === 'up' ? 'upload' : 'download');
+    const dirLabel = $derived(transfer.direction === 'up' ? 'Uploading' : 'Downloading');
+    const statusClass = $derived(
+        transfer.status === 'done' ? 'is-done'
+        : transfer.status === 'failed' ? 'is-failed'
+        : transfer.status === 'canceled' ? 'is-canceled'
+        : 'is-active',
+    );
+    const progressWidth = $derived(Math.max(0, Math.min(100, transfer.progress || 0)));
+    const terminalLabel = $derived(
+        transfer.status === 'done' ? 'Done'
+        : transfer.status === 'failed' ? 'Failed'
+        : transfer.status === 'canceled' ? 'Canceled'
+        : '',
+    );
+    const doneBytes = $derived(
+        transfer.total > 0 ? Math.min(transfer.total, ((transfer.progress || 0) / 100) * transfer.total) : 0,
+    );
+
+    // pointerdown, not click: the panel re-renders on every progress tick,
+    // which can replace the button between mousedown and mouseup and eat a
+    // click. It also runs before the row's copy handler can see the event.
+    function onCancelPointerDown(event: PointerEvent): void {
+        event.preventDefault();
+        event.stopPropagation();
+        onCancel?.(transfer.direction);
+    }
+</script>
+
+<div class={`notif-row notif-row-transfer ${statusClass}`}>
+    <span class="notif-row-icon" data-kind={direction} aria-hidden="true">
+        {#if transfer.direction === 'up'}
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg>
+        {:else}
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12l7 7 7-7"/></svg>
+        {/if}
+    </span>
+    <div class="notif-row-body">
+        <div class="notif-row-title" title={transfer.name}>{transfer.name || dirLabel}</div>
+        <div class="notif-row-progress">
+            <div class="notif-row-progress-fill" style={`width:${progressWidth}%`}></div>
+        </div>
+    </div>
+    <div class="notif-row-meta">
+        {#if terminalLabel}
+            {terminalLabel}
+        {:else if transfer.total <= 0}
+            {Math.round(transfer.progress || 0)}%
+        {:else}
+            <div class="notif-row-size">{formatBytes(doneBytes)} / {formatBytes(transfer.total)}</div>
+            {#if transfer.speed > 0}
+                <div class="notif-row-speed">{formatBytes(transfer.speed)}/s</div>
+            {/if}
+        {/if}
+    </div>
+    {#if transfer.status === 'active'}
+        <button
+            class="notif-row-cancel"
+            type="button"
+            data-cancel-dir={transfer.direction}
+            aria-label="Cancel transfer"
+            title="Cancel"
+            onpointerdown={onCancelPointerDown}
+        >
+            &times;
+        </button>
+    {/if}
+</div>

--- a/frontend/src/ui/notifications/notif-store.ts
+++ b/frontend/src/ui/notifications/notif-store.ts
@@ -1,0 +1,53 @@
+import { derived, writable } from 'svelte/store';
+
+export type TransferDirection = 'up' | 'down';
+export type TransferStatus = 'active' | 'done' | 'failed' | 'canceled';
+
+export interface TransferEvent {
+    kind: 'transfer';
+    id: string; // "xfer:<direction>:<callerId>"
+    direction: TransferDirection;
+    name: string;
+    progress: number; // 0..100
+    total: number; // bytes; 0 when unknown
+    bytes: number; // transferred bytes derived from progress
+    speed: number; // smoothed bytes/sec; 0 when unknown
+    status: TransferStatus;
+    startedAt: number;
+    finishedAt: number;
+}
+
+export interface NoticeEvent {
+    kind: 'event';
+    id: string;
+    level: string;
+    title: string;
+    body: string;
+    ts: number;
+}
+
+export type HistoryEvent = TransferEvent | NoticeEvent;
+
+export type BellMode = 'idle' | 'active' | 'error';
+
+// Newest first, capped by modules/notif-bell.ts. All mutations go through
+// that module so cap/dedupe/idempotency rules live in one place.
+export const historyEvents = writable<HistoryEvent[]>([]);
+export const notifPanelOpen = writable(false);
+export const notifHoverOpen = writable(false);
+export const notifUnreadErrors = writable(0);
+
+export const activeTransfers = derived(historyEvents, (events) =>
+    events.filter((e): e is TransferEvent => e.kind === 'transfer' && e.status === 'active'),
+);
+
+// Everything that is not an in-flight transfer: notices plus finished
+// transfers, in arrival order (newest first).
+export const recentEvents = derived(historyEvents, (events) =>
+    events.filter((e) => !(e.kind === 'transfer' && e.status === 'active')),
+);
+
+export const bellMode = derived(
+    [notifUnreadErrors, activeTransfers],
+    ([unread, active]): BellMode => (unread > 0 ? 'error' : active.length > 0 ? 'active' : 'idle'),
+);

--- a/frontend/src/ui/notifications/notifications.test.ts
+++ b/frontend/src/ui/notifications/notifications.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import EventRow from './EventRow.svelte';
+import ToastStack from './ToastStack.svelte';
+import TransferRow from './TransferRow.svelte';
+import { toasts, type ToastItem } from './toast-store';
+import type { NoticeEvent, TransferEvent } from './notif-store';
+
+const noop = () => {};
+
+const stackProps = {
+    onDismiss: noop,
+    onPauseToast: noop,
+    onResumeToast: noop,
+    onPauseAll: noop,
+    onResumeAll: noop,
+};
+
+function makeTransfer(overrides: Partial<TransferEvent> = {}): TransferEvent {
+    return {
+        kind: 'transfer',
+        id: 'xfer:up:1',
+        direction: 'up',
+        name: 'clip.mp4',
+        progress: 40,
+        total: 1000,
+        bytes: 400,
+        speed: 0,
+        status: 'active',
+        startedAt: 0,
+        finishedAt: 0,
+        ...overrides,
+    };
+}
+
+function makeToast(overrides: Partial<ToastItem> = {}): ToastItem {
+    return {
+        id: 't1',
+        level: 'info',
+        title: 'Hello',
+        body: '',
+        sticky: false,
+        spinner: false,
+        durationMs: 4000,
+        expiresAt: 0,
+        paused: false,
+        ...overrides,
+    };
+}
+
+afterEach(() => {
+    toasts.set([]);
+});
+
+describe('TransferRow', () => {
+    it('renders progress, size meta, and a cancel control while active', () => {
+        const { body } = render(TransferRow, {
+            props: { transfer: makeTransfer({ speed: 2048 }), onCancel: noop },
+        });
+
+        expect(body).toContain('is-active');
+        expect(body).toContain('width:40%');
+        expect(body).toContain('400 B / 1000 B');
+        expect(body).toContain('2 KB/s');
+        expect(body).toContain('notif-row-cancel');
+        expect(body).toContain('data-cancel-dir="up"');
+    });
+
+    it('renders a terminal status word without a cancel control', () => {
+        const { body } = render(TransferRow, {
+            props: { transfer: makeTransfer({ status: 'failed', direction: 'down' }) },
+        });
+
+        expect(body).toContain('is-failed');
+        expect(body).toContain('Failed');
+        expect(body).not.toContain('notif-row-cancel');
+    });
+
+    it('falls back to a percent readout when the total is unknown', () => {
+        const { body } = render(TransferRow, {
+            props: { transfer: makeTransfer({ total: 0, progress: 62.4 }) },
+        });
+
+        expect(body).toContain('62%');
+    });
+});
+
+describe('EventRow', () => {
+    it('marks error rows with a body as copyable', () => {
+        const event: NoticeEvent = {
+            kind: 'event',
+            id: 'e1',
+            level: 'error',
+            title: 'Could not join drive',
+            body: 'INVITE_HASH_EXPIRED',
+            ts: 0,
+        };
+
+        const { body } = render(EventRow, { props: { event } });
+
+        expect(body).toContain('data-clipable="1"');
+        expect(body).toContain('level-error');
+        expect(body).toContain('INVITE_HASH_EXPIRED');
+    });
+
+    it('escapes untrusted titles', () => {
+        const event: NoticeEvent = {
+            kind: 'event',
+            id: 'e2',
+            level: 'info',
+            title: '<img src=x>',
+            body: '',
+            ts: 0,
+        };
+
+        const { body } = render(EventRow, { props: { event } });
+
+        expect(body).not.toContain('<img src=x>');
+    });
+});
+
+describe('ToastStack', () => {
+    it('renders toasts from the store with level styling', () => {
+        toasts.set([
+            makeToast({ id: 'a', level: 'success', title: 'Folder created' }),
+            makeToast({ id: 'b', level: 'error', title: 'Upload failed', body: 'FLOOD_WAIT (420)' }),
+        ]);
+
+        const { body } = render(ToastStack, { props: stackProps });
+
+        expect(body).toContain('toast-success');
+        expect(body).toContain('Folder created');
+        expect(body).toContain('toast-error');
+        expect(body).toContain('FLOOD_WAIT (420)');
+        expect(body).toContain('role="alert"');
+    });
+
+    it('renders the spinner icon for in-progress toasts', () => {
+        toasts.set([makeToast({ id: 'c', spinner: true, title: 'Deleting…' })]);
+
+        const { body } = render(ToastStack, { props: stackProps });
+
+        expect(body).toContain('toast-spinner');
+    });
+});

--- a/frontend/src/ui/notifications/portal.ts
+++ b/frontend/src/ui/notifications/portal.ts
@@ -1,0 +1,12 @@
+// Svelte action that reparents an element to document.body. The bell's
+// popover and panel are positioned with fixed viewport coordinates; hosting
+// them under the header would subject them to whatever positioned ancestor
+// or overflow clipping the header chrome happens to have.
+export function portal(node: HTMLElement): { destroy(): void } {
+    document.body.appendChild(node);
+    return {
+        destroy() {
+            node.remove();
+        },
+    };
+}

--- a/frontend/src/ui/notifications/toast-store.ts
+++ b/frontend/src/ui/notifications/toast-store.ts
@@ -1,0 +1,21 @@
+import { writable } from 'svelte/store';
+
+export type ToastLevel = 'info' | 'success' | 'warning' | 'error';
+
+export interface ToastItem {
+    id: string;
+    level: ToastLevel;
+    title: string;
+    body: string;
+    sticky: boolean;
+    spinner: boolean;
+    durationMs: number;
+    // Absolute deadline for auto-dismiss; 0 for sticky toasts. The expiry
+    // ticker in modules/notifications.ts owns this field, together with the
+    // paused/remainingMs pair that freezes the countdown while hovered.
+    expiresAt: number;
+    paused: boolean;
+    remainingMs?: number;
+}
+
+export const toasts = writable<ToastItem[]>([]);


### PR DESCRIPTION
The two biggest innerHTML surfaces are gone: toasts and the notification bell are Svelte islands driven by typed stores (toast queue with cap/replace/hover-pause rules, history with a 100-entry cap, dedupe and idempotent terminal transitions, plus an O(1) speed-sample sidecar so hot progress ticks never wake subscribers until the visible percent moves). The bell keeps all three layers: idle dot, hover popover with grace timers, and the full panel with Active and Recent sections, unread error badge, click-to-copy error rows, and per-direction cancel. Header chrome came along for the ride: breadcrumb (including drag-to-move drop targets and the dragRootEl registration), profile menu (avatar view model, keyboard nav, lazy Me() hydration), and the upload popover. Five more fields left the global state object; index.html keeps shrinking. All public module APIs (notify, pushTransferStart, renderBreadcrumb, loadSelfUser, etc.) are byte-compatible with their callers. typecheck / lint / vitest (86 tests, ssr + happy-dom behavior coverage for the bell) / build all green. Next: PR 2 gallery + auth + app shell, PR 3 preview lightbox then video player.