### PR TITLE
Stabilize markdown viewer CI test

### DIFF
--- a/frontend/src/ui/viewers/file-viewer-modal.dom.test.ts
+++ b/frontend/src/ui/viewers/file-viewer-modal.dom.test.ts
@@ -24,10 +24,12 @@ async function settle(): Promise<void> {
 }
 
 async function waitForElement<T extends Element>(selector: string): Promise<T> {
-    for (let i = 0; i < 20; i += 1) {
+    const deadline = Date.now() + 3_000;
+    while (Date.now() < deadline) {
         await settle();
         const element = host.querySelector<T>(selector);
         if (element) return element;
+        await new Promise((resolve) => { setTimeout(resolve, 25); });
     }
     throw new Error(`Expected ${selector} to render. DOM: ${host.innerHTML}`);
 }


### PR DESCRIPTION
This stabilizes the markdown file-viewer DOM test that started failing on `master` after the lazy structured-viewer split. The product code is fine; the test was polling for a fixed small number of Svelte/microtask turns and could time out on GitHub's slower runner while the dynamically imported markdown renderer was still resolving.

The helper now waits against a short real deadline and polls the DOM between render settles. That keeps the assertion meaningful — the rendered markdown heading still has to appear — while removing the CI-only race.


