### PR TITLE
svelte gallery + auth screens

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,70 +9,8 @@
 <body>
     <div id="app"> 
 
-        <div id="auth-wrapper">
-            
-            <div id="setupcontainer" class="auth-box" style="display: none;">
-                <div class="auth-icon-box">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-                </div>
-                <h2>System Setup</h2>
-                <p>Configure API Credentials</p>
-                <input id="api_id" type="text" placeholder="App ID">
-                <input id="api_hash" type="text" placeholder="App Hash">
-                <button class="primary-btn" onclick="submitSetup()">Save Configuration</button>
-            </div>
-
-            <div id="phonecontainer" class="auth-box" style="display: none;"> <div class="auth-icon-box">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
-                </div>
-                <h2>Welcome Back</h2>
-                <p>Login to your secure cloud</p>
-                <input id="enterphone" type="text" placeholder="+1234567890">
-                <button class="primary-btn" onclick="startLogin()">Send Code</button>
-            </div>
-
-            <div id="codecontainer" class="auth-box" style="display: none;">
-                <div class="auth-icon-box">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
-                </div>
-                <h2>Verify Identity</h2>
-                <p class="auth-subtitle">Enter Telegram Code</p>
-                <div id="code-target-row" class="auth-helper-row" style="display: none;">
-                    <span class="auth-helper-label">Sent to</span>
-                    <span id="code-target" class="auth-helper-pill"></span>
-                    <button type="button" class="auth-link" onclick="backToPhone()">Change</button>
-                </div>
-                <input id="entercode" class="code-input" type="text" placeholder="12345">
-                <button class="primary-btn" onclick="sendCode()">Verify</button>
-            </div>
-
-            <div id="passwordcontainer" class="auth-box" style="display: none;">
-                <div class="auth-icon-box">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11.536 16.464a.5.5 0 00-.496.568l.1 1.15a.5.5 0 01-.037.24l-1.352 3.863a.5.5 0 01-.47.315H7.5a.5.5 0 01-.5-.5v-2.204a.5.5 0 01.146-.354l3.298-3.297A6 6 0 0115 7z"/></svg>
-                </div>
-                <h2>Two-Factor Auth</h2>
-                <p class="auth-subtitle">Enter your Telegram password</p>
-                <div id="hint-box" class="auth-caption" style="display: none;">
-                    Hint: <span id="hinttext"></span>
-                </div>
-                <div class="input-with-action">
-                    <input id="enterpassword" type="password" placeholder="Password" autocomplete="current-password">
-                    <button id="toggle-password" class="input-action-btn" type="button" aria-label="Show password" title="Show password">
-                        <svg class="input-action-icon icon-eye" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
-                        </svg>
-                        <svg class="input-action-icon icon-eye-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l18 18"/>
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M10.477 10.48a3 3 0 004.243 4.243"/>
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M9.88 5.09A10.48 10.48 0 0112 5c4.477 0 8.268 2.943 9.542 7a10.53 10.53 0 01-2.36 3.95"/>
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6.53 6.53A10.52 10.52 0 002.458 12c1.274 4.057 5.065 7 9.542 7 1.11 0 2.18-.18 3.19-.51"/>
-                        </svg>
-                    </button>
-                </div>
-                <button class="primary-btn" onclick="sendPassword()">Unlock</button>
-            </div>
-        </div>
+        <!-- Svelte-owned (see src/ui/auth/AuthScreens.svelte). -->
+        <div id="auth-wrapper"></div>
 
         <div id="success-screen" class="dashboard-container" style="display: none;">
             

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -8,7 +8,7 @@ import { setupSelectionBar } from './modules/selection';
 import { setupDownloadProgress, setupUploadProgress, setupUploadMenu, setupFileDrop, uploadWithParentID } from './modules/transfers';
 import { setupBreadcrumb } from './modules/navigation';
 import { setupContextMenu } from './modules/context-menu';
-import { setupPasswordReveal, setupAuthWindowBindings, checkStatusAndShowScreen, hideAllScreens } from './modules/auth';
+import { setupAuthWindowBindings, checkStatusAndShowScreen, hideAllScreens } from './modules/auth';
 import { setupFileListWindowBindings, refreshFiles } from './modules/file-list';
 import { setupGallery } from './modules/gallery';
 import { setupSearchBar, runGlobalSearch } from './modules/search';
@@ -124,7 +124,6 @@ window.onload = async function() {
     setupUploadProgress();
     setupUploadMenu();
     setupFileDrop();
-    setupPasswordReveal();
     setupSearchBar();
     setupGallery();
 

--- a/frontend/src/modules/auth.ts
+++ b/frontend/src/modules/auth.ts
@@ -189,7 +189,6 @@ function submitPhone(phoneRaw: string): void {
         notify({ level: 'warning', title: 'Enter your phone number' });
         return;
     }
-    state.lastLoginPhoneNumber = phone;
 
     LoginPhoneNumber(phone).then(() => {
         showAuthWrapper();

--- a/frontend/src/modules/auth.ts
+++ b/frontend/src/modules/auth.ts
@@ -1,4 +1,9 @@
-// Authentication flows for TDrive frontend
+// Authentication flows for TDrive frontend.
+//
+// The four auth screens (setup, phone, code, 2FA password) are rendered by
+// AuthScreens.svelte from the auth store; this module owns the orchestration:
+// the login state machine, InitDrive/dashboard bring-up, and the Telegram
+// event stream that advances screens.
 
 import { state } from '../state';
 import {
@@ -11,53 +16,28 @@ import { loadChannels } from './channels';
 import { loadEncryptionStatus } from './encryption';
 import { loadSelfUser } from './profile-menu';
 import { notify, dismissNotification } from './notifications';
+import AuthScreens from '../ui/auth/AuthScreens.svelte';
+import { authCodeReset, authHint, authPhone, authScreen } from '../ui/auth/auth-store';
+import { mountSvelte, type SvelteMountHandle } from '../ui/mount';
 
-declare global {
-    interface Window {
-        submitSetup: () => void;
-        startLogin: () => void;
-        sendCode: () => void;
-        sendPassword: () => void;
-        backToPhone: () => void;
-    }
+let authScreensHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
+
+function successScreen(): HTMLElement | null {
+    return document.getElementById('success-screen');
 }
 
 export function hideAllScreens() {
-    const screens = ["setupcontainer", "phonecontainer", "codecontainer", "passwordcontainer", "success-screen"];
-    screens.forEach(id => {
-        const el = document.getElementById(id);
-        if(el) el.style.display = "none";
-    });
+    authScreen.set(null);
+    const dashboard = successScreen();
+    if (dashboard) dashboard.style.display = 'none';
 }
 
 export function showAuthWrapper() {
-    const authWrapper = document.getElementById("auth-wrapper");
-    if (authWrapper) authWrapper.style.display = "flex";
+    const authWrapper = document.getElementById('auth-wrapper');
+    if (authWrapper) authWrapper.style.display = 'flex';
 
-    const dashboard = document.getElementById("success-screen");
-    if (dashboard) dashboard.style.display = "none";
-}
-
-export function setupPasswordReveal() {
-    const pw = document.getElementById("enterpassword") as HTMLInputElement | null;
-    const toggle = document.getElementById("toggle-password") as HTMLElement | null;
-    if (!pw || !toggle) return;
-
-    const apply = (isVisible: boolean) => {
-        pw.type = isVisible ? "text" : "password";
-
-        toggle.dataset.state = isVisible ? "visible" : "hidden";
-        toggle.setAttribute("aria-label", isVisible ? "Hide password" : "Show password");
-        toggle.setAttribute("title", isVisible ? "Hide password" : "Show password");
-    };
-
-    apply(false);
-
-    toggle.addEventListener("click", () => {
-        const isVisible = pw.type === "password";
-        apply(isVisible);
-        pw.focus();
-    });
+    const dashboard = successScreen();
+    if (dashboard) dashboard.style.display = 'none';
 }
 
 async function initDriveWithRetry(maxAttempts = 3) {
@@ -102,8 +82,8 @@ export async function showDashboard() {
     const authWrapper = document.getElementById("auth-wrapper");
     if (authWrapper) authWrapper.style.display = "none";
 
-    hideAllScreens();
-    document.getElementById("success-screen")!.style.display = "flex";
+    authScreen.set(null);
+    successScreen()!.style.display = "flex";
     state.currentFolderId = "";
     state.folderPath = [];
     renderBreadcrumb();
@@ -157,7 +137,6 @@ export async function showDashboard() {
     // Hydrate the profile menu (display name, photo). Failure is non-fatal —
     // the avatar falls back to a blank circle.
     loadSelfUser();
-
 }
 
 export async function checkStatusAndShowScreen() {
@@ -167,8 +146,7 @@ export async function checkStatusAndShowScreen() {
 
         if (status === "NEEDS_SETUP") {
             showAuthWrapper();
-            hideAllScreens();
-            document.getElementById("setupcontainer")!.style.display = "block";
+            authScreen.set('setup');
             return;
         }
 
@@ -178,10 +156,8 @@ export async function checkStatusAndShowScreen() {
             showDashboard();
         } else {
             showAuthWrapper();
-            hideAllScreens();
-            document.getElementById("phonecontainer")!.style.display = "block";
+            authScreen.set('phone');
         }
-
     } catch (err) {
         console.error("Startup Crash:", err);
         notify({
@@ -192,61 +168,74 @@ export async function checkStatusAndShowScreen() {
     }
 }
 
-// Window bindings for auth functions
+// --- screen submit handlers (wired into AuthScreens) ---
+
+function submitSetup(apiIdRaw: string, apiHash: string): void {
+    const id = parseInt(apiIdRaw, 10);
+    const hash = (apiHash || '').trim();
+    if (!id || !hash) {
+        notify({ level: 'warning', title: 'Enter both API ID and hash' });
+        return;
+    }
+    SaveSetup(id, hash).then((res) => {
+        if (res === "Success") location.reload();
+        else notify({ level: 'error', title: 'Setup failed', body: String(res) });
+    });
+}
+
+function submitPhone(phoneRaw: string): void {
+    const phone = (phoneRaw || '').trim();
+    if (!phone) {
+        notify({ level: 'warning', title: 'Enter your phone number' });
+        return;
+    }
+    state.lastLoginPhoneNumber = phone;
+
+    LoginPhoneNumber(phone).then(() => {
+        showAuthWrapper();
+        authPhone.set(phone);
+        authScreen.set('code');
+    }).catch((err) => {
+        notify({ level: 'error', title: 'Could not start login', body: String(err) });
+    });
+}
+
+function submitCode(codeRaw: string): void {
+    const code = (codeRaw || '').trim();
+    if (!code) {
+        notify({ level: 'warning', title: 'Enter the code from Telegram' });
+        return;
+    }
+    SumbitCode(code).catch((err) => {
+        notify({ level: 'error', title: 'Could not submit code', body: String(err) });
+    });
+}
+
+function submitPassword(password: string): void {
+    SumbitPassword(password).catch((err) => {
+        notify({ level: 'error', title: 'Could not submit password', body: String(err) });
+    });
+}
+
+function backToPhone(): void {
+    showAuthWrapper();
+    authScreen.set('phone');
+}
+
 export function setupAuthWindowBindings() {
-    window.submitSetup = function() {
-        const id = parseInt((document.getElementById("api_id") as HTMLInputElement).value);
-        const hash = (document.getElementById("api_hash") as HTMLInputElement).value;
-        if (!id || !hash) {
-            notify({ level: 'warning', title: 'Enter both API ID and hash' });
-            return;
-        }
-
-        SaveSetup(id, hash).then(res => {
-            if (res === "Success") location.reload();
-            else notify({ level: 'error', title: 'Setup failed', body: String(res) });
+    const host = document.getElementById('auth-wrapper');
+    if (host && !authScreensHandle) {
+        authScreensHandle = mountSvelte(AuthScreens, {
+            target: host,
+            props: {
+                onSetup: submitSetup,
+                onPhone: submitPhone,
+                onCode: submitCode,
+                onPassword: submitPassword,
+                onBackToPhone: backToPhone,
+            },
         });
-    };
-
-    window.startLogin = function () {
-        const phone = ((document.getElementById("enterphone") as HTMLInputElement).value || "").trim();
-        if (!phone) {
-            notify({ level: 'warning', title: 'Enter your phone number' });
-            return;
-        }
-
-        state.lastLoginPhoneNumber = phone;
-
-        LoginPhoneNumber(phone).then(() => {
-            showAuthWrapper();
-            hideAllScreens();
-            document.getElementById("codecontainer")!.style.display = "block";
-
-            const row = document.getElementById("code-target-row");
-            const target = document.getElementById("code-target");
-            if (target) target.innerText = state.lastLoginPhoneNumber;
-            if (row) row.style.display = state.lastLoginPhoneNumber ? "flex" : "none";
-        }).catch((err) => {
-            notify({ level: 'error', title: 'Could not start login', body: String(err) });
-        });
-    };
-
-    window.sendCode = function () {
-        const code = ((document.getElementById("entercode") as HTMLInputElement).value || "").trim();
-        if (!code) {
-            notify({ level: 'warning', title: 'Enter the code from Telegram' });
-            return;
-        }
-        SumbitCode(code).catch((err) => {
-            notify({ level: 'error', title: 'Could not submit code', body: String(err) });
-        });
-    };
-
-    window.sendPassword = function () {
-        SumbitPassword((document.getElementById("enterpassword") as HTMLInputElement).value).catch((err) => {
-            notify({ level: 'error', title: 'Could not submit password', body: String(err) });
-        });
-    };
+    }
 
     // The login-flow listeners below need the Wails runtime. Boot waits for it
     // (see waitForWailsRuntime in main.ts), but guard here too so a genuinely
@@ -259,22 +248,8 @@ export function setupAuthWindowBindings() {
 
     window.runtime.EventsOn("login-password-required", () => {
         showAuthWrapper();
-        hideAllScreens();
-        document.getElementById("passwordcontainer")!.style.display = "block";
-
-        const hintBox = document.getElementById("hint-box");
-        const hintEl = document.getElementById("hinttext");
-        if (hintEl) hintEl.innerText = "";
-        if (hintBox) hintBox.style.display = "none";
-
-        const pw = document.getElementById("enterpassword") as HTMLInputElement | null;
-        const toggle = document.getElementById("toggle-password") as HTMLElement | null;
-        if (pw) pw.type = "password";
-        if (toggle) {
-            toggle.dataset.state = "hidden";
-            toggle.setAttribute("aria-label", "Show password");
-            toggle.setAttribute("title", "Show password");
-        }
+        authHint.set('');
+        authScreen.set('password');
     });
 
     window.runtime.EventsOn("login-error", (msg: any) => {
@@ -282,46 +257,22 @@ export function setupAuthWindowBindings() {
     });
 
     // Wrong code: the backend keeps the login attempt alive and waits for a new
-    // code, so stay on the code screen, clear the field, and let the user retry.
+    // code, so stay on the code screen (AuthScreens clears + refocuses it) and
+    // surface the error.
     window.runtime.EventsOn("login-code-invalid", () => {
         showAuthWrapper();
-        hideAllScreens();
-        document.getElementById("codecontainer")!.style.display = "block";
-
-        const codeEl = document.getElementById("entercode") as HTMLInputElement | null;
-        if (codeEl) {
-            codeEl.value = "";
-            codeEl.focus();
-        }
+        authScreen.set('code');
+        authCodeReset.update((n) => n + 1);
         notify({ level: 'error', title: 'Wrong code', body: 'That code was incorrect — try again.' });
     });
 
     window.runtime.EventsOn("gothint", (hint: any) => {
-        const hintEl = document.getElementById("hinttext");
-        const hintBox = document.getElementById("hint-box");
-        if (!hintEl || !hintBox) return;
-
         const text = (hint ?? "").toString().trim();
         const normalized = text.replace(/^(hint\s*:?[\s\u00A0]*)+/i, "").trim();
-
         if (!normalized || normalized.toLowerCase().includes("no hint")) {
-            hintEl.innerText = "";
-            hintBox.style.display = "none";
+            authHint.set('');
             return;
         }
-
-        hintEl.innerText = normalized;
-        hintBox.style.display = "block";
+        authHint.set(normalized);
     });
-
-    window.backToPhone = function () {
-        showAuthWrapper();
-        hideAllScreens();
-
-        const phoneContainer = document.getElementById("phonecontainer");
-        if (phoneContainer) phoneContainer.style.display = "block";
-
-        const codeEl = document.getElementById("entercode") as HTMLInputElement | null;
-        if (codeEl) codeEl.value = "";
-    };
 }

--- a/frontend/src/modules/gallery.ts
+++ b/frontend/src/modules/gallery.ts
@@ -1,49 +1,43 @@
 // Photos gallery: a flat, date-grouped grid of every image in the active
-// drive. Thumbnails lazy-load as cells scroll into view (IntersectionObserver),
-// and clicking a cell opens the shared lightbox with prev/next over the whole
-// set. Entered via the Photos item in the sidebar; renders into #gallery-view,
-// a sibling of #file-list that CSS shows only in photos mode.
+// drive. Thumbnails lazy-load as cells scroll into view, and clicking a cell
+// opens the shared lightbox with prev/next over the whole set. Entered via the
+// Photos item in the sidebar; renders into #gallery-view, a sibling of
+// #file-list that CSS shows only in photos mode.
+//
+// This module orchestrates: it fetches media, groups it, and drives view
+// switching. The grid rendering is Gallery.svelte; the lazy-load / eviction /
+// thumbnail-cache machinery lives in ui/gallery/gallery-controller.ts, which
+// owns the IntersectionObserver rooted on the stable #gallery-view host.
 
 import { state } from '../state';
-import { getMedia, getThumbnail } from '../api';
+import { getMedia } from '../api';
 import { openPreviewList } from './modals/preview';
 import { clearSearch } from './search';
+import Gallery from '../ui/gallery/Gallery.svelte';
+import { beginRender, cachedThumb, rearmLocked, setRoot } from '../ui/gallery/gallery-controller';
+import { galleryView, type GalleryGroup } from '../ui/gallery/gallery-store';
+import { mountSvelte, type SvelteMountHandle } from '../ui/mount';
 import type { FileItem } from '../types';
 
-// Soft cap on the in-memory thumbnail-URL map (keyed channelId:msgId). The
-// backend disk cache makes a re-fetch cheap, so this only bounds bookkeeping.
-const THUMB_CACHE_MAX = 1500;
-
-// Cap on cells holding a decoded image at once. Loaded <img>s retain their
-// decoded bitmaps, so we unload the least-recently-loaded ones past this bound
-// (they reload instantly from the thumb cache when scrolled back). This keeps
-// memory flat on large libraries instead of growing with every scrolled cell.
-const MAX_LOADED_CELLS = 240;
-
-const lockSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path stroke-linecap="round" stroke-linejoin="round" d="M8 11V7a4 4 0 018 0v4"/></svg>`;
-const brokenSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path stroke-linecap="round" stroke-linejoin="round" d="M3 16l5-5 4 4 3-3 6 6"/></svg>`;
-const photosSvg = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.6"/><path stroke-linecap="round" stroke-linejoin="round" d="M21 15l-5-5L5 21"/></svg>`;
-
 let galleryEl: HTMLElement | null = null;
-let observer: IntersectionObserver | null = null;
+let galleryHandle: SvelteMountHandle<Record<string, unknown>> | null = null;
 let renderToken = 0;
 let currentItems: FileItem[] = [];
 let currentChannelId = 0;
 
-// "channelId:msgId" -> loaded thumbnail data URL. Keyed by drive because a
-// Telegram msg id is only unique within its channel; reused across re-renders
-// and handed to the lightbox as an instant placeholder.
-const thumbCache = new Map<string, string>();
-
-// Cells currently holding a decoded image, oldest first (FIFO eviction).
-const loadedCells: HTMLElement[] = [];
-
 export function setupGallery(): void {
     galleryEl = document.getElementById('gallery-view');
-    setupGalleryClicks();
-    // When the vault is unlocked (e.g. from the lightbox), let locked thumbnail
-    // cells try again without waiting for a full gallery refresh.
-    window.addEventListener('tdrive:unlocked', rearmLockedCells);
+    if (!galleryEl || galleryHandle) return;
+
+    setRoot(galleryEl);
+    galleryEl.replaceChildren();
+    galleryHandle = mountSvelte(Gallery, { target: galleryEl, props: {} });
+
+    // Click delegation stays on the stable host, matching the pre-Svelte path.
+    galleryEl.addEventListener('click', onGalleryClick);
+    // When the vault unlocks (e.g. from the lightbox), let locked cells retry
+    // without waiting for a full gallery refresh.
+    window.addEventListener('tdrive:unlocked', rearmLocked);
 }
 
 // setPhotosMode toggles the whole main view between the file list and the
@@ -60,24 +54,19 @@ export function setPhotosMode(on: boolean): void {
 }
 
 export async function renderGallery(): Promise<void> {
-    if (!galleryEl) galleryEl = document.getElementById('gallery-view');
+    if (!galleryEl) setupGallery();
     if (!galleryEl) return;
 
     const token = ++renderToken;
-    teardownObserver();
-    loadedCells.length = 0;
-    galleryEl.innerHTML = '<div class="gallery-status">Loading photos…</div>';
-
     const channelId = Number(state.activeChannel?.id || 0);
+    galleryView.set({ status: 'loading' });
 
     let media: FileItem[];
     try {
         media = await getMedia();
     } catch (err) {
         console.error('ListMedia failed:', err);
-        if (token === renderToken) {
-            galleryEl.innerHTML = '<div class="gallery-status">Could not load photos.</div>';
-        }
+        if (token === renderToken) galleryView.set({ status: 'error' });
         return;
     }
 
@@ -86,193 +75,28 @@ export async function renderGallery(): Promise<void> {
 
     currentItems = media;
     currentChannelId = channelId;
+    beginRender(channelId);
 
     if (media.length === 0) {
-        galleryEl.innerHTML = `
-            <div class="gallery-empty">
-                <div class="gallery-empty-icon">${photosSvg}</div>
-                <div class="gallery-empty-title">No photos yet</div>
-                <div class="gallery-empty-sub">Images you upload to this drive show up here.</div>
-            </div>`;
+        galleryView.set({ status: 'empty' });
         return;
     }
-
-    const frag = document.createDocumentFragment();
-    let index = 0;
-    for (const group of groupByMonth(media)) {
-        const section = document.createElement('section');
-        section.className = 'gallery-group';
-
-        const header = document.createElement('div');
-        header.className = 'gallery-group-header';
-        header.textContent = group.label;
-        section.appendChild(header);
-
-        const grid = document.createElement('div');
-        grid.className = 'gallery-grid';
-        for (const item of group.items) {
-            grid.appendChild(buildCell(item, index));
-            index += 1;
-        }
-        section.appendChild(grid);
-        frag.appendChild(section);
-    }
-
-    galleryEl.innerHTML = '';
-    galleryEl.appendChild(frag);
-    setupObserver();
-    observeCells();
+    galleryView.set({ status: 'ready', groups: groupByMonth(media) });
 }
 
-function buildCell(item: FileItem, index: number): HTMLElement {
-    const cell = document.createElement('button');
-    cell.type = 'button';
-    cell.className = 'gallery-cell';
-    cell.dataset.id = String(item.msgId);
-    cell.dataset.index = String(index);
-    cell.dataset.name = item.name;
-    cell.title = item.name;
-    cell.setAttribute('aria-label', item.name);
-
-    const img = document.createElement('img');
-    img.className = 'gallery-thumb';
-    img.alt = '';
-    img.decoding = 'async';
-    cell.appendChild(img);
-
-    if (item.encrypted) {
-        const lock = document.createElement('span');
-        lock.className = 'gallery-lock';
-        lock.innerHTML = lockSvg;
-        cell.appendChild(lock);
-    }
-    // Thumbnails (even already-cached ones) load through the observer/loadCell
-    // path so the loaded-cell budget stays accurate.
-    return cell;
-}
-
-function setupObserver(): void {
-    if (!galleryEl) return;
-    observer = new IntersectionObserver(
-        (entries) => {
-            for (const entry of entries) {
-                if (!entry.isIntersecting) continue;
-                const cell = entry.target as HTMLElement;
-                observer?.unobserve(cell);
-                void loadCell(cell);
-            }
-        },
-        { root: galleryEl, rootMargin: '320px 0px' },
-    );
-}
-
-function observeCells(): void {
-    if (!observer || !galleryEl) return;
-    // Only arm genuinely-untouched cells; loaded/in-flight/errored cells are
-    // either done or owned by an in-flight load.
-    galleryEl
-        .querySelectorAll('.gallery-cell:not(.is-loaded):not(.is-loading):not(.is-failed):not(.is-locked)')
-        .forEach((cell) => observer!.observe(cell));
-}
-
-function teardownObserver(): void {
-    if (observer) {
-        observer.disconnect();
-        observer = null;
-    }
-}
-
-async function loadCell(cell: HTMLElement): Promise<void> {
-    if (cell.classList.contains('is-loaded') || cell.classList.contains('is-loading')) return;
-    const msgId = Number(cell.dataset.id || 0);
-    const img = cell.querySelector('img.gallery-thumb') as HTMLImageElement | null;
-    if (!msgId || !img) return;
-
-    const channelId = currentChannelId;
-    const key = `${channelId}:${msgId}`;
-
-    const cached = thumbCache.get(key);
-    if (cached) {
-        img.src = cached;
-        cell.classList.remove('is-failed', 'is-locked');
-        cell.classList.add('is-loaded');
-        registerLoaded(cell);
-        return;
-    }
-
-    cell.classList.add('is-loading');
-    const token = renderToken;
-    try {
-        const url = await getThumbnail(msgId);
-        // Discard if a newer render started, the active drive changed mid-flight,
-        // or this cell is gone — never paint or cache a stale/wrong-drive image.
-        if (token !== renderToken || channelId !== currentChannelId || !cell.isConnected) return;
-        cacheThumb(key, url);
-        img.src = url;
-        cell.classList.remove('is-loading');
-        cell.classList.add('is-loaded');
-        registerLoaded(cell);
-    } catch (err) {
-        if (token !== renderToken || channelId !== currentChannelId || !cell.isConnected) return;
-        cell.classList.remove('is-loading');
-        const name = cell.dataset.name || '';
-        if (/password required/i.test(String(err))) {
-            cell.classList.add('is-locked');
-            cell.title = `${name} — locked, click to unlock`.trim();
-        } else {
-            cell.classList.add('is-failed');
-            cell.title = `${name} — couldn't load`.trim();
-            const badge = document.createElement('span');
-            badge.className = 'gallery-broken';
-            badge.innerHTML = brokenSvg;
-            cell.appendChild(badge);
-        }
-    }
-}
-
-// registerLoaded tracks a cell holding a decoded image and unloads the oldest
-// once we exceed the budget, keeping decoded-image memory bounded.
-function registerLoaded(cell: HTMLElement): void {
-    loadedCells.push(cell);
-    while (loadedCells.length > MAX_LOADED_CELLS) {
-        const old = loadedCells.shift();
-        if (old && old !== cell) unloadCell(old);
-    }
-}
-
-function unloadCell(cell: HTMLElement): void {
-    if (!cell.isConnected) return;
-    const img = cell.querySelector('img.gallery-thumb') as HTMLImageElement | null;
-    if (img) img.removeAttribute('src');
-    cell.classList.remove('is-loaded');
-    // Re-arm so it reloads (instantly, from the thumb cache) when scrolled back.
-    observer?.observe(cell);
-}
-
-function cacheThumb(key: string, url: string): void {
-    thumbCache.set(key, url);
-    if (thumbCache.size > THUMB_CACHE_MAX) {
-        const oldest = thumbCache.keys().next().value;
-        if (oldest !== undefined) thumbCache.delete(oldest);
-    }
-}
-
-function setupGalleryClicks(): void {
-    if (!galleryEl) return;
-    galleryEl.addEventListener('click', (e) => {
-        const cell = (e.target as HTMLElement).closest('.gallery-cell') as HTMLElement | null;
-        if (!cell) return;
-        const index = Number(cell.dataset.index ?? -1);
-        if (index < 0 || index >= currentItems.length) return;
-        openGalleryLightbox(index);
-    });
+function onGalleryClick(event: MouseEvent): void {
+    const cell = (event.target as HTMLElement).closest('.gallery-cell') as HTMLElement | null;
+    if (!cell) return;
+    const index = Number(cell.dataset.index ?? -1);
+    if (index < 0 || index >= currentItems.length) return;
+    openGalleryLightbox(index);
 }
 
 function openGalleryLightbox(index: number): void {
     const channelId = currentChannelId;
-    // Carry the fields the lightbox + info panel need: a download size (plaintext
-    // for encrypted files), the loaded thumbnail as an instant placeholder, and
-    // the metadata the info panel shows.
+    // Carry the fields the lightbox + info panel need: a download size
+    // (plaintext for encrypted files), the loaded thumbnail as an instant
+    // placeholder, and the metadata the info panel shows.
     const items = currentItems.map((it) => ({
         type: 'file',
         id: it.msgId,
@@ -281,18 +105,9 @@ function openGalleryLightbox(index: number): void {
         encrypted: it.encrypted,
         uploaderId: it.uploaderId,
         uploadTime: it.uploadTime,
-        thumbUrl: thumbCache.get(`${channelId}:${it.msgId}`) || '',
+        thumbUrl: cachedThumb(channelId, it.msgId),
     }));
     void openPreviewList(items, index);
-}
-
-// rearmLockedCells lets locked thumbnail cells retry after the vault unlocks.
-function rearmLockedCells(): void {
-    if (!observer || !galleryEl) return;
-    galleryEl.querySelectorAll('.gallery-cell.is-locked').forEach((cell) => {
-        cell.classList.remove('is-locked');
-        observer!.observe(cell);
-    });
 }
 
 // --- view switching (wired from the sidebar Photos item) ---
@@ -314,19 +129,19 @@ export function exitPhotos(): void {
 
 // --- date grouping ---
 
-function groupByMonth(items: FileItem[]): { label: string; items: FileItem[] }[] {
-    const groups: { label: string; items: FileItem[] }[] = [];
+function groupByMonth(items: FileItem[]): GalleryGroup[] {
+    const groups: GalleryGroup[] = [];
     let curKey = '';
-    let cur: { label: string; items: FileItem[] } | null = null;
-    for (const item of items) {
+    let cur: GalleryGroup | null = null;
+    items.forEach((item, index) => {
         const key = monthKey(item.uploadTime);
         if (!cur || key !== curKey) {
-            cur = { label: monthLabel(item.uploadTime), items: [] };
+            cur = { label: monthLabel(item.uploadTime), cells: [] };
             groups.push(cur);
             curKey = key;
         }
-        cur.items.push(item);
-    }
+        cur.cells.push({ item, index });
+    });
     return groups;
 }
 

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -35,8 +35,6 @@ export interface State {
     downloadQueue: any[];
     activeDownloadId: string | number | null;
 
-    lastLoginPhoneNumber: string;
-
     transferPillEl: HTMLElement | null;
     transferSheetEl: HTMLElement | null;
     transferUploadListEl: HTMLElement | null;
@@ -92,8 +90,6 @@ export const state: State = {
     activeTransfer: null,
     downloadQueue: [],
     activeDownloadId: null,
-
-    lastLoginPhoneNumber: "",
 
     transferPillEl: null,
     transferSheetEl: null,

--- a/frontend/src/ui/auth/AuthScreens.svelte
+++ b/frontend/src/ui/auth/AuthScreens.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+    import { tick } from 'svelte';
+    import { authCodeReset, authHint, authPhone, authScreen } from './auth-store';
+
+    interface Props {
+        onSetup: (apiId: string, apiHash: string) => void;
+        onPhone: (phone: string) => void;
+        onCode: (code: string) => void;
+        onPassword: (password: string) => void;
+        onBackToPhone: () => void;
+    }
+
+    let { onSetup, onPhone, onCode, onPassword, onBackToPhone }: Props = $props();
+
+    let apiId = $state('');
+    let apiHash = $state('');
+    let phone = $state('');
+    let code = $state('');
+    let password = $state('');
+    let revealPassword = $state(false);
+
+    let apiIdEl = $state<HTMLInputElement | null>(null);
+    let phoneEl = $state<HTMLInputElement | null>(null);
+    let codeEl = $state<HTMLInputElement | null>(null);
+    let passwordEl = $state<HTMLInputElement | null>(null);
+
+    // Reset per-screen inputs and focus the primary field on each transition,
+    // matching the old per-container clear/focus behavior.
+    let lastScreen: string | null = null;
+    $effect(() => {
+        const screen = $authScreen;
+        if (screen === lastScreen) return;
+        lastScreen = screen;
+        if (screen === 'code') code = '';
+        if (screen === 'password') {
+            password = '';
+            revealPassword = false;
+        }
+        void tick().then(() => {
+            if ($authScreen !== screen) return;
+            const el = screen === 'setup' ? apiIdEl
+                : screen === 'phone' ? phoneEl
+                : screen === 'code' ? codeEl
+                : screen === 'password' ? passwordEl
+                : null;
+            el?.focus();
+        });
+    });
+
+    // Rejected code: clear and refocus the field without a screen change.
+    let lastReset = 0;
+    $effect(() => {
+        const nonce = $authCodeReset;
+        if (nonce === lastReset) return;
+        lastReset = nonce;
+        code = '';
+        void tick().then(() => codeEl?.focus());
+    });
+
+    function submitOnEnter(event: KeyboardEvent, action: () => void): void {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            action();
+        }
+    }
+</script>
+
+{#if $authScreen === 'setup'}
+    <div class="auth-box">
+        <div class="auth-icon-box">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+        </div>
+        <h2>System Setup</h2>
+        <p>Configure API Credentials</p>
+        <input bind:this={apiIdEl} bind:value={apiId} type="text" placeholder="App ID" />
+        <input bind:value={apiHash} type="text" placeholder="App Hash" onkeydown={(e) => submitOnEnter(e, () => onSetup(apiId, apiHash))} />
+        <button class="primary-btn" type="button" onclick={() => onSetup(apiId, apiHash)}>Save Configuration</button>
+    </div>
+{:else if $authScreen === 'phone'}
+    <div class="auth-box">
+        <div class="auth-icon-box">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
+        </div>
+        <h2>Welcome Back</h2>
+        <p>Login to your secure cloud</p>
+        <input bind:this={phoneEl} bind:value={phone} type="text" placeholder="+1234567890" onkeydown={(e) => submitOnEnter(e, () => onPhone(phone))} />
+        <button class="primary-btn" type="button" onclick={() => onPhone(phone)}>Send Code</button>
+    </div>
+{:else if $authScreen === 'code'}
+    <div class="auth-box">
+        <div class="auth-icon-box">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+        </div>
+        <h2>Verify Identity</h2>
+        <p class="auth-subtitle">Enter Telegram Code</p>
+        {#if $authPhone}
+            <div class="auth-helper-row">
+                <span class="auth-helper-label">Sent to</span>
+                <span class="auth-helper-pill">{$authPhone}</span>
+                <button type="button" class="auth-link" onclick={onBackToPhone}>Change</button>
+            </div>
+        {/if}
+        <input bind:this={codeEl} bind:value={code} class="code-input" type="text" placeholder="12345" onkeydown={(e) => submitOnEnter(e, () => onCode(code))} />
+        <button class="primary-btn" type="button" onclick={() => onCode(code)}>Verify</button>
+    </div>
+{:else if $authScreen === 'password'}
+    <div class="auth-box">
+        <div class="auth-icon-box">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11.536 16.464a.5.5 0 00-.496.568l.1 1.15a.5.5 0 01-.037.24l-1.352 3.863a.5.5 0 01-.47.315H7.5a.5.5 0 01-.5-.5v-2.204a.5.5 0 01.146-.354l3.298-3.297A6 6 0 0115 7z"/></svg>
+        </div>
+        <h2>Two-Factor Auth</h2>
+        <p class="auth-subtitle">Enter your Telegram password</p>
+        {#if $authHint}
+            <div class="auth-caption">Hint: <span>{$authHint}</span></div>
+        {/if}
+        <div class="input-with-action">
+            <input
+                bind:this={passwordEl}
+                bind:value={password}
+                type={revealPassword ? 'text' : 'password'}
+                placeholder="Password"
+                autocomplete="current-password"
+                onkeydown={(e) => submitOnEnter(e, () => onPassword(password))}
+            />
+            <button
+                class="input-action-btn"
+                type="button"
+                data-state={revealPassword ? 'visible' : 'hidden'}
+                aria-label={revealPassword ? 'Hide password' : 'Show password'}
+                title={revealPassword ? 'Hide password' : 'Show password'}
+                onclick={() => { revealPassword = !revealPassword; passwordEl?.focus(); }}
+            >
+                <svg class="input-action-icon icon-eye" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                </svg>
+                <svg class="input-action-icon icon-eye-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l18 18"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M10.477 10.48a3 3 0 004.243 4.243"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.88 5.09A10.48 10.48 0 0112 5c4.477 0 8.268 2.943 9.542 7a10.53 10.53 0 01-2.36 3.95"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6.53 6.53A10.52 10.52 0 002.458 12c1.274 4.057 5.065 7 9.542 7 1.11 0 2.18-.18 3.19-.51"/>
+                </svg>
+            </button>
+        </div>
+        <button class="primary-btn" type="button" onclick={() => onPassword(password)}>Unlock</button>
+    </div>
+{/if}

--- a/frontend/src/ui/auth/auth-store.ts
+++ b/frontend/src/ui/auth/auth-store.ts
@@ -1,0 +1,19 @@
+import { writable } from 'svelte/store';
+
+// Which auth screen is visible. null means no auth screen (the wrapper is
+// hidden, or the dashboard is showing). modules/auth.ts drives this from the
+// login flow and the Telegram event stream.
+export type AuthScreen = 'setup' | 'phone' | 'code' | 'password' | null;
+
+export const authScreen = writable<AuthScreen>(null);
+
+// The submitted phone number, shown as the "Sent to" pill on the code screen.
+export const authPhone = writable('');
+
+// The 2FA password hint from Telegram; empty hides the hint row.
+export const authHint = writable('');
+
+// Bumped when Telegram rejects a login code, so the code screen clears and
+// refocuses its field even though it stays on the same screen (a screen-value
+// change cannot signal this because the value does not change).
+export const authCodeReset = writable(0);

--- a/frontend/src/ui/auth/auth.dom.test.ts
+++ b/frontend/src/ui/auth/auth.dom.test.ts
@@ -1,0 +1,77 @@
+// Behavior tests for the two field-reset paths that needed care: clearing on a
+// screen transition, and clearing via the reset nonce when a rejected code
+// keeps the user on the same screen (where a screen-value change cannot fire).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import AuthScreens from './AuthScreens.svelte';
+import { authCodeReset, authPhone, authScreen } from './auth-store';
+
+let host: HTMLElement;
+let app: Record<string, unknown>;
+
+function codeInput(): HTMLInputElement {
+    const el = host.querySelector('.code-input') as HTMLInputElement | null;
+    if (!el) throw new Error('code input not rendered');
+    return el;
+}
+
+beforeEach(() => {
+    authScreen.set(null);
+    authPhone.set('');
+    authCodeReset.set(0);
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    app = mount(AuthScreens, {
+        target: host,
+        props: {
+            onSetup: vi.fn(),
+            onPhone: vi.fn(),
+            onCode: vi.fn(),
+            onPassword: vi.fn(),
+            onBackToPhone: vi.fn(),
+        },
+    });
+});
+
+afterEach(async () => {
+    authScreen.set(null);
+    flushSync();
+    await unmount(app);
+    host.remove();
+});
+
+describe('AuthScreens field reset', () => {
+    it('clears the code field when transitioning onto the code screen', () => {
+        authScreen.set('code');
+        flushSync();
+        const input = codeInput();
+        input.value = '123';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        flushSync();
+
+        // Leave and return: the transition back clears the field.
+        authScreen.set('phone');
+        flushSync();
+        authScreen.set('code');
+        flushSync();
+
+        expect(codeInput().value).toBe('');
+    });
+
+    it('clears the code field on a reset nonce bump without a screen change', () => {
+        authScreen.set('code');
+        flushSync();
+        const input = codeInput();
+        input.value = '999';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        flushSync();
+        expect(codeInput().value).toBe('999');
+
+        // Same screen, rejected code: only the nonce changes.
+        authCodeReset.update((n) => n + 1);
+        flushSync();
+
+        expect(codeInput().value).toBe('');
+    });
+});

--- a/frontend/src/ui/auth/auth.test.ts
+++ b/frontend/src/ui/auth/auth.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import AuthScreens from './AuthScreens.svelte';
+import { authHint, authPhone, authScreen } from './auth-store';
+
+const noop = () => {};
+const props = {
+    onSetup: noop,
+    onPhone: noop,
+    onCode: noop,
+    onPassword: noop,
+    onBackToPhone: noop,
+};
+
+afterEach(() => {
+    authScreen.set(null);
+    authPhone.set('');
+    authHint.set('');
+});
+
+describe('AuthScreens', () => {
+    it('renders no auth box when no screen is active', () => {
+        authScreen.set(null);
+        expect(render(AuthScreens, { props }).body).not.toContain('auth-box');
+    });
+
+    it('renders the setup screen', () => {
+        authScreen.set('setup');
+        const { body } = render(AuthScreens, { props });
+        expect(body).toContain('System Setup');
+        expect(body).toContain('Save Configuration');
+    });
+
+    it('renders the phone screen', () => {
+        authScreen.set('phone');
+        const { body } = render(AuthScreens, { props });
+        expect(body).toContain('Welcome Back');
+        expect(body).toContain('Send Code');
+    });
+
+    it('shows the sent-to pill on the code screen only when a phone is set', () => {
+        authScreen.set('code');
+        expect(render(AuthScreens, { props }).body).not.toContain('auth-helper-pill');
+
+        authPhone.set('+15551234567');
+        const { body } = render(AuthScreens, { props });
+        expect(body).toContain('auth-helper-pill');
+        expect(body).toContain('+15551234567');
+        expect(body).toContain('Verify');
+    });
+
+    it('shows the 2FA hint row only when a hint is set', () => {
+        authScreen.set('password');
+        expect(render(AuthScreens, { props }).body).not.toContain('auth-caption');
+
+        authHint.set('rhymes with cat');
+        const { body } = render(AuthScreens, { props });
+        expect(body).toContain('auth-caption');
+        expect(body).toContain('rhymes with cat');
+        expect(body).toContain('Unlock');
+    });
+
+    it('escapes an untrusted hint', () => {
+        authScreen.set('password');
+        authHint.set('<img src=x>');
+        expect(render(AuthScreens, { props }).body).not.toContain('<img src=x>');
+    });
+});

--- a/frontend/src/ui/gallery/Gallery.svelte
+++ b/frontend/src/ui/gallery/Gallery.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+    // Renders the gallery view state. The scroll host (#gallery-view) stays in
+    // index.html: it is the IntersectionObserver root and owns click
+    // delegation, both wired by modules/gallery.ts against a stable element.
+    import GalleryCell from './GalleryCell.svelte';
+    import { galleryView } from './gallery-store';
+</script>
+
+{#if $galleryView.status === 'loading'}
+    <div class="gallery-status">Loading photos…</div>
+{:else if $galleryView.status === 'error'}
+    <div class="gallery-status">Could not load photos.</div>
+{:else if $galleryView.status === 'empty'}
+    <div class="gallery-empty">
+        <div class="gallery-empty-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.6"/><path stroke-linecap="round" stroke-linejoin="round" d="M21 15l-5-5L5 21"/></svg>
+        </div>
+        <div class="gallery-empty-title">No photos yet</div>
+        <div class="gallery-empty-sub">Images you upload to this drive show up here.</div>
+    </div>
+{:else}
+    <!-- Keyed on the group's first flat index: unique and stable even when two
+         non-adjacent groups share a label (e.g. scattered undated photos). -->
+    {#each $galleryView.groups as group (group.cells[0].index)}
+        <section class="gallery-group">
+            <div class="gallery-group-header">{group.label}</div>
+            <div class="gallery-grid">
+                {#each group.cells as cell (cell.item.msgId)}
+                    <GalleryCell item={cell.item} index={cell.index} />
+                {/each}
+            </div>
+        </section>
+    {/each}
+{/if}

--- a/frontend/src/ui/gallery/GalleryCell.svelte
+++ b/frontend/src/ui/gallery/GalleryCell.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+    import type { FileItem } from '../../types';
+    import { registerCell, unregisterCell, type CellPatch, type CellStatus } from './gallery-controller';
+
+    interface Props {
+        item: FileItem;
+        index: number;
+    }
+
+    let { item, index }: Props = $props();
+
+    let status = $state<CellStatus>('idle');
+    let src = $state('');
+    let detail = $state('');
+
+    // The controller drives loads/eviction and pushes state here (O(1) per
+    // cell, matching the old direct DOM writes).
+    function apply(patch: CellPatch): void {
+        if (patch.status !== undefined) status = patch.status;
+        if (patch.src !== undefined) src = patch.src;
+        if (patch.title !== undefined) detail = patch.title;
+    }
+
+    function register(node: HTMLElement) {
+        registerCell(node, { msgId: item.msgId, apply });
+        return {
+            destroy() {
+                unregisterCell(node);
+            },
+        };
+    }
+
+    const cellClass = $derived(
+        `gallery-cell${status === 'loaded' ? ' is-loaded' : ''}${status === 'loading' ? ' is-loading' : ''}${status === 'failed' ? ' is-failed' : ''}${status === 'locked' ? ' is-locked' : ''}`,
+    );
+    const title = $derived(detail ? `${item.name} — ${detail}` : item.name);
+</script>
+
+<button
+    type="button"
+    class={cellClass}
+    data-id={item.msgId}
+    data-index={index}
+    data-name={item.name}
+    {title}
+    aria-label={item.name}
+    use:register
+>
+    <img class="gallery-thumb" alt="" decoding="async" src={src || undefined} />
+    {#if item.encrypted}
+        <span class="gallery-lock">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="5" y="11" width="14" height="10" rx="2"/><path stroke-linecap="round" stroke-linejoin="round" d="M8 11V7a4 4 0 018 0v4"/></svg>
+        </span>
+    {/if}
+    {#if status === 'failed'}
+        <span class="gallery-broken">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path stroke-linecap="round" stroke-linejoin="round" d="M3 16l5-5 4 4 3-3 6 6"/></svg>
+        </span>
+    {/if}
+</button>

--- a/frontend/src/ui/gallery/gallery-controller.dom.test.ts
+++ b/frontend/src/ui/gallery/gallery-controller.dom.test.ts
@@ -1,0 +1,153 @@
+// Unit tests for the gallery controller: lazy load on intersect, thumb-cache
+// hits, drive-change and unregister discard guards, and FIFO eviction of
+// decoded images. getThumbnail is mocked; a manual IntersectionObserver shim
+// lets the test drive intersections deterministically.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CellPatch } from './gallery-controller';
+
+const thumbnails = vi.hoisted(() => ({
+    resolver: (msgId: number) => Promise.resolve(`data:url:${msgId}`),
+}));
+
+vi.mock('../../api', () => ({
+    getThumbnail: (msgId: number) => thumbnails.resolver(msgId),
+}));
+
+// Manual IntersectionObserver: records observed nodes and exposes a trigger to
+// fire an intersection for a specific node.
+const observed = new Set<Element>();
+let fireIntersect: (node: Element) => void = () => {};
+
+class TestObserver {
+    constructor(private cb: IntersectionObserverCallback) {
+        fireIntersect = (node: Element) => {
+            this.cb(
+                [{ target: node, isIntersecting: true } as IntersectionObserverEntry],
+                this as unknown as IntersectionObserver,
+            );
+        };
+    }
+    observe(node: Element) { observed.add(node); }
+    unobserve(node: Element) { observed.delete(node); }
+    disconnect() { observed.clear(); }
+}
+
+(globalThis as any).IntersectionObserver = TestObserver;
+
+let controller: typeof import('./gallery-controller');
+
+async function flush(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+function makeCell(msgId: number) {
+    const node = document.createElement('button');
+    const patches: CellPatch[] = [];
+    const apply = (patch: CellPatch): void => {
+        patches.push(patch);
+    };
+    return { node, msgId, apply, patches, last: () => patches[patches.length - 1] };
+}
+
+beforeEach(async () => {
+    vi.resetModules();
+    observed.clear();
+    thumbnails.resolver = (msgId: number) => Promise.resolve(`data:url:${msgId}`);
+    controller = await import('./gallery-controller');
+    controller.setRoot(document.createElement('div'));
+    controller.beginRender(1);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('gallery-controller', () => {
+    it('loads a thumbnail when a cell intersects and caches it', async () => {
+        const cell = makeCell(10);
+        controller.registerCell(cell.node, { msgId: cell.msgId, apply: cell.apply });
+        expect(observed.has(cell.node)).toBe(true);
+
+        fireIntersect(cell.node);
+        await flush();
+
+        expect(cell.last()).toEqual({ status: 'loaded', src: 'data:url:10' });
+        expect(observed.has(cell.node)).toBe(false); // unobserved once loaded
+        expect(controller.cachedThumb(1, 10)).toBe('data:url:10');
+    });
+
+    it('serves a cache hit without calling the backend again', async () => {
+        const first = makeCell(20);
+        controller.registerCell(first.node, { msgId: 20, apply: first.apply });
+        fireIntersect(first.node);
+        await flush();
+
+        const calls = vi.fn();
+        thumbnails.resolver = (msgId: number) => { calls(); return Promise.resolve(`data:url:${msgId}`); };
+
+        const second = makeCell(20);
+        controller.registerCell(second.node, { msgId: 20, apply: second.apply });
+        fireIntersect(second.node);
+        await flush();
+
+        expect(second.last()).toEqual({ status: 'loaded', src: 'data:url:20' });
+        expect(calls).not.toHaveBeenCalled();
+    });
+
+    it('discards a load whose cell was unregistered mid-flight', async () => {
+        let resolve!: (v: string) => void;
+        thumbnails.resolver = () => new Promise<string>((r) => { resolve = r; });
+
+        const cell = makeCell(30);
+        controller.registerCell(cell.node, { msgId: 30, apply: cell.apply });
+        fireIntersect(cell.node);
+        await flush();
+        expect(cell.last()).toEqual({ status: 'loading' });
+
+        controller.unregisterCell(cell.node);
+        resolve('data:url:30');
+        await flush();
+
+        // No 'loaded' patch after unregister, and nothing cached.
+        expect(cell.patches.some((p) => p.status === 'loaded')).toBe(false);
+        expect(controller.cachedThumb(1, 30)).toBe('');
+    });
+
+    it('discards a load when the drive changed mid-flight', async () => {
+        let resolve!: (v: string) => void;
+        thumbnails.resolver = () => new Promise<string>((r) => { resolve = r; });
+
+        const cell = makeCell(40);
+        controller.registerCell(cell.node, { msgId: 40, apply: cell.apply });
+        fireIntersect(cell.node);
+        await flush();
+
+        controller.beginRender(2); // user switched drives
+        resolve('data:url:40');
+        await flush();
+
+        expect(cell.patches.some((p) => p.status === 'loaded')).toBe(false);
+    });
+
+    it('marks a locked cell and rearms it on unlock', async () => {
+        thumbnails.resolver = () => Promise.reject(new Error('encryption password required'));
+
+        const cell = makeCell(50);
+        controller.registerCell(cell.node, { msgId: 50, apply: cell.apply });
+        fireIntersect(cell.node);
+        await flush();
+
+        expect(cell.last()).toMatchObject({ status: 'locked' });
+        expect(observed.has(cell.node)).toBe(false);
+
+        thumbnails.resolver = (msgId: number) => Promise.resolve(`data:url:${msgId}`);
+        controller.rearmLocked();
+        expect(observed.has(cell.node)).toBe(true); // re-observed for retry
+
+        fireIntersect(cell.node);
+        await flush();
+        expect(cell.last()).toEqual({ status: 'loaded', src: 'data:url:50' });
+    });
+});

--- a/frontend/src/ui/gallery/gallery-controller.ts
+++ b/frontend/src/ui/gallery/gallery-controller.ts
@@ -1,0 +1,176 @@
+// Imperative machinery behind the photos gallery: one IntersectionObserver
+// for lazy thumbnail loading, an LRU thumbnail-URL cache, and FIFO eviction of
+// decoded <img> bitmaps so memory stays flat on large libraries. The Svelte
+// components render structure and register each cell here; this controller
+// owns every load, cache, and eviction decision so that behavior is identical
+// to the pre-Svelte gallery.
+//
+// It is a module singleton because the caches must outlive any single render:
+// scrolling away and back, or switching drives and returning, reuses thumbs.
+
+import { getThumbnail } from '../../api';
+
+// Soft cap on the in-memory thumbnail-URL map (keyed channelId:msgId). The
+// backend disk cache makes a re-fetch cheap, so this only bounds bookkeeping.
+const THUMB_CACHE_MAX = 1500;
+
+// Cap on cells holding a decoded image at once. Loaded <img>s retain their
+// decoded bitmaps, so we unload the least-recently-loaded ones past this bound
+// (they reload instantly from the thumb cache when scrolled back).
+const MAX_LOADED_CELLS = 240;
+
+export type CellStatus = 'idle' | 'loading' | 'loaded' | 'failed' | 'locked';
+
+export interface CellPatch {
+    status?: CellStatus;
+    src?: string;
+    title?: string;
+}
+
+export interface CellRegistration {
+    msgId: number;
+    apply: (patch: CellPatch) => void;
+}
+
+interface CellHandle extends CellRegistration {
+    node: HTMLElement;
+    status: CellStatus;
+}
+
+const handles = new Map<HTMLElement, CellHandle>();
+// Cells currently holding a decoded image, oldest first (FIFO eviction). Kept
+// consistent across renders by register/unregister alone — never bulk-cleared,
+// because Svelte reuses keyed cells whose loaded state must keep being tracked.
+const loadedHandles: CellHandle[] = [];
+// "channelId:msgId" -> loaded thumbnail data URL.
+const thumbCache = new Map<string, string>();
+
+let observer: IntersectionObserver | null = null;
+let rootEl: HTMLElement | null = null;
+let currentChannelId = 0;
+
+// setRoot installs the scroll container used as the observer root. Called once
+// when the gallery component mounts.
+export function setRoot(el: HTMLElement): void {
+    if (rootEl === el && observer) return;
+    if (observer) observer.disconnect();
+    rootEl = el;
+    observer = new IntersectionObserver(onIntersect, { root: el, rootMargin: '320px 0px' });
+    // Re-observe any cells that registered before the root was ready.
+    for (const handle of handles.values()) {
+        if (handle.status === 'idle') observer.observe(handle.node);
+    }
+}
+
+// beginRender records the drive the upcoming cells belong to, so an in-flight
+// thumbnail load from a previous drive is discarded rather than painted onto a
+// reused cell. Called before the orchestrator publishes new cells.
+export function beginRender(channelId: number): void {
+    currentChannelId = channelId;
+}
+
+export function registerCell(node: HTMLElement, reg: CellRegistration): void {
+    const handle: CellHandle = { node, msgId: reg.msgId, apply: reg.apply, status: 'idle' };
+    handles.set(node, handle);
+    observer?.observe(node);
+}
+
+export function unregisterCell(node: HTMLElement): void {
+    observer?.unobserve(node);
+    const handle = handles.get(node);
+    if (handle) {
+        const idx = loadedHandles.indexOf(handle);
+        if (idx >= 0) loadedHandles.splice(idx, 1);
+    }
+    handles.delete(node);
+}
+
+// rearmLocked lets locked cells retry after the vault unlocks, without a full
+// gallery refresh.
+export function rearmLocked(): void {
+    for (const handle of handles.values()) {
+        if (handle.status !== 'locked') continue;
+        handle.status = 'idle';
+        handle.apply({ status: 'idle' });
+        observer?.observe(handle.node);
+    }
+}
+
+// cachedThumb returns a loaded thumbnail URL for the lightbox placeholder.
+export function cachedThumb(channelId: number, msgId: number): string {
+    return thumbCache.get(`${channelId}:${msgId}`) || '';
+}
+
+function onIntersect(entries: IntersectionObserverEntry[]): void {
+    for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        const node = entry.target as HTMLElement;
+        observer?.unobserve(node);
+        const handle = handles.get(node);
+        if (handle) void loadCell(handle);
+    }
+}
+
+async function loadCell(handle: CellHandle): Promise<void> {
+    if (handle.status === 'loaded' || handle.status === 'loading') return;
+
+    const channelId = currentChannelId;
+    const key = `${channelId}:${handle.msgId}`;
+
+    const cached = thumbCache.get(key);
+    if (cached) {
+        handle.status = 'loaded';
+        handle.apply({ status: 'loaded', src: cached });
+        registerLoaded(handle);
+        return;
+    }
+
+    handle.status = 'loading';
+    handle.apply({ status: 'loading' });
+    try {
+        const url = await getThumbnail(handle.msgId);
+        // Discard if the drive changed mid-flight or the cell was unregistered
+        // (destroyed), so a stale or wrong-drive image is never painted/cached.
+        // A reused same-drive cell still matches both guards and paints.
+        if (channelId !== currentChannelId || !handles.has(handle.node)) return;
+        cacheThumb(key, url);
+        handle.status = 'loaded';
+        handle.apply({ status: 'loaded', src: url });
+        registerLoaded(handle);
+    } catch (err) {
+        if (channelId !== currentChannelId || !handles.has(handle.node)) return;
+        if (/password required/i.test(String(err))) {
+            handle.status = 'locked';
+            handle.apply({ status: 'locked', title: 'locked, click to unlock' });
+        } else {
+            handle.status = 'failed';
+            handle.apply({ status: 'failed', title: "couldn't load" });
+        }
+    }
+}
+
+// registerLoaded tracks a cell holding a decoded image and unloads the oldest
+// once we exceed the budget, keeping decoded-image memory bounded.
+function registerLoaded(handle: CellHandle): void {
+    loadedHandles.push(handle);
+    while (loadedHandles.length > MAX_LOADED_CELLS) {
+        const old = loadedHandles.shift();
+        if (old && old !== handle) unloadCell(old);
+    }
+}
+
+function unloadCell(handle: CellHandle): void {
+    if (!handles.has(handle.node)) return;
+    handle.status = 'idle';
+    handle.apply({ status: 'idle', src: '' });
+    // Re-arm so it reloads (instantly, from the thumb cache) when scrolled back.
+    observer?.observe(handle.node);
+}
+
+function cacheThumb(key: string, url: string): void {
+    thumbCache.set(key, url);
+    if (thumbCache.size > THUMB_CACHE_MAX) {
+        const oldest = thumbCache.keys().next().value;
+        if (oldest !== undefined) thumbCache.delete(oldest);
+    }
+}

--- a/frontend/src/ui/gallery/gallery-store.ts
+++ b/frontend/src/ui/gallery/gallery-store.ts
@@ -1,0 +1,21 @@
+import { writable } from 'svelte/store';
+import type { FileItem } from '../../types';
+
+export interface GalleryCellModel {
+    item: FileItem;
+    // Flat index across all groups, for lightbox prev/next over the whole set.
+    index: number;
+}
+
+export interface GalleryGroup {
+    label: string;
+    cells: GalleryCellModel[];
+}
+
+export type GalleryView =
+    | { status: 'loading' }
+    | { status: 'error' }
+    | { status: 'empty' }
+    | { status: 'ready'; groups: GalleryGroup[] };
+
+export const galleryView = writable<GalleryView>({ status: 'loading' });

--- a/frontend/src/ui/gallery/gallery.test.ts
+++ b/frontend/src/ui/gallery/gallery.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import Gallery from './Gallery.svelte';
+import GalleryCell from './GalleryCell.svelte';
+import { galleryView, type GalleryGroup } from './gallery-store';
+import type { FileItem } from '../../types';
+
+function makeItem(overrides: Partial<FileItem> = {}): FileItem {
+    return {
+        msgId: 1,
+        name: 'photo.jpg',
+        size: 1000,
+        parentId: '',
+        uploadTime: 0,
+        uploaderId: 0,
+        encrypted: false,
+        plaintextSize: 0,
+        ...overrides,
+    };
+}
+
+function makeGroup(label: string, items: FileItem[], startIndex = 0): GalleryGroup {
+    return { label, cells: items.map((item, i) => ({ item, index: startIndex + i })) };
+}
+
+afterEach(() => {
+    galleryView.set({ status: 'loading' });
+});
+
+describe('Gallery view states', () => {
+    it('renders the loading placeholder', () => {
+        galleryView.set({ status: 'loading' });
+        expect(render(Gallery).body).toContain('Loading photos…');
+    });
+
+    it('renders the error and empty states', () => {
+        galleryView.set({ status: 'error' });
+        expect(render(Gallery).body).toContain('Could not load photos.');
+
+        galleryView.set({ status: 'empty' });
+        const empty = render(Gallery).body;
+        expect(empty).toContain('gallery-empty');
+        expect(empty).toContain('No photos yet');
+    });
+
+    it('renders month groups with a cell per item', () => {
+        galleryView.set({
+            status: 'ready',
+            groups: [
+                makeGroup('July 2026', [makeItem({ msgId: 10 }), makeItem({ msgId: 11 })], 0),
+                makeGroup('June 2026', [makeItem({ msgId: 12 })], 2),
+            ],
+        });
+
+        const { body } = render(Gallery);
+
+        expect(body).toContain('July 2026');
+        expect(body).toContain('June 2026');
+        expect((body.match(/gallery-cell/g) || [])).toHaveLength(3);
+        expect(body).toContain('data-id="10"');
+        expect(body).toContain('data-index="2"');
+    });
+});
+
+describe('GalleryCell', () => {
+    it('starts idle with no image source and a plain title', () => {
+        const { body } = render(GalleryCell, { props: { item: makeItem({ name: 'a.jpg' }), index: 0 } });
+
+        expect(body).toContain('class="gallery-cell"');
+        expect(body).not.toContain('is-loaded');
+        expect(body).not.toContain('src=');
+        expect(body).toContain('title="a.jpg"');
+        expect(body).not.toContain('gallery-lock');
+    });
+
+    it('shows a lock badge for encrypted items', () => {
+        const { body } = render(GalleryCell, { props: { item: makeItem({ encrypted: true }), index: 0 } });
+        expect(body).toContain('gallery-lock');
+    });
+
+    it('escapes untrusted names in the aria-label and title', () => {
+        const { body } = render(GalleryCell, { props: { item: makeItem({ name: '<img src=x>.jpg' }), index: 0 } });
+        expect(body).not.toContain('<img src=x>');
+    });
+});


### PR DESCRIPTION
The photos gallery and the login screens are now Svelte. The gallery keeps its performance-critical machinery intact but moves it into a dedicated controller (ui/gallery/gallery-controller.ts): one IntersectionObserver rooted on the stable host, an LRU thumbnail-URL cache, and FIFO eviction of decoded image bitmaps so memory stays flat on large libraries. One correctness improvement fell out of the rewrite: the old renderToken guard would strand a keyed-reused cell mid-load, so discard is now gated on the precise invariants (drive changed, or cell unregistered), which also handles Svelte reuse of unchanged cells. The four auth screens (setup, phone, code, 2FA) render from a small store-driven state machine; the login flow, InitDrive bring-up, and the Telegram event stream stay in modules/auth.ts. Rejected-code field reset uses a dedicated nonce because the screen value does not change, so an effect keyed on it cannot fire. The five inline onclick globals and the password-reveal helper are gone. index.html is down to 300 lines and three more fields left the global state object. Every exported module API (setupGallery, renderGallery, enterPhotos, checkStatusAndShowScreen, hideAllScreens, showDashboard) is byte-compatible with its callers. typecheck / lint / vitest (105 tests: SSR view coverage, a controller unit suite for load/cache/evict/guards, and dom coverage for the auth field-reset paths) / build all green. The app-shell extraction is deferred to PR 3, where it lands with the preview lightbox and video player so index.html becomes minimal in one coherent step and boot ordering is reasoned about once.