### PR TITLE
Add file sorting and custom playback speed

### DIFF
--- a/frontend/src/modules/file-list.ts
+++ b/frontend/src/modules/file-list.ts
@@ -376,32 +376,40 @@ function activateRow(row: HTMLElement) {
     window.initDownload(Number(row.dataset.id), row.dataset.name, Number(row.dataset.size || 0));
 }
 
-function fillVisibleFolderSizes(folders: any[], parentId: string, folderEpoch: number, list: HTMLElement) {
+function fillVisibleFolderSizes(folders: any[], parentId: string, folderEpoch: number) {
     if (!folders.length) return;
     calculateVisibleFolderBytes(parentId)
         .then((sizes) => {
             if (state.folderSizeEpoch !== folderEpoch) return;
             if (state.currentFolderId !== parentId) return;
-            for (const folder of folders) {
-                const id = String(folder?.id || "");
-                if (!id) continue;
-                const row = list.querySelector(`.folder-row[data-id="${CSS.escape(id)}"]`);
-                const sizeEl = row?.querySelector(".folder-size");
-                if (!sizeEl) continue;
-                sizeEl.textContent = formatBytes(sizes.get(id) ?? 0);
-            }
+            applyFolderSizeLabels(folders, (id) => formatBytes(sizes.get(id) ?? 0));
         })
         .catch(() => {
             if (state.folderSizeEpoch !== folderEpoch) return;
             if (state.currentFolderId !== parentId) return;
-            for (const folder of folders) {
-                const id = String(folder?.id || "");
-                if (!id) continue;
-                const row = list.querySelector(`.folder-row[data-id="${CSS.escape(id)}"]`);
-                const sizeEl = row?.querySelector(".folder-size");
-                if (sizeEl) sizeEl.textContent = "—";
-            }
+            applyFolderSizeLabels(folders, () => "—");
         });
+}
+
+function applyFolderSizeLabels(folders: any[], labelForID: (id: string) => string) {
+    const folderIDs = new Set(
+        folders
+            .map((folder) => String(folder?.id || ""))
+            .filter(Boolean),
+    );
+    if (!folderIDs.size) return;
+
+    updateFileListRows((rows) => {
+        let changed = false;
+        const nextRows = rows.map((row) => {
+            if (row.kind !== "folder" || !folderIDs.has(row.id)) return row;
+            const sizeLabel = labelForID(row.id);
+            if (row.sizeLabel === sizeLabel) return row;
+            changed = true;
+            return { ...row, sizeLabel };
+        });
+        return changed ? nextRows : rows;
+    });
 }
 
 export function refreshFiles() {
@@ -560,7 +568,7 @@ export function refreshFiles() {
                 if (state.currentFolderId !== requestedFolderId) return;
 
                 syncDriveRowTabStops(list);
-                fillVisibleFolderSizes(folders, requestedFolderId, folderEpoch, list);
+                fillVisibleFolderSizes(folders, requestedFolderId, folderEpoch);
 
                 // Restore prior scroll on a same-folder re-render. Before
                 // pendingFocus so a just-uploaded/renamed file can still scroll

--- a/frontend/src/modules/modals/video.ts
+++ b/frontend/src/modules/modals/video.ts
@@ -27,6 +27,8 @@ const LOADING_DEBOUNCE_MS = 250;
 const SEEK_STEP_SECONDS = 10;
 const VOLUME_STEP = 0.05;
 const RATE_OPTIONS = [0.5, 0.75, 1, 1.25, 1.5, 2];
+const MIN_PLAYBACK_RATE = 0.25;
+const MAX_PLAYBACK_RATE = 4;
 const THUMBNAIL_BUCKET_SECONDS = 10;
 const THUMBNAIL_LONG_BUCKET_SECONDS = 20;
 const THUMBNAIL_VERY_LONG_BUCKET_SECONDS = 30;
@@ -190,7 +192,7 @@ class HtmlVideoAdapter implements PlayerAdapter {
     }
 
     setSpeed(value: number) {
-        this.video.playbackRate = clamp(value, 0.25, 4);
+        this.video.playbackRate = clampPlaybackRate(value);
         this.emit();
     }
 
@@ -298,7 +300,7 @@ class NativeMpvAdapter implements PlayerAdapter {
     }
 
     setSpeed(value: number) {
-        const next = clamp(value, 0.25, 4);
+        const next = clampPlaybackRate(value);
         this.scheduleLatestCommand("speed", ["set", "speed", String(next)]);
         this.updateFallbackState((state) => ({ ...state, rate: next }));
     }
@@ -1051,13 +1053,17 @@ function previewVolume(value: number) {
 }
 
 function syncSpeed(state: PlayerState) {
+    const customInput = byID<HTMLInputElement>("video-speed-custom-input");
     if (speedBtnEl) {
         speedBtnEl.textContent = `${formatRate(state.rate)}x`;
         speedBtnEl.title = isNativeFallbackActive() ? "Playback speed (click to cycle)" : "Playback speed";
         speedBtnEl.setAttribute("aria-label", speedBtnEl.title);
     }
+    if (customInput && document.activeElement !== customInput) {
+        customInput.value = formatRate(state.rate);
+    }
     speedMenuEl?.querySelectorAll<HTMLButtonElement>("[data-rate]").forEach((button) => {
-        const selected = Number(button.dataset.rate || 1) === state.rate;
+        const selected = Math.abs(Number(button.dataset.rate || 1) - state.rate) < 0.001;
         button.classList.toggle("is-selected", selected);
         button.setAttribute("aria-checked", selected ? "true" : "false");
     });
@@ -1069,6 +1075,16 @@ function nextPlaybackRate(currentRate: number) {
     if (currentIndex >= 0) return RATE_OPTIONS[(currentIndex + 1) % RATE_OPTIONS.length];
     const nextHigher = RATE_OPTIONS.find((rate) => rate > current);
     return nextHigher ?? RATE_OPTIONS[0];
+}
+
+function clampPlaybackRate(value: number) {
+    return clamp(Number.isFinite(value) ? value : 1, MIN_PLAYBACK_RATE, MAX_PLAYBACK_RATE);
+}
+
+function parseCustomPlaybackRate(value: string) {
+    const rate = Number(value.trim());
+    if (!Number.isFinite(rate) || rate <= 0) return null;
+    return clampPlaybackRate(rate);
 }
 
 function cycleFallbackPlaybackRate() {
@@ -1915,8 +1931,31 @@ function bindSpeedMenu() {
         closeSpeedMenu(true);
         revealChrome();
     });
+    speedMenuEl?.addEventListener("submit", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!activeAdapter) return;
+        const input = byID<HTMLInputElement>("video-speed-custom-input");
+        const rate = input ? parseCustomPlaybackRate(input.value) : null;
+        if (rate == null) {
+            input?.focus({ preventScroll: true });
+            return;
+        }
+        activeAdapter.setSpeed(rate);
+        closeSpeedMenu(true);
+        revealChrome();
+    });
     speedMenuEl?.addEventListener("keydown", (event) => {
         if (!isSpeedMenuOpen()) return;
+        const target = event.target as HTMLElement | null;
+        if (target?.closest(".video-speed-custom")) {
+            if (event.key === "Escape") {
+                event.preventDefault();
+                event.stopPropagation();
+                closeSpeedMenu(true);
+            }
+            return;
+        }
         if (event.key === "Escape") {
             event.preventDefault();
             event.stopPropagation();
@@ -2045,9 +2084,16 @@ function bindControls() {
 
 function renderSpeedOptions() {
     if (!speedMenuEl) return;
-    speedMenuEl.innerHTML = RATE_OPTIONS.map((rate) => (
-        `<button type="button" role="menuitemradio" data-rate="${rate}" aria-checked="${rate === 1 ? "true" : "false"}"><span class="video-speed-check" aria-hidden="true">✓</span><span>${formatRate(rate)}x</span></button>`
-    )).join("");
+    const options = RATE_OPTIONS.map(speedOptionMarkup).join("");
+    speedMenuEl.innerHTML = `${options}${customSpeedMarkup()}`;
+}
+
+function speedOptionMarkup(rate: number) {
+    return `<button type="button" role="menuitemradio" data-rate="${rate}" aria-checked="${rate === 1 ? "true" : "false"}"><span class="video-speed-check" aria-hidden="true">✓</span><span>${formatRate(rate)}x</span></button>`;
+}
+
+function customSpeedMarkup() {
+    return `<form class="video-speed-custom" role="none" aria-label="Custom playback speed"><label for="video-speed-custom-input">Custom</label><div class="video-speed-custom-row"><input id="video-speed-custom-input" type="number" inputmode="decimal" min="${MIN_PLAYBACK_RATE}" max="${MAX_PLAYBACK_RATE}" step="0.05" value="1" aria-label="Custom playback speed" /><span aria-hidden="true">x</span><button type="submit">Set</button></div></form>`;
 }
 
 export function setupVideoModal() {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -951,6 +951,48 @@ header {
 }
 .col-name { padding-left: 10px; }
 
+.file-sort-button {
+    width: max-content;
+    max-width: 100%;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 26px;
+    margin: -4px 0;
+    padding: 4px 8px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    cursor: pointer;
+    transition:
+        background-color var(--motion-fast) var(--ease-standard),
+        color var(--motion-fast) var(--ease-standard);
+}
+
+.file-sort-button:hover,
+.file-sort-button.active {
+    color: var(--text-main);
+    background: var(--overlay-white-1);
+}
+
+.file-sort-button:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+.file-sort-indicator {
+    width: 10px;
+    display: inline-flex;
+    justify-content: center;
+    color: var(--accent);
+    font-size: 0.72rem;
+    line-height: 1;
+}
+
 .file-list-box {
     flex: 1;
     overflow-y: auto;
@@ -3572,7 +3614,7 @@ header {
     bottom: calc(100% + 10px);
     z-index: 3;
     display: none;
-    min-width: 92px;
+    min-width: 196px;
     padding: 6px;
     border-radius: 10px;
     background: rgba(11, 14, 24, 0.96);
@@ -3624,6 +3666,110 @@ header {
 
 .video-speed-menu button.is-selected .video-speed-check {
     opacity: 1;
+}
+
+.video-speed-custom {
+    margin-top: 5px;
+    padding: 8px 6px 4px;
+    border-top: 1px solid rgba(255, 255, 255, 0.10);
+}
+
+.video-speed-custom label {
+    display: block;
+    margin: 0 0 7px;
+    color: rgba(255, 255, 255, 0.58);
+    font-size: 11px;
+    font-weight: 800;
+    line-height: 1;
+}
+
+.video-speed-custom-row {
+    display: grid;
+    grid-template-columns: minmax(78px, 1fr) 12px 54px;
+    align-items: center;
+    gap: 8px;
+}
+
+.video-speed-custom input {
+    box-sizing: border-box;
+    /* Cancel the global `input { margin-bottom: 15px }` reset; inside this
+       align-items:center grid that stray margin shifts the field up ~7px and
+       drops the Set button off its baseline. */
+    margin: 0;
+    width: 100%;
+    min-width: 0;
+    height: 36px;
+    padding: 0 10px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.06);
+    color: #fff;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 36px;
+    text-align: center;
+    outline: none;
+    /* Hide the native number spinner; it renders as a cramped, off-theme
+       stepper box. Keyboard ArrowUp/ArrowDown still step the value. */
+    appearance: textfield;
+    -moz-appearance: textfield;
+}
+
+.video-speed-custom input::-webkit-inner-spin-button,
+.video-speed-custom input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
+}
+
+.video-speed-custom input:focus {
+    border-color: var(--video-accent-border);
+    box-shadow: 0 0 0 2px var(--video-accent-ring);
+}
+
+.video-speed-custom-row > span {
+    justify-self: center;
+    color: rgba(255, 255, 255, 0.68);
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+}
+
+.video-speed-custom button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    grid-template-columns: none;
+    width: 54px;
+    min-width: 54px;
+    height: 36px;
+    padding: 0;
+    text-align: center;
+    color: #fff;
+    background: var(--video-accent);
+    border-radius: 7px;
+    font-size: 12px;
+    font-weight: 800;
+    line-height: 1;
+    transition: filter 0.12s ease, transform 0.12s ease;
+}
+
+/* Own hover/focus/active so the faint generic menu-button hover can't wash
+   the primary "Set" action back out. */
+.video-speed-custom button:hover,
+.video-speed-custom button:focus-visible {
+    background: var(--video-accent);
+    color: #fff;
+    filter: brightness(1.12);
+    outline: none;
+}
+
+.video-speed-custom button:focus-visible {
+    box-shadow: 0 0 0 2px var(--video-accent-ring);
+}
+
+.video-speed-custom button:active {
+    transform: translateY(0.5px) scale(0.98);
 }
 
 .video-loading {

--- a/frontend/src/ui/AppShell.svelte
+++ b/frontend/src/ui/AppShell.svelte
@@ -1,10 +1,24 @@
 <script lang="ts">
+    import { setFileSortKey, fileSortState } from './file-list/file-sort-store';
+    import type { FileSortKey } from './file-list/file-sort';
+
     function refreshFiles(): void {
         void window.triggerRefresh?.();
     }
 
     function openFolderModal(): void {
         window.openNewFolderModal?.();
+    }
+
+    function sortButtonLabel(key: FileSortKey): string {
+        const active = $fileSortState.key === key;
+        if (!active) return `Sort by ${key}`;
+        return `Sort by ${key} ${$fileSortState.direction === 'asc' ? 'descending' : 'ascending'}`;
+    }
+
+    function sortIndicator(key: FileSortKey): string {
+        if ($fileSortState.key !== key) return '';
+        return $fileSortState.direction === 'asc' ? '↑' : '↓';
     }
 </script>
 
@@ -82,9 +96,39 @@
         </div>
 
         <div class="file-table-header">
-            <span class="col-name">Name</span>
-            <span class="col-date">Date</span>
-            <span class="col-size">Size</span>
+            <button
+                class:active={$fileSortState.key === 'name'}
+                class="file-sort-button col-name"
+                type="button"
+                aria-label={sortButtonLabel('name')}
+                aria-pressed={$fileSortState.key === 'name'}
+                onclick={() => setFileSortKey('name')}
+            >
+                <span>Name</span>
+                <span class="file-sort-indicator" aria-hidden="true">{sortIndicator('name')}</span>
+            </button>
+            <button
+                class:active={$fileSortState.key === 'date'}
+                class="file-sort-button col-date"
+                type="button"
+                aria-label={sortButtonLabel('date')}
+                aria-pressed={$fileSortState.key === 'date'}
+                onclick={() => setFileSortKey('date')}
+            >
+                <span>Date</span>
+                <span class="file-sort-indicator" aria-hidden="true">{sortIndicator('date')}</span>
+            </button>
+            <button
+                class:active={$fileSortState.key === 'size'}
+                class="file-sort-button col-size"
+                type="button"
+                aria-label={sortButtonLabel('size')}
+                aria-pressed={$fileSortState.key === 'size'}
+                onclick={() => setFileSortKey('size')}
+            >
+                <span>Size</span>
+                <span class="file-sort-indicator" aria-hidden="true">{sortIndicator('size')}</span>
+            </button>
             <span class="col-actions">Actions</span>
             <div id="selection-bar" class="selection-bar" style="display: none;" role="status" aria-live="polite"></div>
         </div>

--- a/frontend/src/ui/app-shell.dom.test.ts
+++ b/frontend/src/ui/app-shell.dom.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import AppShell from './AppShell.svelte';
+import { resetFileSortState } from './file-list/file-sort-store';
 
 let app: Record<string, unknown> | null = null;
 let host: HTMLElement | null = null;
@@ -20,6 +21,7 @@ function click(selector: string): void {
 }
 
 afterEach(async () => {
+    resetFileSortState();
     delete (window as unknown as { triggerRefresh?: unknown }).triggerRefresh;
     delete (window as unknown as { openNewFolderModal?: unknown }).openNewFolderModal;
     if (app) await unmount(app);
@@ -65,5 +67,21 @@ describe('AppShell behavior', () => {
         const selectionBar = host?.querySelector('#selection-bar');
         expect(selectionBar).not.toBeNull();
         expect(selectionBar?.children).toHaveLength(0);
+    });
+
+    it('toggles file-list sort headers accessibly', () => {
+        setup();
+
+        click('.file-sort-button.col-name');
+        let name = host?.querySelector<HTMLButtonElement>('.file-sort-button.col-name');
+        expect(name?.classList.contains('active')).toBe(true);
+        expect(name?.getAttribute('aria-pressed')).toBe('true');
+        expect(name?.getAttribute('aria-label')).toContain('descending');
+        expect(name?.textContent).toContain('↑');
+
+        click('.file-sort-button.col-name');
+        name = host?.querySelector<HTMLButtonElement>('.file-sort-button.col-name');
+        expect(name?.getAttribute('aria-label')).toContain('ascending');
+        expect(name?.textContent).toContain('↓');
     });
 });

--- a/frontend/src/ui/file-list/FileList.svelte
+++ b/frontend/src/ui/file-list/FileList.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import FileState from './FileState.svelte';
+    import { sortFileListRows } from './file-sort';
     import { fileListView } from './file-list-store';
+    import { fileSortState } from './file-sort-store';
     import { activeFileRowKey, selectedFileRowKeys } from './row-state-store';
     import type { FileListAction, FileListFileRow, FileListRow, FolderListRow } from './types';
 
@@ -28,6 +30,10 @@
     // the row makes Svelte's a11y contract explicit without adding per-row
     // behavior or fighting the existing roving-focus controller.
     function onDelegatedKeydown() {}
+
+    const visibleRows = $derived($fileListView.kind === 'rows'
+        ? sortFileListRows($fileListView.rows, $fileSortState)
+        : []);
 </script>
 
 {#if $fileListView.kind === 'state'}
@@ -39,7 +45,7 @@
         onAction={$fileListView.onAction}
     />
 {:else}
-    {#each $fileListView.rows as row (row.key)}
+    {#each visibleRows as row (row.key)}
         {#if row.kind === 'pending-folder'}
             <div
                 class="file-row drive-row folder-row pending-folder"

--- a/frontend/src/ui/file-list/file-list.dom.test.ts
+++ b/frontend/src/ui/file-list/file-list.dom.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, unmount } from 'svelte';
 import FileList from './FileList.svelte';
 import { showFileListRows, showFileListState, updateFileListRows } from './file-list-store';
+import { resetFileSortState, setFileSortKey } from './file-sort-store';
 import { setActiveFileRowKey, setSelectedFileRowKeys } from './row-state-store';
 import type { FileListFileRow } from './types';
 
@@ -47,6 +48,7 @@ function row(): HTMLElement {
 }
 
 afterEach(async () => {
+    resetFileSortState();
     showFileListState({
         stateKind: 'loading',
         title: 'Loading files',
@@ -120,5 +122,22 @@ describe('FileList DOM behavior', () => {
 
         expect(onRowClick).toHaveBeenCalledTimes(1);
         expect(onDownload).toHaveBeenCalledTimes(1);
+    });
+
+    it('reorders keyed rows when the sort state changes', () => {
+        setup();
+        showFileListRows([
+            makeFileRow({ id: '2', key: 'file:2', selectionKey: 'file:2', name: 'beta.mp4', baseName: 'beta', uploadTime: 10 }),
+            makeFileRow({ id: '1', key: 'file:1', selectionKey: 'file:1', name: 'alpha.mp4', baseName: 'alpha', uploadTime: 20 }),
+        ]);
+        setSelectedFileRowKeys(['file:2']);
+        flushSync();
+
+        setFileSortKey('name');
+        flushSync();
+
+        const rows = Array.from(host?.querySelectorAll<HTMLElement>('.drive-row') ?? []);
+        expect(rows.map((item) => item.dataset.rowKey)).toEqual(['file:1', 'file:2']);
+        expect(rows[1].classList.contains('is-selected')).toBe(true);
     });
 });

--- a/frontend/src/ui/file-list/file-sort-store.ts
+++ b/frontend/src/ui/file-list/file-sort-store.ts
@@ -1,0 +1,49 @@
+import { writable } from 'svelte/store';
+import {
+    DEFAULT_FILE_SORT,
+    nextFileSortState,
+    type FileSortKey,
+    type FileSortState,
+} from './file-sort';
+
+const STORAGE_KEY = 'tdrive.fileListSort';
+
+function readInitialSort(): FileSortState {
+    if (typeof window === 'undefined') return DEFAULT_FILE_SORT;
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return DEFAULT_FILE_SORT;
+        const parsed = JSON.parse(raw) as Partial<FileSortState>;
+        if (!isSortState(parsed)) return DEFAULT_FILE_SORT;
+        return parsed;
+    } catch {
+        return DEFAULT_FILE_SORT;
+    }
+}
+
+export const fileSortState = writable<FileSortState>(readInitialSort());
+
+if (typeof window !== 'undefined') {
+    fileSortState.subscribe((state) => {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+        } catch {
+            // Sorting is still usable without persistence.
+        }
+    });
+}
+
+export function setFileSortKey(key: FileSortKey): void {
+    fileSortState.update((current) => nextFileSortState(current, key));
+}
+
+export function resetFileSortState(): void {
+    fileSortState.set(DEFAULT_FILE_SORT);
+}
+
+function isSortState(value: Partial<FileSortState>): value is FileSortState {
+    return (
+        (value.key === 'name' || value.key === 'date' || value.key === 'size') &&
+        (value.direction === 'asc' || value.direction === 'desc')
+    );
+}

--- a/frontend/src/ui/file-list/file-sort.test.ts
+++ b/frontend/src/ui/file-list/file-sort.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { nextFileSortState, sortFileListRows, type FileSortState } from './file-sort';
+import type { FileListFileRow, FolderListRow, PendingFolderListRow } from './types';
+
+function file(overrides: Partial<FileListFileRow>): FileListFileRow {
+    const name = overrides.name ?? 'file.txt';
+    return {
+        kind: 'file',
+        key: `file:${overrides.id ?? name}`,
+        selectionKey: `file:${overrides.id ?? name}`,
+        id: String(overrides.id ?? name),
+        name,
+        baseName: name.replace(/\.[^.]+$/, ''),
+        ext: 'TXT',
+        source: 'fs',
+        parentId: '',
+        metaLabel: '',
+        sizeLabel: '',
+        ariaLabel: `File: ${name}`,
+        size: 0,
+        uploadTime: 0,
+        uploaderID: 0,
+        encrypted: false,
+        canDelete: true,
+        canRename: true,
+        actions: [],
+        ...overrides,
+    };
+}
+
+function folder(id: string, name: string): FolderListRow {
+    return {
+        kind: 'folder',
+        key: `folder:${id}`,
+        selectionKey: `folder:${id}`,
+        id,
+        name,
+        parentId: '',
+        metaLabel: '—',
+        sizeLabel: '…',
+        ariaLabel: `Folder: ${name}`,
+        actions: [],
+    };
+}
+
+function pending(tempId: string, name: string): PendingFolderListRow {
+    return { kind: 'pending-folder', key: `pending:${tempId}`, tempId, name };
+}
+
+function keysFor(state: FileSortState) {
+    return sortFileListRows([
+        file({ id: 'small-old', name: 'beta.mp4', size: 10, uploadTime: 100 }),
+        folder('z', 'Zoo'),
+        file({ id: 'large-new', name: 'alpha.mp4', size: 90, uploadTime: 300 }),
+        pending('1', 'Creating'),
+        folder('a', 'Archive'),
+        file({ id: 'mid', name: 'gamma.mp4', size: 50, uploadTime: 200 }),
+    ], state).map((row) => row.key);
+}
+
+describe('file list sorting', () => {
+    it('keeps pending rows first and folders pinned above files', () => {
+        expect(keysFor({ key: 'date', direction: 'desc' })).toEqual([
+            'pending:1',
+            'folder:a',
+            'folder:z',
+            'file:large-new',
+            'file:mid',
+            'file:small-old',
+        ]);
+    });
+
+    it('sorts files by name in either direction', () => {
+        expect(keysFor({ key: 'name', direction: 'asc' }).slice(3)).toEqual([
+            'file:large-new',
+            'file:small-old',
+            'file:mid',
+        ]);
+        expect(keysFor({ key: 'name', direction: 'desc' }).slice(3)).toEqual([
+            'file:mid',
+            'file:small-old',
+            'file:large-new',
+        ]);
+    });
+
+    it('sorts files by size using deterministic name tie-breaks', () => {
+        const rows = sortFileListRows([
+            file({ id: 'a', name: 'alpha.mp4', size: 10, uploadTime: 1 }),
+            file({ id: 'b', name: 'beta.mp4', size: 10, uploadTime: 2 }),
+            file({ id: 'c', name: 'charlie.mp4', size: 20, uploadTime: 3 }),
+        ], { key: 'size', direction: 'desc' });
+
+        expect(rows.map((row) => row.key)).toEqual(['file:c', 'file:a', 'file:b']);
+    });
+
+    it('toggles an active column and applies sensible defaults for new columns', () => {
+        expect(nextFileSortState({ key: 'date', direction: 'desc' }, 'date')).toEqual({ key: 'date', direction: 'asc' });
+        expect(nextFileSortState({ key: 'date', direction: 'asc' }, 'name')).toEqual({ key: 'name', direction: 'asc' });
+        expect(nextFileSortState({ key: 'name', direction: 'asc' }, 'size')).toEqual({ key: 'size', direction: 'desc' });
+    });
+});

--- a/frontend/src/ui/file-list/file-sort.ts
+++ b/frontend/src/ui/file-list/file-sort.ts
@@ -1,0 +1,92 @@
+import type { FileListFileRow, FileListRow, FolderListRow, PendingFolderListRow } from './types';
+
+export type FileSortKey = 'name' | 'date' | 'size';
+export type FileSortDirection = 'asc' | 'desc';
+
+export type FileSortState = {
+    key: FileSortKey;
+    direction: FileSortDirection;
+};
+
+export const DEFAULT_FILE_SORT: FileSortState = Object.freeze({
+    key: 'date',
+    direction: 'desc',
+});
+
+const DEFAULT_DIRECTIONS: Record<FileSortKey, FileSortDirection> = {
+    name: 'asc',
+    date: 'desc',
+    size: 'desc',
+};
+
+const collator = new Intl.Collator(undefined, {
+    numeric: true,
+    sensitivity: 'base',
+});
+
+export function nextFileSortState(current: FileSortState, key: FileSortKey): FileSortState {
+    if (current.key === key) {
+        return {
+            key,
+            direction: current.direction === 'asc' ? 'desc' : 'asc',
+        };
+    }
+    return { key, direction: DEFAULT_DIRECTIONS[key] };
+}
+
+export function sortFileListRows(rows: readonly FileListRow[], sort: FileSortState): FileListRow[] {
+    const pending: PendingFolderListRow[] = [];
+    const folders: FolderListRow[] = [];
+    const files: FileListFileRow[] = [];
+
+    for (const row of rows) {
+        if (row.kind === 'pending-folder') pending.push(row);
+        else if (row.kind === 'folder') folders.push(row);
+        else files.push(row);
+    }
+
+    const folderDirection = sort.key === 'name' ? sort.direction : 'asc';
+    return [
+        ...pending,
+        ...folders.sort((a, b) => compareDirection(compareName(a, b), folderDirection)),
+        ...files.sort((a, b) => compareFiles(a, b, sort)),
+    ];
+}
+
+function compareFiles(a: FileListFileRow, b: FileListFileRow, sort: FileSortState): number {
+    const primary = compareFilePrimary(a, b, sort.key);
+    if (primary !== 0) return compareDirection(primary, sort.direction);
+    return compareFileTieBreak(a, b);
+}
+
+function compareFilePrimary(a: FileListFileRow, b: FileListFileRow, key: FileSortKey): number {
+    switch (key) {
+        case 'date':
+            return compareNumber(a.uploadTime, b.uploadTime);
+        case 'size':
+            return compareNumber(a.size, b.size);
+        case 'name':
+        default:
+            return compareName(a, b);
+    }
+}
+
+function compareFileTieBreak(a: FileListFileRow, b: FileListFileRow): number {
+    const name = compareName(a, b);
+    if (name !== 0) return name;
+    return collator.compare(a.key, b.key);
+}
+
+function compareName(a: Pick<FileListRow, 'name'>, b: Pick<FileListRow, 'name'>): number {
+    return collator.compare(a.name || '', b.name || '');
+}
+
+function compareNumber(a: number, b: number): number {
+    const left = Number.isFinite(a) ? a : 0;
+    const right = Number.isFinite(b) ? b : 0;
+    return left - right;
+}
+
+function compareDirection(value: number, direction: FileSortDirection): number {
+    return direction === 'asc' ? value : -value;
+}


### PR DESCRIPTION
This adds first-class sorting to the drive list without moving the work back into imperative DOM code. The table headers now sort by name, date, and size, persist the preference locally, keep pending folder rows at the top, and keep folders pinned above files. The ordering lives in the keyed Svelte list layer, so normal folders and search results share the same behavior while row identity, selection, focus, and async folder-size updates stay stable.

Folder-size hydration now updates the file-list row state instead of mutating size cells directly, which prevents Svelte re-renders from wiping late folder-size values. The new sort helper is isolated and covered with unit tests for folder pinning, pending rows, numeric name ordering, size/date ordering, and toggle behavior.

This also adds a custom playback-speed control to the existing video speed menu. Presets still work as before, and custom values are clamped through the same 0.25x-4x adapter boundary used by webview and native playback.


