### PR TITLE
fix: index forwarded media in personal drives

### DIFF
--- a/backend/sync/parse.go
+++ b/backend/sync/parse.go
@@ -1,33 +1,56 @@
 package sync
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
 	"TDrive/backend/projection"
 	"TDrive/backend/tgclient"
 )
 
-// ParsedMessage is a tgclient.HistoryMessage that successfully decoded into
-// a TDX1 op. Messages without a header (legacy uploads, regular Telegram
-// posts) are dropped during parsing; the unmanaged-bucket UI in Step 6 will
-// surface them separately.
+// ParsedMessage is a tgclient.HistoryMessage that decoded into a projectable
+// op. By default only TDX1 captions are projectable. Personal-drive sync can
+// opt into adopting captionless Telegram documents as root files.
 type ParsedMessage struct {
-	MsgID     int64
-	FromID    int64
-	Op        projection.Op
-	RawHeader string
+	MsgID              int64
+	FromID             int64
+	Op                 projection.Op
+	RawHeader          string
+	AdoptedCaptionless bool
+}
+
+type ParseOptions struct {
+	// AdoptCaptionlessMedia projects regular Telegram document messages as
+	// root files. This is safe for personal drives, where the channel is the
+	// user's storage bucket; shared drives intentionally leave this off so
+	// normal chat attachments do not become TDrive files.
+	AdoptCaptionlessMedia bool
 }
 
 // ParseHistoryPage filters and parses a slice of history messages. Order is
 // not preserved — the caller is expected to sort the result ascending by
 // MsgID before feeding it to ProjectFromOp.
 func ParseHistoryPage(msgs []tgclient.HistoryMessage) []ParsedMessage {
+	return ParseHistoryPageWithOptions(msgs, ParseOptions{})
+}
+
+func ParseHistoryPageWithOptions(msgs []tgclient.HistoryMessage, opts ParseOptions) []ParsedMessage {
 	out := make([]ParsedMessage, 0, len(msgs))
 	for _, m := range msgs {
 		header := projection.ExtractHeaderLine(m.Text)
 		op, err := projection.Parse(header)
+		adoptedCaptionless := false
 		if err != nil {
-			continue
+			if !opts.AdoptCaptionlessMedia || tdriveHeaderCandidate(header) {
+				continue
+			}
+			var ok bool
+			op, header, ok = captionlessMediaOp(m)
+			if !ok {
+				continue
+			}
+			adoptedCaptionless = true
 		}
 		if op.Type == projection.OpFileUpload || op.Type == projection.OpMeta {
 			if op.FileSize == 0 && m.MediaSize > 0 {
@@ -38,13 +61,36 @@ func ParseHistoryPage(msgs []tgclient.HistoryMessage) []ParsedMessage {
 			}
 		}
 		out = append(out, ParsedMessage{
-			MsgID:     m.MsgID,
-			FromID:    m.FromID,
-			Op:        op,
-			RawHeader: header,
+			MsgID:              m.MsgID,
+			FromID:             m.FromID,
+			Op:                 op,
+			RawHeader:          header,
+			AdoptedCaptionless: adoptedCaptionless,
 		})
 	}
 	return out
+}
+
+func tdriveHeaderCandidate(header string) bool {
+	return strings.HasPrefix(strings.TrimSpace(header), "TDX1")
+}
+
+func captionlessMediaOp(m tgclient.HistoryMessage) (projection.Op, string, bool) {
+	if !m.HasMedia {
+		return projection.Op{}, "", false
+	}
+	name := strings.TrimSpace(m.DocumentName)
+	if name == "" {
+		name = fmt.Sprintf("Telegram file %d", m.MsgID)
+	}
+	op := projection.Op{
+		Type:           projection.OpFileUpload,
+		Parent:         projection.RootParent,
+		Name:           name,
+		FileSize:       m.MediaSize,
+		FileUploadTime: m.Date,
+	}
+	return op, projection.Format(op), true
 }
 
 // SortAscending sorts by msg_id in place. Telegram history is descending;

--- a/backend/sync/sync.go
+++ b/backend/sync/sync.go
@@ -115,12 +115,19 @@ func (e *Engine) Incremental(ctx context.Context, channelID int64) error {
 	if err != nil {
 		return err
 	}
+	parseOpts, err := parseOptionsForChannel(e.db, channelID)
+	if err != nil {
+		return err
+	}
 
 	plan, err := e.planHistory(ctx, channelID, peer, watermark)
 	if err != nil {
 		return err
 	}
-	return e.applyHistoryPlan(ctx, channelID, peer, watermark, plan)
+	if len(plan.upperBounds) == 0 {
+		return e.adoptRecentCaptionlessMedia(ctx, channelID, peer, parseOpts)
+	}
+	return e.applyHistoryPlan(ctx, channelID, peer, watermark, plan, parseOpts)
 }
 
 // InitialSyncEmptyChannel paginates the full history of a channel that has
@@ -140,6 +147,10 @@ func (e *Engine) InitialSyncEmptyChannel(ctx context.Context, channelID int64) e
 		return projection.ErrChannelNotEmpty
 	}
 	watermark := int64(0)
+	parseOpts, err := parseOptionsForChannel(e.db, channelID)
+	if err != nil {
+		return err
+	}
 
 	peer, err := e.peers.ResolvePeer(ctx, channelID)
 	if err != nil {
@@ -153,7 +164,7 @@ func (e *Engine) InitialSyncEmptyChannel(ctx context.Context, channelID int64) e
 	if len(plan.upperBounds) == 0 {
 		return markInitialSyncDone(e.db, channelID, watermark)
 	}
-	return e.applyInitialHistoryPlan(ctx, channelID, peer, watermark, plan)
+	return e.applyInitialHistoryPlan(ctx, channelID, peer, watermark, plan, parseOpts)
 }
 
 func (e *Engine) planHistory(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64) (historyPlan, error) {
@@ -198,7 +209,7 @@ func (e *Engine) planHistory(ctx context.Context, channelID int64, peer tgclient
 	return historyPlan{upperBounds: upperBounds, highestSeen: highestSeen}, nil
 }
 
-func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan) error {
+func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan, parseOpts ParseOptions) error {
 	for i := len(plan.upperBounds) - 1; i >= 0; i-- {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -218,7 +229,7 @@ func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgc
 				pageWatermark = m.MsgID
 			}
 		}
-		parsed := ParseHistoryPage(filtered)
+		parsed := ParseHistoryPageWithOptions(filtered, parseOpts)
 		SortAscending(parsed)
 
 		tx, err := e.db.Begin()
@@ -245,7 +256,7 @@ func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgc
 	return nil
 }
 
-func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan) error {
+func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan, parseOpts ParseOptions) error {
 	tx, err := e.db.Begin()
 	if err != nil {
 		return fmt.Errorf("sync: begin initial projection: %w", err)
@@ -267,7 +278,7 @@ func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, p
 			}
 			filtered = append(filtered, m)
 		}
-		parsed := ParseHistoryPage(filtered)
+		parsed := ParseHistoryPageWithOptions(filtered, parseOpts)
 		SortAscending(parsed)
 		for _, p := range parsed {
 			if _, err := projection.ProjectFromOpTx(tx, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
@@ -283,6 +294,51 @@ func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, p
 		return fmt.Errorf("sync: commit initial projection: %w", err)
 	}
 	return nil
+}
+
+func (e *Engine) adoptRecentCaptionlessMedia(ctx context.Context, channelID int64, peer tgclient.InputPeer, parseOpts ParseOptions) error {
+	if !parseOpts.AdoptCaptionlessMedia {
+		return nil
+	}
+	page, err := e.getHistory(ctx, channelID, peer, 0, 0, defaultPageSize)
+	if err != nil {
+		return fmt.Errorf("sync: get recent history: %w", err)
+	}
+	parsed := ParseHistoryPageWithOptions(page, parseOpts)
+	SortAscending(parsed)
+	adopted := parsed[:0]
+	for _, p := range parsed {
+		if p.AdoptedCaptionless {
+			adopted = append(adopted, p)
+		}
+	}
+	if len(adopted) == 0 {
+		return nil
+	}
+
+	tx, err := e.db.Begin()
+	if err != nil {
+		return fmt.Errorf("sync: begin captionless adoption: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for _, p := range adopted {
+		if _, err := projection.ProjectFromOpTx(tx, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
+			return fmt.Errorf("sync: adopt captionless media msg=%d: %w", p.MsgID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sync: commit captionless adoption: %w", err)
+	}
+	return nil
+}
+
+func parseOptionsForChannel(db *sql.DB, channelID int64) (ParseOptions, error) {
+	ch, err := projection.GetChannel(db, channelID)
+	if err != nil {
+		return ParseOptions{}, err
+	}
+	return ParseOptions{AdoptCaptionlessMedia: ch.Kind == projection.KindPersonal}, nil
 }
 
 func readWatermark(db *sql.DB, channelID int64) (int64, error) {

--- a/backend/sync/sync_test.go
+++ b/backend/sync/sync_test.go
@@ -174,6 +174,110 @@ func TestIncrementalBackfillsMissingFileSizeFromTelegramMedia(t *testing.T) {
 	}
 }
 
+func TestIncrementalAutoAdoptsCaptionlessMediaInPersonalDrive(t *testing.T) {
+	db, tg, eng := newSyncEnv(t)
+	tg.SeedHistory(tgclient.HistoryMessage{
+		MsgID:        42,
+		Date:         1234,
+		FromID:       9,
+		Text:         "forwarded from another channel",
+		HasMedia:     true,
+		MediaSize:    9876,
+		DocumentName: "forwarded.mkv",
+	})
+
+	if err := eng.Incremental(context.Background(), testChan); err != nil {
+		t.Fatalf("incremental: %v", err)
+	}
+
+	var name string
+	var size, uploadTime, uploader int64
+	if err := db.QueryRow(`
+		SELECT name, size, upload_time, uploader_user_id FROM files
+		WHERE channel_id = ? AND msg_id = ?
+	`, testChan, 42).Scan(&name, &size, &uploadTime, &uploader); err != nil {
+		t.Fatalf("file row: %v", err)
+	}
+	if name != "forwarded.mkv" {
+		t.Fatalf("name = %q, want forwarded.mkv", name)
+	}
+	if size != 9876 {
+		t.Fatalf("size = %d, want 9876", size)
+	}
+	if uploadTime != 1234 {
+		t.Fatalf("upload_time = %d, want 1234", uploadTime)
+	}
+	if uploader != 9 {
+		t.Fatalf("uploader = %d, want 9", uploader)
+	}
+}
+
+func TestIncrementalRecoversRecentlySkippedCaptionlessMediaBelowWatermark(t *testing.T) {
+	db, tg, eng := newSyncEnv(t)
+	tg.SeedHistory(tgclient.HistoryMessage{
+		MsgID:        42,
+		Date:         1234,
+		FromID:       9,
+		Text:         "forwarded before the auto-adopt fix",
+		HasMedia:     true,
+		MediaSize:    9876,
+		DocumentName: "already-skipped.mkv",
+	})
+	if _, err := db.Exec(`UPDATE channels SET last_synced_msg = ? WHERE channel_id = ?`, int64(100), testChan); err != nil {
+		t.Fatalf("seed watermark: %v", err)
+	}
+
+	if err := eng.Incremental(context.Background(), testChan); err != nil {
+		t.Fatalf("incremental: %v", err)
+	}
+
+	var name string
+	if err := db.QueryRow(`
+		SELECT name FROM files
+		WHERE channel_id = ? AND msg_id = ?
+	`, testChan, 42).Scan(&name); err != nil {
+		t.Fatalf("file row: %v", err)
+	}
+	if name != "already-skipped.mkv" {
+		t.Fatalf("name = %q, want already-skipped.mkv", name)
+	}
+	var wm int64
+	if err := db.QueryRow(`SELECT last_synced_msg FROM channels WHERE channel_id = ?`, testChan).Scan(&wm); err != nil {
+		t.Fatalf("watermark: %v", err)
+	}
+	if wm != 100 {
+		t.Fatalf("watermark = %d, want 100", wm)
+	}
+}
+
+func TestIncrementalDoesNotAutoAdoptCaptionlessMediaInSharedDrive(t *testing.T) {
+	db, tg, eng := newSyncEnv(t)
+	if _, err := db.Exec(`UPDATE channels SET kind = ? WHERE channel_id = ?`, projection.KindShared, testChan); err != nil {
+		t.Fatalf("mark shared: %v", err)
+	}
+	tg.SeedHistory(tgclient.HistoryMessage{
+		MsgID:        42,
+		Date:         1234,
+		FromID:       9,
+		Text:         "regular shared-drive attachment",
+		HasMedia:     true,
+		MediaSize:    9876,
+		DocumentName: "chat-attachment.mkv",
+	})
+
+	if err := eng.Incremental(context.Background(), testChan); err != nil {
+		t.Fatalf("incremental: %v", err)
+	}
+
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM files WHERE channel_id = ?`, testChan).Scan(&rows); err != nil {
+		t.Fatalf("file count: %v", err)
+	}
+	if rows != 0 {
+		t.Fatalf("files = %d, want 0", rows)
+	}
+}
+
 func TestParseHistoryPagePreservesExplicitFileSizeAndTime(t *testing.T) {
 	parsed := ParseHistoryPage([]tgclient.HistoryMessage{{
 		MsgID:     42,
@@ -191,6 +295,49 @@ func TestParseHistoryPagePreservesExplicitFileSizeAndTime(t *testing.T) {
 	}
 	if parsed[0].Op.FileUploadTime != 222 {
 		t.Fatalf("upload_time = %d, want explicit 222", parsed[0].Op.FileUploadTime)
+	}
+}
+
+func TestParseHistoryPageCanAdoptCaptionlessMedia(t *testing.T) {
+	parsed := ParseHistoryPageWithOptions([]tgclient.HistoryMessage{{
+		MsgID:        42,
+		Date:         1234,
+		FromID:       9,
+		Text:         "not a TDX header",
+		HasMedia:     true,
+		MediaSize:    9876,
+		DocumentName: "forwarded.mkv",
+	}}, ParseOptions{AdoptCaptionlessMedia: true})
+	if len(parsed) != 1 {
+		t.Fatalf("parsed = %d, want 1", len(parsed))
+	}
+	got := parsed[0]
+	if got.Op.Type != projection.OpFileUpload {
+		t.Fatalf("op type = %q, want file upload", got.Op.Type)
+	}
+	if got.Op.Parent != projection.RootParent || got.Op.Name != "forwarded.mkv" {
+		t.Fatalf("op parent/name = %q/%q, want root/forwarded.mkv", got.Op.Parent, got.Op.Name)
+	}
+	if got.Op.FileSize != 9876 || got.Op.FileUploadTime != 1234 {
+		t.Fatalf("op size/time = %d/%d, want 9876/1234", got.Op.FileSize, got.Op.FileUploadTime)
+	}
+	if got.RawHeader == "" {
+		t.Fatal("raw header must be deterministic for replay-log hashing")
+	}
+}
+
+func TestParseHistoryPageDoesNotAdoptMalformedTDXMedia(t *testing.T) {
+	parsed := ParseHistoryPageWithOptions([]tgclient.HistoryMessage{{
+		MsgID:        42,
+		Date:         1234,
+		FromID:       9,
+		Text:         "TDX1|t=f|p=",
+		HasMedia:     true,
+		MediaSize:    9876,
+		DocumentName: "forwarded.mkv",
+	}}, ParseOptions{AdoptCaptionlessMedia: true})
+	if len(parsed) != 0 {
+		t.Fatalf("parsed = %d, want 0 for malformed TDX header", len(parsed))
 	}
 }
 


### PR DESCRIPTION
This fixes a sync blind spot where forwarded Telegram document messages were skipped because they do not carry a TDrive `TDX1|...` metadata caption. The sync parser now has an explicit personal-drive adoption mode that projects captionless document media as root files, while shared drives keep the old behavior so normal chat attachments are not pulled into the drive index.

The implementation also performs a bounded recent-page recovery scan for personal drives when there are no newer messages, so recently forwarded files that an older client already skipped below the watermark can still be adopted without resetting the channel. Malformed TDX metadata remains ignored rather than being silently converted into synthetic files.

Notes: this covers Telegram document media, which is the path TDrive can already resolve/download/play. Telegram photo messages use a different media API shape and should be handled separately when photo-message download support is added.