### PR TITLE
Add live drive sync from Telegram activity signals

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -89,6 +89,10 @@ func LoadImpCredentials() (ImpCredentials, error) {
 }
 
 func Connect() (*telegram.Client, error) {
+	return ConnectWithOptions(telegram.Options{})
+}
+
+func ConnectWithOptions(options telegram.Options) (*telegram.Client, error) {
 	creds, err := LoadImpCredentials()
 	if err != nil {
 		return nil, fmt.Errorf("API credentials are not configured")
@@ -114,9 +118,8 @@ func Connect() (*telegram.Client, error) {
 		Path: sessionPath,
 	}
 
-	tgclient := telegram.NewClient(TgApiID, TgApiHash, telegram.Options{
-		SessionStorage: ses,
-	})
+	options.SessionStorage = ses
+	tgclient := telegram.NewClient(TgApiID, TgApiHash, options)
 
 	return tgclient, nil
 }

--- a/backend/core/engine.go
+++ b/backend/core/engine.go
@@ -10,6 +10,7 @@ import (
 	"TDrive/backend"
 	"TDrive/backend/auth"
 	"TDrive/backend/backfill"
+	"TDrive/backend/livesync"
 	"TDrive/backend/media"
 	"TDrive/backend/projection"
 	authsvc "TDrive/backend/services/auth"
@@ -84,6 +85,7 @@ type Engine struct {
 	lifecycle  *lifecycleservice.Service
 	users      *userservice.Service
 	syncEngine *tdsync.Engine
+	liveSync   *livesync.Coordinator
 	active     *lifecycleservice.ActiveDrive
 	selfUserID atomic.Int64
 	thumbs     *thumbnail.Cache
@@ -96,6 +98,7 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	usingDefaultConnect := cfg.Connect == nil
 	if cfg.Connect == nil {
 		cfg.Connect = auth.Connect
 	}
@@ -114,8 +117,16 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 		active:  lifecycleservice.NewActiveDrive(),
 		thumbs:  cfg.Thumbs,
 	}
+	var liveActivity *livesync.TelegramActivity
 	if e.tg == nil {
-		e.tg = tgclient.NewGotd(e.connect)
+		if usingDefaultConnect {
+			liveActivity = livesync.NewTelegramActivity(256)
+			e.tg = tgclient.NewGotd(func() (*telegram.Client, error) {
+				return auth.ConnectWithOptions(telegram.Options{UpdateHandler: liveActivity})
+			})
+		} else {
+			e.tg = tgclient.NewGotd(e.connect)
+		}
 	}
 
 	if client, err := e.connect(); err != nil {
@@ -142,6 +153,7 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 	e.syncEngine = tdsync.NewEngine(backend.DB, e.tg, peerResolverFn(e.ResolvePeer))
 	e.lifecycle = e.newLifecycleService()
 	e.users = e.newUserService()
+	e.startLiveSync(liveActivity)
 
 	if savedID, err := auth.LoadConfig(); err == nil && savedID != 0 {
 		if err := e.lifecycle.UsePersonalChannel(e.ctx, savedID); err != nil {
@@ -152,7 +164,41 @@ func New(ctx context.Context, cfg Config) (*Engine, error) {
 	return e, nil
 }
 
+func (e *Engine) startLiveSync(activity *livesync.TelegramActivity) {
+	if e == nil || activity == nil || e.lifecycle == nil {
+		return
+	}
+	e.liveSync = livesync.NewCoordinator(livesync.Config{
+		Activity: activity,
+		Syncer:   e.lifecycle,
+		Events:   e.events,
+		Warnf: func(format string, args ...any) {
+			e.warnf(format, args...)
+		},
+		ListChannels: func(ctx context.Context) ([]int64, error) {
+			if backend.DB == nil {
+				return nil, fmt.Errorf("db not ready")
+			}
+			channels, err := projection.ListChannels(backend.DB)
+			if err != nil {
+				return nil, err
+			}
+			ids := make([]int64, 0, len(channels))
+			for _, channel := range channels {
+				if channel.ChannelID > 0 {
+					ids = append(ids, channel.ChannelID)
+				}
+			}
+			return ids, nil
+		},
+	})
+	e.liveSync.Start(e.ctx)
+}
+
 func (e *Engine) Close() {
+	if e != nil && e.liveSync != nil {
+		e.liveSync.Stop()
+	}
 	if e != nil && e.media != nil {
 		_ = e.media.Close()
 	}

--- a/backend/livesync/activity.go
+++ b/backend/livesync/activity.go
@@ -1,0 +1,127 @@
+package livesync
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+const defaultSignalBuffer = 256
+
+// Activity is a liveness-only source. Values mean "channel probably changed";
+// they are never treated as projection payloads.
+type Activity interface {
+	Signals() <-chan int64
+}
+
+// TelegramActivity adapts gotd updates into channel-id doorbells. Signal drops
+// are acceptable because the coordinator also has a periodic authoritative
+// history pull backstop.
+type TelegramActivity struct {
+	ch      chan int64
+	dropped atomic.Int64
+}
+
+func NewTelegramActivity(buffer int) *TelegramActivity {
+	if buffer <= 0 {
+		buffer = defaultSignalBuffer
+	}
+	return &TelegramActivity{ch: make(chan int64, buffer)}
+}
+
+func (a *TelegramActivity) Signals() <-chan int64 {
+	if a == nil {
+		return nil
+	}
+	return a.ch
+}
+
+func (a *TelegramActivity) Dropped() int64 {
+	if a == nil {
+		return 0
+	}
+	return a.dropped.Load()
+}
+
+func (a *TelegramActivity) Signal(channelID int64) {
+	if a == nil || channelID <= 0 {
+		return
+	}
+	select {
+	case a.ch <- channelID:
+	default:
+		a.dropped.Add(1)
+	}
+}
+
+func (a *TelegramActivity) Handle(_ context.Context, updates tg.UpdatesClass) error {
+	for _, channelID := range ChannelIDsFromUpdates(updates) {
+		a.Signal(channelID)
+	}
+	return nil
+}
+
+var _ Activity = (*TelegramActivity)(nil)
+var _ telegram.UpdateHandler = (*TelegramActivity)(nil)
+
+func ChannelIDsFromUpdates(updates tg.UpdatesClass) []int64 {
+	seen := make(map[int64]struct{})
+	var out []int64
+	add := func(channelID int64) {
+		if channelID <= 0 {
+			return
+		}
+		if _, ok := seen[channelID]; ok {
+			return
+		}
+		seen[channelID] = struct{}{}
+		out = append(out, channelID)
+	}
+
+	switch u := updates.(type) {
+	case *tg.UpdateShort:
+		add(channelIDFromUpdate(u.Update))
+	case *tg.Updates:
+		for _, item := range u.Updates {
+			add(channelIDFromUpdate(item))
+		}
+	case *tg.UpdatesCombined:
+		for _, item := range u.Updates {
+			add(channelIDFromUpdate(item))
+		}
+	}
+	return out
+}
+
+func channelIDFromUpdate(update tg.UpdateClass) int64 {
+	switch u := update.(type) {
+	case *tg.UpdateNewChannelMessage:
+		return channelIDFromMessage(u.Message)
+	case *tg.UpdateEditChannelMessage:
+		return channelIDFromMessage(u.Message)
+	case *tg.UpdateDeleteChannelMessages:
+		return u.ChannelID
+	default:
+		return 0
+	}
+}
+
+func channelIDFromMessage(message tg.MessageClass) int64 {
+	switch msg := message.(type) {
+	case *tg.Message:
+		return channelIDFromPeer(msg.GetPeerID())
+	case *tg.MessageService:
+		return channelIDFromPeer(msg.GetPeerID())
+	default:
+		return 0
+	}
+}
+
+func channelIDFromPeer(peer tg.PeerClass) int64 {
+	if p, ok := peer.(*tg.PeerChannel); ok {
+		return p.ChannelID
+	}
+	return 0
+}

--- a/backend/livesync/activity_test.go
+++ b/backend/livesync/activity_test.go
@@ -1,0 +1,52 @@
+package livesync
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestChannelIDsFromUpdatesExtractsChannelDoorbells(t *testing.T) {
+	updates := &tg.Updates{
+		Updates: []tg.UpdateClass{
+			&tg.UpdateNewChannelMessage{Message: &tg.Message{PeerID: &tg.PeerChannel{ChannelID: 101}}},
+			&tg.UpdateEditChannelMessage{Message: &tg.MessageService{PeerID: &tg.PeerChannel{ChannelID: 202}}},
+			&tg.UpdateDeleteChannelMessages{ChannelID: 303},
+			&tg.UpdateNewChannelMessage{Message: &tg.Message{PeerID: &tg.PeerChannel{ChannelID: 101}}},
+		},
+	}
+
+	got := ChannelIDsFromUpdates(updates)
+	want := []int64{101, 202, 303}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ChannelIDsFromUpdates() = %v, want %v", got, want)
+	}
+}
+
+func TestChannelIDsFromUpdatesIgnoresNonChannelUpdates(t *testing.T) {
+	got := ChannelIDsFromUpdates(&tg.UpdateShort{
+		Update: &tg.UpdateNewMessage{Message: &tg.Message{PeerID: &tg.PeerUser{UserID: 10}}},
+	})
+	if len(got) != 0 {
+		t.Fatalf("ChannelIDsFromUpdates() = %v, want empty", got)
+	}
+}
+
+func TestTelegramActivityHandleNeverBlocksWhenFull(t *testing.T) {
+	activity := NewTelegramActivity(1)
+	activity.Signal(1)
+
+	err := activity.Handle(context.Background(), &tg.Updates{
+		Updates: []tg.UpdateClass{
+			&tg.UpdateDeleteChannelMessages{ChannelID: 2},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Handle() error = %v", err)
+	}
+	if activity.Dropped() != 1 {
+		t.Fatalf("Dropped() = %d, want 1", activity.Dropped())
+	}
+}

--- a/backend/livesync/coordinator.go
+++ b/backend/livesync/coordinator.go
@@ -1,0 +1,241 @@
+package livesync
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	EventStarted   = "live_sync_started"
+	EventCompleted = "live_sync_completed"
+	EventFailed    = "live_sync_failed"
+)
+
+const (
+	ReasonSignal   = "signal"
+	ReasonBackstop = "backstop"
+)
+
+type Syncer interface {
+	SyncChannel(ctx context.Context, channelID int64) error
+}
+
+type EventSink interface {
+	Emit(name string, args ...any)
+}
+
+type WarnFunc func(format string, args ...any)
+
+type Config struct {
+	Activity Activity
+	Syncer   Syncer
+	Events   EventSink
+	Warnf    WarnFunc
+
+	ListChannels func(ctx context.Context) ([]int64, error)
+
+	Debounce         time.Duration
+	BackstopInterval time.Duration
+	SyncTimeout      time.Duration
+}
+
+type Coordinator struct {
+	activity Activity
+	syncer   Syncer
+	events   EventSink
+	warnf    WarnFunc
+
+	listChannels func(ctx context.Context) ([]int64, error)
+
+	debounce         time.Duration
+	backstopInterval time.Duration
+	syncTimeout      time.Duration
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func NewCoordinator(cfg Config) *Coordinator {
+	if cfg.Debounce <= 0 {
+		cfg.Debounce = 750 * time.Millisecond
+	}
+	if cfg.BackstopInterval < 0 {
+		cfg.BackstopInterval = 0
+	}
+	if cfg.BackstopInterval == 0 {
+		cfg.BackstopInterval = 5 * time.Minute
+	}
+	if cfg.SyncTimeout <= 0 {
+		cfg.SyncTimeout = 2 * time.Minute
+	}
+	if cfg.Warnf == nil {
+		cfg.Warnf = func(string, ...any) {}
+	}
+	return &Coordinator{
+		activity:         cfg.Activity,
+		syncer:           cfg.Syncer,
+		events:           cfg.Events,
+		warnf:            cfg.Warnf,
+		listChannels:     cfg.ListChannels,
+		debounce:         cfg.Debounce,
+		backstopInterval: cfg.BackstopInterval,
+		syncTimeout:      cfg.SyncTimeout,
+	}
+}
+
+func (c *Coordinator) Start(ctx context.Context) {
+	if c == nil || c.activity == nil || c.syncer == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.cancel != nil {
+		return
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	c.cancel = cancel
+	c.done = make(chan struct{})
+	go c.loop(runCtx, c.done)
+}
+
+func (c *Coordinator) Stop() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	cancel := c.cancel
+	done := c.done
+	c.cancel = nil
+	c.done = nil
+	c.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func (c *Coordinator) loop(ctx context.Context, done chan<- struct{}) {
+	defer close(done)
+
+	signals := c.activity.Signals()
+	known, _ := c.loadKnown(ctx)
+	pending := make(map[int64]string)
+
+	var debounceTimer *time.Timer
+	var debounceC <-chan time.Time
+	stopDebounce := func() {
+		if debounceTimer == nil {
+			return
+		}
+		if !debounceTimer.Stop() {
+			select {
+			case <-debounceTimer.C:
+			default:
+			}
+		}
+		debounceTimer = nil
+		debounceC = nil
+	}
+	resetDebounce := func(delay time.Duration) {
+		stopDebounce()
+		debounceTimer = time.NewTimer(delay)
+		debounceC = debounceTimer.C
+	}
+	defer stopDebounce()
+
+	backstop := time.NewTicker(c.backstopInterval)
+	defer backstop.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case channelID, ok := <-signals:
+			if !ok {
+				return
+			}
+			if channelID <= 0 {
+				continue
+			}
+			if !known[channelID] {
+				known, _ = c.loadKnown(ctx)
+				if !known[channelID] {
+					continue
+				}
+			}
+			pending[channelID] = ReasonSignal
+			resetDebounce(c.debounce)
+		case <-debounceC:
+			c.flush(ctx, pending)
+			pending = make(map[int64]string)
+			debounceTimer = nil
+			debounceC = nil
+		case <-backstop.C:
+			known, _ = c.loadKnown(ctx)
+			for channelID := range known {
+				pending[channelID] = ReasonBackstop
+			}
+			if len(pending) > 0 {
+				resetDebounce(0)
+			}
+		}
+	}
+}
+
+func (c *Coordinator) flush(ctx context.Context, pending map[int64]string) {
+	for channelID, reason := range pending {
+		if ctx.Err() != nil {
+			return
+		}
+		c.syncOne(ctx, channelID, reason)
+	}
+}
+
+func (c *Coordinator) syncOne(ctx context.Context, channelID int64, reason string) {
+	payload := map[string]any{"channel_id": channelID, "reason": reason}
+	c.emit(EventStarted, payload)
+
+	syncCtx, cancel := context.WithTimeout(ctx, c.syncTimeout)
+	defer cancel()
+	err := c.syncer.SyncChannel(syncCtx, channelID)
+	if err != nil {
+		c.warnf("live sync: channel=%d reason=%s: %v\n", channelID, reason, err)
+		c.emit(EventFailed, map[string]any{
+			"channel_id": channelID,
+			"reason":     reason,
+			"error":      err.Error(),
+		})
+		return
+	}
+	c.emit(EventCompleted, payload)
+}
+
+func (c *Coordinator) loadKnown(ctx context.Context) (map[int64]bool, error) {
+	out := make(map[int64]bool)
+	if c.listChannels == nil {
+		return out, nil
+	}
+	ids, err := c.listChannels(ctx)
+	if err != nil {
+		c.warnf("live sync: list channels: %v\n", err)
+		return out, fmt.Errorf("list channels: %w", err)
+	}
+	for _, id := range ids {
+		if id > 0 {
+			out[id] = true
+		}
+	}
+	return out, nil
+}
+
+func (c *Coordinator) emit(name string, args ...any) {
+	if c.events != nil {
+		c.events.Emit(name, args...)
+	}
+}

--- a/backend/livesync/coordinator_test.go
+++ b/backend/livesync/coordinator_test.go
@@ -1,0 +1,177 @@
+package livesync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeActivity struct {
+	ch chan int64
+}
+
+func newFakeActivity() *fakeActivity {
+	return &fakeActivity{ch: make(chan int64, 32)}
+}
+
+func (f *fakeActivity) Signals() <-chan int64 { return f.ch }
+
+func (f *fakeActivity) Signal(id int64) { f.ch <- id }
+
+type fakeSyncer struct {
+	mu    sync.Mutex
+	calls []int64
+	err   error
+}
+
+func (f *fakeSyncer) SyncChannel(_ context.Context, channelID int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, channelID)
+	return f.err
+}
+
+func (f *fakeSyncer) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func (f *fakeSyncer) snapshot() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]int64(nil), f.calls...)
+}
+
+type eventRecorder struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *eventRecorder) Emit(name string, _ ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, name)
+}
+
+func (r *eventRecorder) has(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, event := range r.events {
+		if event == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCoordinatorCoalescesSignalBursts(t *testing.T) {
+	activity := newFakeActivity()
+	syncer := &fakeSyncer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := NewCoordinator(Config{
+		Activity: activity,
+		Syncer:   syncer,
+		ListChannels: func(context.Context) ([]int64, error) {
+			return []int64{42}, nil
+		},
+		Debounce:         10 * time.Millisecond,
+		BackstopInterval: time.Hour,
+	})
+	c.Start(ctx)
+	defer c.Stop()
+
+	activity.Signal(42)
+	activity.Signal(42)
+	activity.Signal(42)
+
+	eventually(t, time.Second, func() bool { return syncer.count() == 1 })
+	if got := syncer.snapshot(); len(got) != 1 || got[0] != 42 {
+		t.Fatalf("sync calls = %v, want [42]", got)
+	}
+}
+
+func TestCoordinatorIgnoresUnknownChannels(t *testing.T) {
+	activity := newFakeActivity()
+	syncer := &fakeSyncer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := NewCoordinator(Config{
+		Activity: activity,
+		Syncer:   syncer,
+		ListChannels: func(context.Context) ([]int64, error) {
+			return []int64{1}, nil
+		},
+		Debounce:         5 * time.Millisecond,
+		BackstopInterval: time.Hour,
+	})
+	c.Start(ctx)
+	defer c.Stop()
+
+	activity.Signal(99)
+	time.Sleep(40 * time.Millisecond)
+	if syncer.count() != 0 {
+		t.Fatalf("sync count = %d, want 0", syncer.count())
+	}
+}
+
+func TestCoordinatorBackstopSyncsKnownChannels(t *testing.T) {
+	activity := newFakeActivity()
+	syncer := &fakeSyncer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := NewCoordinator(Config{
+		Activity: activity,
+		Syncer:   syncer,
+		ListChannels: func(context.Context) ([]int64, error) {
+			return []int64{7, 8}, nil
+		},
+		Debounce:         time.Millisecond,
+		BackstopInterval: 10 * time.Millisecond,
+	})
+	c.Start(ctx)
+	defer c.Stop()
+
+	eventually(t, time.Second, func() bool { return syncer.count() >= 2 })
+}
+
+func TestCoordinatorEmitsFailureEvents(t *testing.T) {
+	activity := newFakeActivity()
+	syncer := &fakeSyncer{err: context.Canceled}
+	events := &eventRecorder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := NewCoordinator(Config{
+		Activity: activity,
+		Syncer:   syncer,
+		Events:   events,
+		ListChannels: func(context.Context) ([]int64, error) {
+			return []int64{5}, nil
+		},
+		Debounce:         5 * time.Millisecond,
+		BackstopInterval: time.Hour,
+	})
+	c.Start(ctx)
+	defer c.Stop()
+
+	activity.Signal(5)
+	eventually(t, time.Second, func() bool { return events.has(EventFailed) })
+}
+
+func eventually(t *testing.T, timeout time.Duration, ok func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ok() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", timeout)
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -35,7 +35,7 @@ import { setupLogoutModal } from './modules/modals/logout';
 
 // Sidebar / drives
 import { setupSidebar, renderSidebar } from './modules/sidebar';
-import { bindChannelsRenderers, refreshActiveDrive } from './modules/channels';
+import { bindChannelsRenderers, refreshActiveDrive, setupLiveSyncEvents } from './modules/channels';
 
 // Notifications
 import { setupNotifications } from './modules/notifications';
@@ -141,6 +141,7 @@ window.onload = async function() {
     // Setup window bindings
     setupAuthWindowBindings();
     setupFileListWindowBindings();
+    setupLiveSyncEvents();
 
     // Check status and show appropriate screen
     await checkStatusAndShowScreen();

--- a/frontend/src/modules/channels.ts
+++ b/frontend/src/modules/channels.ts
@@ -22,9 +22,13 @@ import {
     SetActiveChannel,
     SyncChannel,
 } from '../../wailsjs/go/main/App';
+import { runGlobalSearch } from './search';
 
 let renderSidebar = () => {};
 let refreshFilesView = () => {};
+const pendingLiveSyncChannels = new Set<number>();
+let processingLiveSyncRefresh = false;
+let liveSyncEventsBound = false;
 
 export function bindChannelsRenderers({ onSidebarUpdate, onActiveDriveChanged }: { onSidebarUpdate: any; onActiveDriveChanged: any }) {
     if (typeof onSidebarUpdate === 'function') renderSidebar = onSidebarUpdate;
@@ -71,6 +75,53 @@ export async function loadChannels() {
         state.activeChannel = null;
         state.pendingJoins = [];
         renderSidebar();
+    }
+}
+
+export function setupLiveSyncEvents() {
+    if (liveSyncEventsBound) return;
+    if (!window.runtime?.EventsOn) return;
+    liveSyncEventsBound = true;
+
+    window.runtime.EventsOn("live_sync_completed", (payload: any) => {
+        queueLiveSyncRefresh(payload);
+    });
+    window.runtime.EventsOn("live_sync_failed", (payload: any) => {
+        const channelID = Number(payload?.channel_id || 0);
+        const activeID = Number(state.activeChannel?.id || 0);
+        if (channelID && channelID !== activeID) return;
+        console.warn("live sync failed:", payload?.error || payload);
+    });
+}
+
+function queueLiveSyncRefresh(payload: any) {
+    const channelID = Number(payload?.channel_id || 0);
+    if (!channelID) return;
+    pendingLiveSyncChannels.add(channelID);
+    if (processingLiveSyncRefresh) return;
+    processingLiveSyncRefresh = true;
+    void processLiveSyncRefreshes();
+}
+
+async function processLiveSyncRefreshes() {
+    try {
+        while (pendingLiveSyncChannels.size > 0) {
+            const changedChannels = new Set(pendingLiveSyncChannels);
+            pendingLiveSyncChannels.clear();
+
+            await loadChannels();
+            const activeID = Number(state.activeChannel?.id || 0);
+            if (!activeID || !changedChannels.has(activeID)) continue;
+
+            state.telegramRootCache = null;
+            if (String(state.searchQuery || "").trim()) {
+                runGlobalSearch();
+            } else {
+                await refreshFilesView();
+            }
+        }
+    } finally {
+        processingLiveSyncRefresh = false;
     }
 }
 

--- a/frontend/src/modules/modals/delete.ts
+++ b/frontend/src/modules/modals/delete.ts
@@ -59,6 +59,7 @@ export function openDeleteModal(target: any) {
     const name = (target?.name || "").trim();
 
     let title: string;
+    let itemName = "";
     let subtitle: string;
     let confirmLabel: string;
 
@@ -92,16 +93,18 @@ export function openDeleteModal(target: any) {
         }
         confirmLabel = total === 0 ? "Close" : "Delete";
     } else if (target?.type === "folder") {
-        title = name ? `Delete folder "${name}"?` : "Delete folder?";
+        title = "Delete folder?";
+        itemName = name;
         subtitle = "This will delete the folder and every file inside it from Telegram. This action can't be undone.";
         confirmLabel = "Delete folder and files";
     } else {
-        title = name ? `Delete "${name}"?` : "Delete file?";
+        title = "Delete file?";
+        itemName = name;
         subtitle = "This will remove the file from your Telegram channel. The action can't be undone.";
         confirmLabel = "Delete file";
     }
 
-    openDeleteModalView({ title, subtitle, confirmLabel });
+    openDeleteModalView({ title, itemName, subtitle, confirmLabel });
 }
 
 export function setupDeleteModal() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1097,6 +1097,20 @@ header {
 }
 .modal-title { color: white; font-size: 1.05rem; font-weight: 700; margin-bottom: 6px; }
 .modal-subtitle { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 18px; }
+.delete-target-name {
+    max-height: 5.5rem;
+    margin: 10px 0 14px;
+    padding: 10px 12px;
+    overflow: auto;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    color: var(--color-text);
+    font-size: var(--type-sm);
+    line-height: 1.35;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--overlay-white-1);
+}
 .field-help {
     color: var(--text-muted);
     font-size: 0.78rem;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -397,6 +397,9 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 
 .uploader-chip {
     display: inline-block;
+    flex: 0 1 auto;
+    max-width: 14ch;
+    overflow: hidden;
     margin-left: 10px;
     padding: 1px 8px;
     border-radius: 999px;
@@ -405,6 +408,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     font-size: 0.72rem;
     font-weight: 500;
     line-height: 1.4;
+    text-overflow: ellipsis;
     vertical-align: 2px;
     white-space: nowrap;
 }
@@ -819,6 +823,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 }
 .pending-folder .pending-indicator {
     display: inline-block;
+    flex: 0 0 auto;
     width: 10px; height: 10px;
     margin-left: 8px;
     border-radius: 50%;
@@ -941,7 +946,7 @@ header {
 /* FILE TABLE */
 .file-table-header {
     position: relative;
-    display: grid; grid-template-columns: 2fr 1fr 1fr 100px; padding: 15px 30px;
+    display: grid; grid-template-columns: minmax(0, 2fr) minmax(96px, 1fr) minmax(84px, 1fr) minmax(100px, auto); padding: 15px 30px;
     font-size: 0.75rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px;
 }
 .col-name { padding-left: 10px; }
@@ -1006,10 +1011,11 @@ header {
 }
 
 .file-row {
-    display: grid; grid-template-columns: 2fr 1fr 1fr 100px; padding: 12px 20px;
+    display: grid; grid-template-columns: minmax(0, 2fr) minmax(96px, 1fr) minmax(84px, 1fr) minmax(100px, auto); padding: 12px 20px;
     align-items: center; border-radius: var(--radius-md); transition: background var(--motion-fast) var(--ease-standard), box-shadow var(--motion-fast) var(--ease-standard), transform var(--motion-fast) var(--ease-standard);
     margin-bottom: 2px; cursor: default;
     outline: none;
+    column-gap: 12px;
 }
 .file-row:hover { background: var(--bg-panel); }
 .file-row:focus-visible,
@@ -1042,6 +1048,7 @@ header {
 
 .file-ext-text {
     display: inline-block;
+    flex: 0 0 auto;
     min-width: 3.2ch;
     margin-right: 12px;
     font-size: 12px;
@@ -1052,16 +1059,41 @@ header {
     opacity: 0.95;
 }
 
-.row-name { font-size: 0.9rem; color: white; font-weight: 500; user-select: text; -webkit-user-select: text; }
+.row-name {
+    min-width: 0;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    color: white;
+    font-size: 0.9rem;
+    font-weight: 500;
+    white-space: nowrap;
+    user-select: text;
+    -webkit-user-select: text;
+}
+.row-label {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .row-name[draggable="true"] { cursor: grab; }
 .row-name[draggable="true"]:active { cursor: grabbing; }
-.row-meta { font-size: 0.85rem; color: var(--text-muted); }
+.row-meta {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 
-.row-actions { display: flex; gap: 8px; opacity: 1; justify-content: flex-end; }
+.row-actions { min-width: 0; display: flex; gap: 8px; opacity: 1; justify-content: flex-end; }
 
 .folder-chip {
     width: 40px; height: 20px; margin-right: 12px;
-    display: inline-flex; align-items: center; justify-content: center;
+    flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;
     background: rgba(122, 162, 247, 0.12);
     border: 1px solid rgba(122, 162, 247, 0.25);
     border-radius: 6px; color: var(--accent);

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1018,10 +1018,16 @@ header {
     column-gap: 12px;
 }
 .file-row:hover { background: var(--bg-panel); }
-.file-row:focus-visible,
-.file-row.is-keyboard-active {
+.file-row:focus-visible {
     background: rgba(122, 162, 247, 0.10);
     box-shadow: inset 0 0 0 1px rgba(122, 162, 247, 0.46), var(--focus-ring);
+}
+.file-row.is-keyboard-active:not(.is-selected) {
+    background: transparent;
+    box-shadow: inset 0 0 0 1px rgba(122, 162, 247, 0.22);
+}
+.file-row.is-keyboard-active:not(.is-selected):hover {
+    background: var(--bg-panel);
 }
 .drive-row.is-selected {
     background: rgba(122, 162, 247, 0.12);

--- a/frontend/src/ui/file-list/FileList.svelte
+++ b/frontend/src/ui/file-list/FileList.svelte
@@ -47,13 +47,13 @@
                 data-temp-id={row.tempId}
                 title="Creating..."
             >
-                <div class="row-name">
+                <div class="row-name" title={row.name}>
                     <span class="folder-chip" aria-hidden="true">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
                         </svg>
                     </span>
-                    {row.name}
+                    <span class="row-label">{row.name}</span>
                     <span class="pending-indicator" aria-hidden="true"></span>
                 </div>
                 <div class="row-meta">Creating...</div>
@@ -86,14 +86,14 @@
                 ondblclick={(event) => onRowDoubleClick(event, row)}
                 onkeydown={onDelegatedKeydown}
             >
-                <div class="row-name" draggable="true">
+                <div class="row-name" draggable="true" title={row.name}>
                     {#if row.kind === 'folder'}
                         <span class="folder-chip" aria-hidden="true">
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
                             </svg>
                         </span>
-                        {row.name}
+                        <span class="row-label">{row.name}</span>
                     {:else}
                         <span class="file-ext-text" aria-hidden="true">{row.ext}</span>
                         {#if row.encrypted}
@@ -104,7 +104,7 @@
                                 </svg>
                             </span>
                         {/if}
-                        {row.baseName}
+                        <span class="row-label">{row.baseName}</span>
                         {#if row.uploaderChip}
                             <span class="uploader-chip">{row.uploaderChip.label}</span>
                         {/if}

--- a/frontend/src/ui/file-list/FileList.test.ts
+++ b/frontend/src/ui/file-list/FileList.test.ts
@@ -63,6 +63,18 @@ describe('FileList', () => {
         expect(body).toContain('tabindex="-1"');
     });
 
+    it('keeps keyboard-active rows semantically unselected when selection is cleared', () => {
+        showFileListRows([makeFileRow()]);
+        setSelectedFileRowKeys([]);
+        setActiveFileRowKey('file:42');
+
+        const { body } = render(FileList);
+
+        expect(body).toContain('class="file-row drive-row is-keyboard-active"');
+        expect(body).toContain('aria-selected="false"');
+        expect(body).toContain('tabindex="0"');
+    });
+
     it('renders uploader chips as escaped text', () => {
         showFileListRows([makeFileRow({
             uploaderChip: { label: 'A<b> 2m ago' },

--- a/frontend/src/ui/file-list/FileList.test.ts
+++ b/frontend/src/ui/file-list/FileList.test.ts
@@ -74,4 +74,19 @@ describe('FileList', () => {
         expect(body).not.toContain('<span class="uploader-chip">A<b>');
         expect(body).not.toContain('data-uploader-slot');
     });
+
+    it('renders long file names through a truncating label with a full-name tooltip', () => {
+        const longName = '@Jesseverse_The_Mentalist_S02E05_720p_WEB_DL_x264_350MB_PaHe_in.mkv';
+        showFileListRows([makeFileRow({
+            name: longName,
+            baseName: longName.replace(/\.mkv$/, ''),
+            ext: 'MKV',
+            ariaLabel: `File: ${longName}`,
+        })]);
+
+        const { body } = render(FileList);
+
+        expect(body).toContain(`title="${longName}"`);
+        expect(body).toContain('<span class="row-label">@Jesseverse_The_Mentalist');
+    });
 });

--- a/frontend/src/ui/modals/DeleteModal.svelte
+++ b/frontend/src/ui/modals/DeleteModal.svelte
@@ -29,6 +29,12 @@
     restoreFocus="#file-list"
     onClose={close}
 >
+    {#if $deleteModalState.itemName}
+        <div class="delete-target-name" title={$deleteModalState.itemName}>
+            {$deleteModalState.itemName}
+        </div>
+    {/if}
+
     {#snippet actions()}
         <button id="delete-cancel" class="secondary-btn" type="button" onclick={close}>Cancel</button>
         <button id="delete-confirm" class="primary-btn danger-btn" type="button" onclick={confirm}>

--- a/frontend/src/ui/modals/delete-modal-store.ts
+++ b/frontend/src/ui/modals/delete-modal-store.ts
@@ -6,6 +6,7 @@ import { writable } from 'svelte/store';
 export interface DeleteModalView {
     open: boolean;
     title: string;
+    itemName: string;
     subtitle: string;
     confirmLabel: string;
 }
@@ -13,6 +14,7 @@ export interface DeleteModalView {
 const initialState: DeleteModalView = {
     open: false,
     title: '',
+    itemName: '',
     subtitle: '',
     confirmLabel: 'Delete',
 };

--- a/frontend/src/ui/modals/modals.test.ts
+++ b/frontend/src/ui/modals/modals.test.ts
@@ -58,23 +58,27 @@ describe('DeleteModal', () => {
 
     it('renders the pre-computed copy and a danger confirm', () => {
         openDeleteModalView({
-            title: 'Delete "notes.txt"?',
+            title: 'Delete file?',
+            itemName: 'notes.txt',
             subtitle: "This will remove the file from your Telegram channel. The action can't be undone.",
             confirmLabel: 'Delete file',
         });
 
         const { body } = render(DeleteModal, { props: { onConfirm: () => {} } });
 
-        expect(body).toContain('Delete "notes.txt"?');
+        expect(body).toContain('Delete file?');
+        expect(body).toContain('class="delete-target-name"');
+        expect(body).toContain('notes.txt');
         expect(body).toContain('This will remove the file from your Telegram channel.');
         expect(body).toContain('danger-btn');
         expect(body).toContain('>Delete file</button>');
         expect(body).toContain('aria-labelledby="delete-modal-title"');
     });
 
-    it('escapes untrusted names in the title', () => {
+    it('escapes untrusted names in the item label', () => {
         openDeleteModalView({
-            title: 'Delete "<img src=x>"?',
+            title: 'Delete file?',
+            itemName: '<img src=x>',
             subtitle: 'sub',
             confirmLabel: 'Delete',
         });
@@ -82,6 +86,21 @@ describe('DeleteModal', () => {
         const { body } = render(DeleteModal, { props: { onConfirm: () => {} } });
 
         expect(body).not.toContain('<img src=x>');
+    });
+
+    it('keeps long delete targets out of the heading', () => {
+        const longName = '@Jesseverse_The_Mentalist_S02E05_720p_WEB_DL_x264_350MB_PaHe_in.mkv';
+        openDeleteModalView({
+            title: 'Delete file?',
+            itemName: longName,
+            subtitle: 'sub',
+            confirmLabel: 'Delete',
+        });
+
+        const { body } = render(DeleteModal, { props: { onConfirm: () => {} } });
+
+        expect(body).toContain('<h3 id="delete-modal-title" class="modal-title">Delete file?</h3>');
+        expect(body).toContain(longName);
     });
 });
 


### PR DESCRIPTION
This adds live drive sync without introducing a second projection writer. Telegram updates are treated only as liveness signals; the coordinator debounces and coalesces channel activity, then calls the existing incremental sync path keyed by last_synced_msg. A periodic backstop keeps missed raw updates from becoming correctness issues after sleep, reconnects, or dropped signals.

The gotd update handler is attached to the shared Telegram connection and never blocks the update path. It extracts channel IDs, performs a bounded non-blocking enqueue, and lets the coordinator filter to known drives, apply a sync timeout, and emit lifecycle events. The frontend listens for completed sync events and refreshes the active drive view from the local projection without calling SyncChannel again from the live event path.


