### PR TITLE
feat: add adaptive multi-theme appearance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/bin
 node_modules
 frontend/dist
+frontend/coverage
 
 # --- Security ---
 .env

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -4,7 +4,7 @@ import svelte from "eslint-plugin-svelte";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-    { ignores: ["dist/", "wailsjs/", "node_modules/"] },
+    { ignores: ["coverage/", "dist/", "wailsjs/", "node_modules/"] },
     js.configs.recommended,
     ...tseslint.configs.recommended,
     ...svelte.configs["flat/recommended"],

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <meta name="color-scheme" content="light dark"/>
+    <meta name="color-scheme" content="dark light"/>
     <title>TDrive</title>
     <script>
         // Resolve the saved palette before CSS is parsed. The typed theme
@@ -14,30 +14,31 @@
             const lightThemes = ['tdrive-light', 'catppuccin-latte', 'solarized-light', 'gruvbox-light'];
             const darkThemes = ['tokyo-night', 'catppuccin-mocha', 'dracula', 'solarized-dark', 'gruvbox-dark', 'nord'];
             const fallback = {
-                mode: 'system',
+                mode: 'dark',
                 lightThemeId: 'tdrive-light',
                 darkThemeId: 'tokyo-night',
             };
+            let saved = fallback;
 
             try {
-                const saved = JSON.parse(localStorage.getItem('tdrive.appearance.v1') || 'null') || fallback;
-                const mode = ['system', 'light', 'dark'].includes(saved.mode) ? saved.mode : fallback.mode;
-                const lightThemeId = lightThemes.includes(saved.lightThemeId)
-                    ? saved.lightThemeId
-                    : fallback.lightThemeId;
-                const darkThemeId = darkThemes.includes(saved.darkThemeId)
-                    ? saved.darkThemeId
-                    : fallback.darkThemeId;
-                const appearance = mode === 'system'
-                    ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-                    : mode;
-
-                document.documentElement.dataset.theme = appearance === 'dark' ? darkThemeId : lightThemeId;
-                document.documentElement.dataset.themeAppearance = appearance;
+                saved = JSON.parse(localStorage.getItem('tdrive.appearance.v1') || 'null') || fallback;
             } catch {
-                // Storage can be unavailable in hardened webviews. CSS retains
-                // a system-aware no-JavaScript fallback in that case.
+                // Storage can be unavailable in hardened webviews. The dark
+                // fallback below still guarantees a deterministic first paint.
             }
+
+            // Legacy System preferences intentionally migrate to dark while
+            // retaining the user's previously selected dark palette.
+            const mode = ['light', 'dark'].includes(saved.mode) ? saved.mode : fallback.mode;
+            const lightThemeId = lightThemes.includes(saved.lightThemeId)
+                ? saved.lightThemeId
+                : fallback.lightThemeId;
+            const darkThemeId = darkThemes.includes(saved.darkThemeId)
+                ? saved.darkThemeId
+                : fallback.darkThemeId;
+
+            document.documentElement.dataset.theme = mode === 'dark' ? darkThemeId : lightThemeId;
+            document.documentElement.dataset.themeAppearance = mode;
         })();
     </script>
     <link rel="stylesheet" href="/src/style.css">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,43 @@
 <head>
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+    <meta name="color-scheme" content="light dark"/>
     <title>TDrive</title>
+    <script>
+        // Resolve the saved palette before CSS is parsed. The typed theme
+        // controller validates the same value during boot; this tiny preflight
+        // exists solely to prevent a bright/dark flash between native window
+        // creation and the Svelte application starting.
+        (() => {
+            const lightThemes = ['tdrive-light', 'catppuccin-latte', 'solarized-light', 'gruvbox-light'];
+            const darkThemes = ['tokyo-night', 'catppuccin-mocha', 'dracula', 'solarized-dark', 'gruvbox-dark', 'nord'];
+            const fallback = {
+                mode: 'system',
+                lightThemeId: 'tdrive-light',
+                darkThemeId: 'tokyo-night',
+            };
+
+            try {
+                const saved = JSON.parse(localStorage.getItem('tdrive.appearance.v1') || 'null') || fallback;
+                const mode = ['system', 'light', 'dark'].includes(saved.mode) ? saved.mode : fallback.mode;
+                const lightThemeId = lightThemes.includes(saved.lightThemeId)
+                    ? saved.lightThemeId
+                    : fallback.lightThemeId;
+                const darkThemeId = darkThemes.includes(saved.darkThemeId)
+                    ? saved.darkThemeId
+                    : fallback.darkThemeId;
+                const appearance = mode === 'system'
+                    ? (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                    : mode;
+
+                document.documentElement.dataset.theme = appearance === 'dark' ? darkThemeId : lightThemeId;
+                document.documentElement.dataset.themeAppearance = appearance;
+            } catch {
+                // Storage can be unavailable in hardened webviews. CSS retains
+                // a system-aware no-JavaScript fallback in that case.
+            }
+        })();
+    </script>
     <link rel="stylesheet" href="/src/style.css">
 </head>
 <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "^9.13.0",
         "@lucide/svelte": "^1.34.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^9.13.0",
         "eslint-plugin-svelte": "^3.19.0",
         "globals": "^15.11.0",
@@ -27,6 +28,66 @@
         "typescript-eslint": "^8.11.0",
         "vite": "^8.1.0",
         "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1328,6 +1389,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
@@ -1521,6 +1613,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2198,6 +2302,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2274,6 +2385,52 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.3.1",
@@ -2690,6 +2847,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-it": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,12 +8,14 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit && svelte-check --tsconfig ./tsconfig.json",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
     "@lucide/svelte": "^1.34.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^9.13.0",
     "eslint-plugin-svelte": "^3.19.0",
     "globals": "^15.11.0",

--- a/frontend/package.json.md5
+++ b/frontend/package.json.md5
@@ -1,1 +1,1 @@
-ad04b7ea18606f53dc188163a0ca019e
+6afab6a473b3cbb8ff1ff5e50c984efd

--- a/frontend/src/main.dom.test.ts
+++ b/frontend/src/main.dom.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const themeLifecycle = vi.hoisted(() => ({
+    disconnect: vi.fn(),
+    initialize: vi.fn(),
+}));
+
+vi.mock('./ui/theme/theme-controller', () => ({
+    initializeTheme: themeLifecycle.initialize,
+}));
+
+vi.mock('./ui/theme/native-theme', () => ({
+    initializeNativeTheme: vi.fn(async () => vi.fn()),
+}));
+
+beforeEach(() => {
+    vi.resetModules();
+    themeLifecycle.disconnect.mockReset();
+    themeLifecycle.initialize.mockReset();
+    themeLifecycle.initialize.mockReturnValue(themeLifecycle.disconnect);
+});
+
+afterEach(() => {
+    window.onload = null;
+});
+
+describe('application appearance lifecycle', () => {
+    it('releases the theme controller once during beforeunload', async () => {
+        await import('./main');
+
+        expect(themeLifecycle.initialize).toHaveBeenCalledOnce();
+
+        window.dispatchEvent(new Event('beforeunload'));
+        window.dispatchEvent(new Event('beforeunload'));
+
+        expect(themeLifecycle.disconnect).toHaveBeenCalledOnce();
+    });
+});

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -14,6 +14,8 @@ import { setupFileListWindowBindings, refreshFiles } from './modules/file-list';
 import { setupGallery } from './modules/gallery';
 import { setupSearchBar, runGlobalSearch } from './modules/search';
 import { setupRefreshShortcut } from './modules/refresh-shortcut';
+import { initializeTheme } from './ui/theme/theme-controller';
+import { initializeNativeTheme } from './ui/theme/native-theme';
 
 // Import modal setup functions
 import { setupDeleteModal, openDeleteModal } from './modules/modals/delete';
@@ -46,6 +48,11 @@ import { setupNotifBell } from './modules/notif-bell';
 
 // Profile menu (top-right avatar dropdown)
 import { setupProfileMenu } from './modules/profile-menu';
+
+// Apply persisted/system appearance before waiting for the native runtime so
+// authentication and startup screens never render in the wrong palette.
+initializeTheme();
+let disconnectNativeTheme = () => {};
 
 // Setup window bindings that need to be available globally
 window.refreshFiles = refreshFiles;
@@ -93,6 +100,7 @@ function waitForWailsRuntime(timeoutMs = 4000): Promise<void> {
 window.onload = async function() {
     console.log("App loaded. Checking Status...");
     await waitForWailsRuntime();
+    disconnectNativeTheme = await initializeNativeTheme();
     setupAppShell();
     hideAllScreens();
 
@@ -152,3 +160,5 @@ window.onload = async function() {
     // Check status and show appropriate screen
     await checkStatusAndShowScreen();
 };
+
+window.addEventListener('beforeunload', () => disconnectNativeTheme(), { once: true });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -51,7 +51,7 @@ import { setupProfileMenu } from './modules/profile-menu';
 
 // Apply persisted/system appearance before waiting for the native runtime so
 // authentication and startup screens never render in the wrong palette.
-initializeTheme();
+const disconnectTheme = initializeTheme();
 let disconnectNativeTheme = () => {};
 
 // Setup window bindings that need to be available globally
@@ -161,4 +161,7 @@ window.onload = async function() {
     await checkStatusAndShowScreen();
 };
 
-window.addEventListener('beforeunload', () => disconnectNativeTheme(), { once: true });
+window.addEventListener('beforeunload', () => {
+    disconnectTheme();
+    disconnectNativeTheme();
+}, { once: true });

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -110,14 +110,14 @@ body { background-color: var(--bg-dark); color: var(--text-main); height: 100vh;
    it. Older WebView2/WebKitGTK builds receive the quieter app-settle fallback
    below, while reduced-motion users always get an immediate palette swap. */
 ::view-transition-old(root) {
-    animation: theme-old-fade 260ms var(--ease-standard) both;
+    animation: theme-old-fade 300ms var(--ease-standard) both;
 }
 ::view-transition-new(root) {
-    animation: theme-new-reveal 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: theme-new-reveal 480ms cubic-bezier(0.16, 1, 0.3, 1) both;
     clip-path: circle(150vmax at var(--theme-origin-x, 50vw) var(--theme-origin-y, 50vh));
 }
 html.theme-transition-fallback #app {
-    animation: theme-app-settle 300ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: theme-app-settle 340ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 @keyframes theme-old-fade {
     to { opacity: 0.84; filter: saturate(0.92); }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -887,7 +887,7 @@ input:focus { border-color: var(--accent); box-shadow: var(--focus-ring); }
 
 .main-content { flex: 1; padding: 0; display: flex; flex-direction: column; background: var(--bg-dark); }
 
-header {
+.main-content > header {
     height: 70px; display: flex; justify-content: space-between; align-items: center;
     padding: 0 30px; border-bottom: 1px solid var(--border);
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1302,6 +1302,33 @@ input:focus { border-color: var(--accent); box-shadow: var(--focus-ring); }
     box-shadow: var(--viewer-shadow);
 }
 
+/* Text, Markdown, and structured-data previews belong to the app workspace,
+   so their shell follows the selected palette. Media/PDF viewers keep the
+   fixed-dark defaults declared by the shared --viewer-* contract. */
+.file-viewer-shell.is-text {
+    --viewer-text: var(--color-text);
+    --viewer-text-muted: var(--color-text-soft);
+    --viewer-text-subtle: var(--color-text-muted);
+    --viewer-surface-0: var(--color-canvas);
+    --viewer-surface-1: var(--color-surface-0);
+    --viewer-surface-2: var(--color-surface-1);
+    --viewer-control-hover: var(--color-surface-2);
+    --viewer-border: var(--color-border);
+    --viewer-border-soft: var(--color-border-soft);
+    --viewer-accent: var(--color-accent);
+    --viewer-on-accent: var(--color-on-accent);
+    --viewer-danger: var(--color-danger);
+    --viewer-on-danger: var(--color-on-danger);
+    --viewer-overlay-1: var(--overlay-white-1);
+    --viewer-overlay-2: var(--overlay-white-2);
+    --viewer-overlay-3: var(--overlay-white-3);
+    --viewer-shadow: var(--shadow-lg);
+    --viewer-focus-ring: var(--focus-ring);
+    --viewer-syntax-key: var(--color-accent);
+    --viewer-syntax-string: var(--color-warning);
+    --viewer-syntax-value: var(--color-success);
+}
+
 .file-viewer-topbar {
     display: flex;
     align-items: center;
@@ -1813,20 +1840,20 @@ input:focus { border-color: var(--accent); box-shadow: var(--focus-ring); }
 .text-viewer-body.is-code .hljs-title,
 .text-viewer-body.is-code .hljs-name,
 .text-viewer-body.is-code .hljs-selector-tag {
-    color: #9db8ff;
+    color: var(--viewer-syntax-key);
 }
 
 .text-viewer-body.is-code .hljs-string,
 .text-viewer-body.is-code .hljs-template-variable,
 .text-viewer-body.is-code .hljs-symbol,
 .text-viewer-body.is-code .hljs-bullet {
-    color: #d4c38a;
+    color: var(--viewer-syntax-string);
 }
 
 .text-viewer-body.is-code .hljs-number,
 .text-viewer-body.is-code .hljs-literal,
 .text-viewer-body.is-code .hljs-boolean {
-    color: #8fd3a8;
+    color: var(--viewer-syntax-value);
 }
 
 .text-viewer-body.is-code .hljs-comment,

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,3 +1,5 @@
+@import './ui/theme/theme-palettes.css';
+
 :root {
     color-scheme: dark;
 
@@ -15,7 +17,9 @@
     --color-accent: #7aa2f7;
     --color-accent-hover: #8fb4ff;
     --color-accent-strong: #5d85e0;
+    --color-on-accent: #16161e;
     --color-danger: #f7768e;
+    --color-on-danger: #16161e;
     --color-warning: #e0af68;
     --color-success: #34c759;
 
@@ -27,6 +31,14 @@
     --overlay-accent-3: rgba(122, 162, 247, 0.32);
     --overlay-danger-1: rgba(247, 118, 142, 0.10);
     --overlay-danger-2: rgba(247, 118, 142, 0.28);
+    --overlay-warning-1: rgba(224, 175, 104, 0.12);
+    --overlay-warning-2: rgba(224, 175, 104, 0.30);
+    --overlay-success-1: rgba(52, 199, 89, 0.12);
+    --overlay-success-2: rgba(52, 199, 89, 0.30);
+    --glass-bg: rgba(36, 40, 59, 0.88);
+    --glass-border: rgba(255, 255, 255, 0.08);
+    --glass-highlight: rgba(255, 255, 255, 0.04);
+    --scrim: rgba(0, 0, 0, 0.55);
 
     --radius-xs: 4px;
     --radius-sm: 6px;
@@ -91,7 +103,39 @@
 
 * { box-sizing: border-box; margin: 0; padding: 0; font-family: 'Nunito', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
 
+html { background: var(--color-canvas); }
 body { background-color: var(--bg-dark); color: var(--text-main); height: 100vh; overflow: hidden; user-select: none; }
+
+/* Theme changes use the browser's snapshot transition when a webview supports
+   it. Older WebView2/WebKitGTK builds receive the quieter app-settle fallback
+   below, while reduced-motion users always get an immediate palette swap. */
+::view-transition-old(root) {
+    animation: theme-old-fade 260ms var(--ease-standard) both;
+}
+::view-transition-new(root) {
+    animation: theme-new-reveal 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    clip-path: circle(150vmax at var(--theme-origin-x, 50vw) var(--theme-origin-y, 50vh));
+}
+html.theme-transition-fallback #app {
+    animation: theme-app-settle 300ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes theme-old-fade {
+    to { opacity: 0.84; filter: saturate(0.92); }
+}
+@keyframes theme-new-reveal {
+    from { clip-path: circle(0 at var(--theme-origin-x, 50vw) var(--theme-origin-y, 50vh)); }
+}
+@keyframes theme-app-settle {
+    from { opacity: 0.82; transform: scale(0.997); filter: saturate(0.9); }
+    to { opacity: 1; transform: scale(1); filter: saturate(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+    ::view-transition-old(root),
+    ::view-transition-new(root),
+    html.theme-transition-fallback #app {
+        animation: none;
+    }
+}
 body.native-video-active { background-color: transparent; }
 body.native-video-active #auth-wrapper,
 body.native-video-active #success-screen,
@@ -131,21 +175,70 @@ body.native-video-active #app > .modal-overlay:not(#video-modal) {
 /* === AUTH SCREENS === */
 #auth-wrapper { display: flex; justify-content: center; align-items: center; height: 100vh; background: var(--bg-dark); }
 
+.auth-appearance-control {
+    position: fixed;
+    top: 18px;
+    right: 18px;
+    z-index: calc(var(--z-popover) + 1);
+}
+.auth-appearance-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    color: var(--color-text-muted);
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 12px;
+    box-shadow: var(--shadow-sm), 0 1px 0 var(--glass-highlight) inset;
+    -webkit-backdrop-filter: blur(18px) saturate(150%);
+    backdrop-filter: blur(18px) saturate(150%);
+    cursor: pointer;
+    transition: color var(--motion-fast) var(--ease-standard),
+        background var(--motion-fast) var(--ease-standard),
+        transform var(--motion-fast) var(--ease-standard);
+}
+.auth-appearance-trigger:hover,
+.auth-appearance-trigger[aria-expanded="true"] {
+    color: var(--color-accent);
+    background: var(--color-surface-2);
+}
+.auth-appearance-trigger:active { transform: scale(0.95); }
+.auth-appearance-trigger:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+.auth-appearance-popover {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: min(390px, calc(100vw - 32px));
+    padding: 6px;
+    overflow: hidden;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 14px;
+    box-shadow: var(--shadow-lg), 0 1px 0 var(--glass-highlight) inset;
+    -webkit-backdrop-filter: blur(28px) saturate(165%);
+    backdrop-filter: blur(28px) saturate(165%);
+    transform-origin: top right;
+    animation: profile-menu-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
 .auth-box {
     background: var(--bg-sidebar); border: 1px solid var(--border);
     padding: 2.5rem; border-radius: 16px; width: 380px; text-align: center;
-    box-shadow: 0 20px 40px rgba(0,0,0,0.4);
+    box-shadow: var(--shadow-md);
 }
 
 .auth-icon-box {
     width: 60px; height: 60px; margin: 0 auto 1.5rem auto;
-    background: rgba(122, 162, 247, 0.1); border-radius: 12px;
+    background: var(--overlay-accent-1); border-radius: 12px;
     display: flex; align-items: center; justify-content: center;
     color: var(--accent);
 }
 .auth-icon-box svg { width: 32px; height: 32px; }
 
-.auth-box h2 { color: white; margin-bottom: 0.5rem; font-weight: 600; }
+.auth-box h2 { color: var(--color-text); margin-bottom: 0.5rem; font-weight: 600; }
 .auth-box p { color: var(--text-muted); margin-bottom: 1.5rem; font-size: 0.9rem; }
 
 .auth-subtitle { margin-bottom: 1rem; }
@@ -163,7 +256,7 @@ body.native-video-active #app > .modal-overlay:not(#video-modal) {
 
 .auth-helper-label {
     font-weight: 600;
-    color: rgba(192, 202, 245, 0.65);
+    color: var(--color-text-muted);
 }
 
 .auth-helper-pill {
@@ -172,7 +265,7 @@ body.native-video-active #app > .modal-overlay:not(#video-modal) {
     max-width: 230px;
     padding: 6px 10px;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.04);
+    background: var(--overlay-white-1);
     border: 1px solid var(--border);
     color: var(--text-main);
     font-weight: 600;
@@ -194,27 +287,27 @@ body.native-video-active #app > .modal-overlay:not(#video-modal) {
     transition: background 0.15s ease, color 0.15s ease;
 }
 
-.auth-link:hover { background: rgba(122, 162, 247, 0.12); }
+.auth-link:hover { background: var(--overlay-accent-1); }
 .auth-link:active { transform: translateY(1px); }
 
 .auth-caption {
     text-align: left;
     margin: -2px 0 12px 0;
     font-size: 0.78rem;
-    color: rgba(192, 202, 245, 0.56);
+    color: var(--color-text-muted);
     line-height: 1.35;
 }
 .auth-caption span {
-    color: rgba(192, 202, 245, 0.82);
+    color: var(--color-text-soft);
     font-weight: 500;
 }
 
 input {
     width: 100%; padding: 12px 15px; background: var(--bg-dark); border: 1px solid var(--border);
-    border-radius: 8px; color: white; margin-bottom: 15px; font-size: 0.95rem; outline: none;
+    border-radius: 8px; color: var(--color-text); margin-bottom: 15px; font-size: 0.95rem; outline: none;
     transition: all 0.2s ease;
 }
-input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 247, 0.2); }
+input:focus { border-color: var(--accent); box-shadow: var(--focus-ring); }
 
 .input-with-action {
     position: relative;
@@ -234,7 +327,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     border-radius: 10px;
     border: 1px solid transparent;
     background: transparent;
-    color: rgba(192, 202, 245, 0.55);
+    color: var(--color-text-muted);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -242,9 +335,9 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
 }
 .input-with-action .input-action-btn:hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: var(--overlay-white-1);
     border-color: var(--border);
-    color: rgba(192, 202, 245, 0.82);
+    color: var(--color-text-soft);
 }
 .input-with-action .input-action-btn:active {
     transform: translateY(-50%) scale(0.98);
@@ -262,7 +355,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     width: 100%;
     padding: var(--space-3);
     background: var(--accent);
-    color: var(--color-surface-0);
+    color: var(--color-on-accent);
     font-weight: 700;
     border: none;
     border-radius: var(--radius-md);
@@ -298,7 +391,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 .secondary-btn:hover { background: var(--bg-panel); }
 .secondary-btn:active { transform: translateY(0.5px); }
 
-.danger-btn { background: var(--danger); color: var(--color-surface-0); }
+.danger-btn { background: var(--danger); color: var(--color-on-danger); }
 .danger-btn:hover { filter: brightness(0.95); }
 
 .icon-btn {
@@ -316,7 +409,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     width: 240px; background: var(--bg-sidebar); border-right: 1px solid var(--color-surface-1);
     padding: 20px; display: flex; flex-direction: column;
 }
-.logo { font-size: 1.2rem; font-weight: 800; color: white; margin-bottom: 40px; letter-spacing: -0.5px; }
+.logo { font-size: 1.2rem; font-weight: 800; color: var(--color-text); margin-bottom: 40px; letter-spacing: -0.5px; }
 
 .storage-info { padding-top: 20px; border-top: 1px solid var(--border); }
 .storage-info p { font-size: 0.75rem; color: var(--text-muted); display: flex; justify-content: space-between; }
@@ -349,7 +442,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     transition: all 0.15s ease; text-align: left; width: 100%;
 }
 .drive-item:hover { background: var(--bg-panel); color: var(--text-main); }
-.drive-item.active { background: rgba(122, 162, 247, 0.12); color: var(--accent); }
+.drive-item.active { background: var(--overlay-accent-1); color: var(--accent); }
 .drive-item .icon { width: 18px; height: 18px; flex-shrink: 0; }
 .drive-item-title {
     flex: 1;
@@ -371,7 +464,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     letter-spacing: 0.05em;
     text-transform: uppercase;
     color: var(--accent);
-    border: 1px solid rgba(122, 162, 247, 0.32);
+    border: 1px solid var(--overlay-accent-3);
     border-radius: 999px;
     padding: 2px 6px;
 }
@@ -403,7 +496,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     margin-left: 10px;
     padding: 1px 8px;
     border-radius: 999px;
-    background: rgba(122, 162, 247, 0.10);
+    background: var(--overlay-accent-1);
     color: var(--text-muted);
     font-size: 0.72rem;
     font-weight: 500;
@@ -461,8 +554,8 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     transform: scale(1);
 }
 @keyframes notif-bell-pulse {
-    0%, 100% { box-shadow: 0 0 0 2px var(--bg-dark), 0 0 0 0 rgba(122, 162, 247, 0.45); }
-    50%      { box-shadow: 0 0 0 2px var(--bg-dark), 0 0 0 6px rgba(122, 162, 247, 0); }
+    0%, 100% { box-shadow: 0 0 0 2px var(--bg-dark), 0 0 0 0 color-mix(in srgb, var(--accent) 45%, transparent); }
+    50%      { box-shadow: 0 0 0 2px var(--bg-dark), 0 0 0 6px transparent; }
 }
 
 /* Hover popover — minimal active-transfer peek */
@@ -473,11 +566,11 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     max-width: calc(100vw - 24px);
     padding: 10px;
     border-radius: 12px;
-    background: rgba(36, 40, 59, 0.78);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
     box-shadow:
-        0 16px 48px rgba(0, 0, 0, 0.45),
-        0 1px 0 rgba(255, 255, 255, 0.04) inset;
+        var(--shadow-md),
+        0 1px 0 var(--glass-highlight) inset;
     backdrop-filter: blur(24px) saturate(180%);
     -webkit-backdrop-filter: blur(24px) saturate(180%);
     color: var(--text-main);
@@ -503,11 +596,11 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     max-width: calc(100vw - 24px);
     max-height: min(560px, calc(100vh - 80px));
     border-radius: 14px;
-    background: rgba(36, 40, 59, 0.82);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
     box-shadow:
-        0 22px 60px rgba(0, 0, 0, 0.50),
-        0 1px 0 rgba(255, 255, 255, 0.04) inset;
+        var(--shadow-lg),
+        0 1px 0 var(--glass-highlight) inset;
     backdrop-filter: blur(28px) saturate(180%);
     -webkit-backdrop-filter: blur(28px) saturate(180%);
     color: var(--text-main);
@@ -523,7 +616,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     flex-shrink: 0;
     display: flex; align-items: center; justify-content: space-between;
     padding: 12px 14px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    border-bottom: 1px solid var(--glass-border);
 }
 .notif-panel-title {
     font-size: 0.92rem;
@@ -532,8 +625,8 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 }
 .notif-panel-clear {
     background: transparent;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    color: rgba(192, 202, 245, 0.8);
+    border: 1px solid var(--color-border-soft);
+    color: var(--color-text-soft);
     font-size: 0.8rem;
     font-weight: 600;
     letter-spacing: 0.01em;
@@ -543,9 +636,9 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
 }
 .notif-panel-clear:hover:not(:disabled) {
-    background: rgba(255, 255, 255, 0.06);
+    background: var(--overlay-white-2);
     color: var(--text-main);
-    border-color: rgba(255, 255, 255, 0.14);
+    border-color: var(--color-border);
 }
 .notif-panel-clear:disabled { opacity: 0.4; cursor: default; }
 .notif-panel-body {
@@ -574,16 +667,16 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     gap: 12px;
     align-items: center;
     padding: 10px 12px;
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.04);
+    background: var(--overlay-white-1);
+    border: 1px solid var(--glass-border);
     border-radius: 10px;
     font-size: 0.85rem;
     transition: background 140ms ease, transform 140ms ease;
 }
-.notif-row:hover { background: rgba(255, 255, 255, 0.05); }
+.notif-row:hover { background: var(--overlay-white-2); }
 .notif-row[data-clipable="1"] { cursor: pointer; }
 .notif-row[data-clipable="1"]:active { transform: scale(0.99); }
-.notif-row.notif-copied { background: rgba(52, 199, 89, 0.10); border-color: rgba(52, 199, 89, 0.25); }
+.notif-row.notif-copied { background: var(--overlay-success-1); border-color: var(--overlay-success-2); }
 
 .notif-row-icon {
     width: 22px; height: 22px;
@@ -592,12 +685,12 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     flex-shrink: 0;
 }
 .notif-row-icon svg { width: 14px; height: 14px; }
-.notif-row-icon[data-kind="upload"]   { background: rgba(122, 162, 247, 0.16); color: var(--accent); }
-.notif-row-icon[data-kind="download"] { background: rgba(122, 162, 247, 0.12); color: #9eb9f9; }
-.notif-row-icon[data-kind="success"]  { background: rgba(52, 199, 89, 0.18); color: #6ee7a3; }
-.notif-row-icon[data-kind="info"]     { background: rgba(122, 162, 247, 0.14); color: var(--accent); }
-.notif-row-icon[data-kind="warning"]  { background: rgba(247, 178, 76, 0.18); color: #f7b24c; }
-.notif-row-icon[data-kind="error"]    { background: rgba(247, 118, 142, 0.20); color: var(--danger); }
+.notif-row-icon[data-kind="upload"]   { background: var(--overlay-accent-2); color: var(--accent); }
+.notif-row-icon[data-kind="download"] { background: var(--overlay-accent-1); color: var(--accent); }
+.notif-row-icon[data-kind="success"]  { background: var(--overlay-success-1); color: var(--success); }
+.notif-row-icon[data-kind="info"]     { background: var(--overlay-accent-1); color: var(--accent); }
+.notif-row-icon[data-kind="warning"]  { background: var(--overlay-warning-1); color: var(--color-warning); }
+.notif-row-icon[data-kind="error"]    { background: var(--overlay-danger-1); color: var(--danger); }
 
 .notif-row-body { min-width: 0; display: flex; flex-direction: column; gap: 4px; }
 .notif-row-title {
@@ -628,7 +721,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     gap: 1px;
     white-space: nowrap;
 }
-.notif-row-size { color: rgba(192, 202, 245, 0.82); }
+.notif-row-size { color: var(--color-text-soft); }
 .notif-row-speed { font-size: 0.68rem; color: var(--text-muted); }
 .notif-row-cancel {
     flex-shrink: 0;
@@ -644,17 +737,17 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     cursor: pointer;
     transition: background 0.15s ease, color 0.15s ease;
 }
-.notif-row-cancel:hover { background: rgba(247, 118, 142, 0.16); color: var(--danger); }
+.notif-row-cancel:hover { background: var(--overlay-danger-1); color: var(--danger); }
 .notif-row-progress {
     width: 100%;
     height: 4px;
-    background: rgba(255, 255, 255, 0.06);
+    background: var(--overlay-white-2);
     border-radius: 999px;
     overflow: hidden;
 }
 .notif-row-progress-fill {
     height: 100%;
-    background: linear-gradient(90deg, var(--accent), #9eb9f9);
+    background: linear-gradient(90deg, var(--accent), var(--accent-hover));
     border-radius: 999px;
     transition: width 200ms ease;
 }
@@ -665,7 +758,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 .notif-row-transfer.is-failed .notif-row-progress,
 .notif-row-transfer.is-canceled .notif-row-progress { display: none; }
 
-.notif-row.level-error .notif-row-title { color: #f7a8b9; }
+.notif-row.level-error .notif-row-title { color: var(--danger); }
 
 /* Empty state */
 .notif-empty {
@@ -680,7 +773,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 .notif-empty-glyph {
     width: 44px; height: 44px;
     display: inline-flex; align-items: center; justify-content: center;
-    background: rgba(255, 255, 255, 0.05);
+    background: var(--overlay-white-2);
     border-radius: 999px;
     color: var(--text-muted);
     opacity: 0.7;
@@ -721,11 +814,11 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     align-items: start;
     padding: 12px 14px;
     border-radius: 12px;
-    background: rgba(36, 40, 59, 0.96);
+    background: var(--glass-bg);
     border: 1px solid var(--border);
     box-shadow:
-        0 10px 30px rgba(0, 0, 0, 0.35),
-        0 1px 0 rgba(255, 255, 255, 0.04) inset;
+        var(--shadow-sm),
+        0 1px 0 var(--glass-highlight) inset;
     backdrop-filter: blur(12px);
     color: var(--text-main);
     font-size: 0.88rem;
@@ -750,15 +843,15 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
 }
 .toast-icon svg { width: 16px; height: 16px; }
 
-.toast-info    .toast-icon { background: rgba(122, 162, 247, 0.16); color: var(--accent); }
-.toast-success .toast-icon { background: rgba(52, 199, 89, 0.18); color: #6ee7a3; }
-.toast-warning .toast-icon { background: rgba(247, 178, 76, 0.18); color: #f7b24c; }
-.toast-error   .toast-icon { background: rgba(247, 118, 142, 0.20); color: #f7768e; }
+.toast-info    .toast-icon { background: var(--overlay-accent-2); color: var(--accent); }
+.toast-success .toast-icon { background: var(--overlay-success-1); color: var(--success); }
+.toast-warning .toast-icon { background: var(--overlay-warning-1); color: var(--color-warning); }
+.toast-error   .toast-icon { background: var(--overlay-danger-1); color: var(--danger); }
 
-.toast-info    { border-color: rgba(122, 162, 247, 0.30); }
-.toast-success { border-color: rgba(52, 199, 89, 0.30); }
-.toast-warning { border-color: rgba(247, 178, 76, 0.32); }
-.toast-error   { border-color: rgba(247, 118, 142, 0.34); }
+.toast-info    { border-color: var(--overlay-accent-3); }
+.toast-success { border-color: var(--overlay-success-2); }
+.toast-warning { border-color: var(--overlay-warning-2); }
+.toast-error   { border-color: var(--overlay-danger-2); }
 
 .toast-content {
     min-width: 0;
@@ -795,7 +888,7 @@ input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px rgba(122, 162, 
     transition: background 120ms ease, color 120ms ease;
 }
 .toast-close svg { width: 14px; height: 14px; }
-.toast-close:hover { background: rgba(255, 255, 255, 0.06); color: var(--text-main); }
+.toast-close:hover { background: var(--overlay-white-2); color: var(--text-main); }
 .toast-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
 .toast-spinner {
@@ -865,7 +958,7 @@ header {
 .drive-breadcrumb {
     height: 48px; display: flex; align-items: center; gap: 10px;
     padding: 0 30px; border-bottom: 1px solid var(--border);
-    background: rgba(22, 22, 30, 0.35);
+    background: color-mix(in srgb, var(--color-surface-0) 58%, transparent);
 }
 .back-btn { width: 32px; height: 32px; }
 .back-btn svg { width: 18px; height: 18px; }
@@ -1045,7 +1138,7 @@ header {
     width: 18px;
     height: 18px;
     border-radius: 999px;
-    border: 2px solid rgba(192, 202, 245, 0.22);
+    border: 2px solid var(--color-border);
     border-top-color: var(--accent);
     animation: pending-spin 0.8s linear infinite;
 }
@@ -1059,37 +1152,37 @@ header {
 }
 .file-row:hover { background: var(--bg-panel); }
 .file-row:focus-visible {
-    background: rgba(122, 162, 247, 0.10);
-    box-shadow: inset 0 0 0 1px rgba(122, 162, 247, 0.46), var(--focus-ring);
+    background: var(--overlay-accent-1);
+    box-shadow: inset 0 0 0 1px var(--color-accent), var(--focus-ring);
 }
 .file-row.is-keyboard-active:not(.is-selected) {
     background: transparent;
-    box-shadow: inset 0 0 0 1px rgba(122, 162, 247, 0.22);
+    box-shadow: inset 0 0 0 1px var(--overlay-accent-2);
 }
 .file-row.is-keyboard-active:not(.is-selected):hover {
     background: var(--bg-panel);
 }
 .drive-row.is-selected {
-    background: rgba(122, 162, 247, 0.12);
-    box-shadow: inset 0 0 0 1px rgba(122, 162, 247, 0.32);
+    background: var(--overlay-accent-1);
+    box-shadow: inset 0 0 0 1px var(--overlay-accent-3);
 }
-.drive-row.is-selected:hover { background: rgba(122, 162, 247, 0.14); }
+.drive-row.is-selected:hover { background: var(--overlay-accent-2); }
 .drive-row.is-dragging {
     opacity: 0.6;
 }
 .drive-row.drop-target {
-    background: rgba(122, 162, 247, 0.10);
-    box-shadow: inset 0 0 0 1px rgba(122, 162, 247, 0.38);
+    background: var(--overlay-accent-1);
+    box-shadow: inset 0 0 0 1px var(--color-accent);
 }
 .drive-row.drop-denied {
-    background: rgba(247, 118, 142, 0.08);
-    box-shadow: inset 0 0 0 1px rgba(247, 118, 142, 0.35);
+    background: var(--overlay-danger-1);
+    box-shadow: inset 0 0 0 1px var(--overlay-danger-2);
 }
 .breadcrumb-link.drop-target {
-    background: rgba(122, 162, 247, 0.12);
+    background: var(--overlay-accent-1);
 }
 .breadcrumb-link.drop-denied {
-    background: rgba(247, 118, 142, 0.10);
+    background: var(--overlay-danger-1);
 }
 
 .file-ext-text {
@@ -1110,7 +1203,7 @@ header {
     overflow: hidden;
     display: flex;
     align-items: center;
-    color: white;
+    color: var(--color-text);
     font-size: 0.9rem;
     font-weight: 500;
     white-space: nowrap;
@@ -1140,8 +1233,8 @@ header {
 .folder-chip {
     width: 40px; height: 20px; margin-right: 12px;
     flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;
-    background: rgba(122, 162, 247, 0.12);
-    border: 1px solid rgba(122, 162, 247, 0.25);
+    background: var(--overlay-accent-1);
+    border: 1px solid var(--overlay-accent-2);
     border-radius: 6px; color: var(--accent);
 }
 .folder-chip svg { width: 16px; height: 16px; }
@@ -1149,7 +1242,7 @@ header {
 .action-icon {
     width: 28px; height: 28px; display: flex; align-items: center; justify-content: center;
     border-radius: 6px; cursor: pointer; transition: all 0.2s;
-    background: rgba(255,255,255,0.03); border: 1px solid var(--border);
+    background: var(--overlay-white-1); border: 1px solid var(--border);
     color: var(--text-main);
     padding: 0;
     appearance: none;
@@ -1164,16 +1257,16 @@ header {
 .modal-overlay {
     position: fixed; inset: 0; z-index: 20000;
     display: flex; align-items: center; justify-content: center;
-    background: rgba(0, 0, 0, 0.55);
+    background: var(--scrim);
     padding: 24px;
 }
 .modal-card {
     width: 100%; max-width: 440px;
     background: var(--bg-sidebar); border: 1px solid var(--border);
     border-radius: 16px; padding: 20px;
-    box-shadow: 0 20px 60px rgba(0,0,0,0.55);
+    box-shadow: var(--shadow-lg);
 }
-.modal-title { color: white; font-size: 1.05rem; font-weight: 700; margin-bottom: 6px; }
+.modal-title { color: var(--color-text); font-size: 1.05rem; font-weight: 700; margin-bottom: 6px; }
 .modal-subtitle { color: var(--text-muted); font-size: 0.9rem; margin-bottom: 18px; }
 .delete-target-name {
     max-height: 5.5rem;
@@ -1204,7 +1297,7 @@ header {
     font-size: 0.9rem;
     border: 1px solid var(--border);
     border-radius: 12px;
-    background: rgba(255,255,255,0.02);
+    background: var(--overlay-white-1);
 }
 .modal-choice-row {
     display: flex;
@@ -1951,14 +2044,24 @@ header {
     top: calc(100% + 8px);
     right: 0;
     min-width: 260px;
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.45);
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 14px;
+    box-shadow: var(--shadow-lg), 0 1px 0 var(--glass-highlight) inset;
     padding: 6px;
     z-index: 60;
+    overflow: hidden;
+    -webkit-backdrop-filter: blur(28px) saturate(165%);
+    backdrop-filter: blur(28px) saturate(165%);
+    transform-origin: top right;
+    animation: profile-menu-in 180ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 .profile-menu[hidden] { display: none; }
+.profile-menu.appearance-view { min-width: min(390px, calc(100vw - 32px)); }
+@keyframes profile-menu-in {
+    from { opacity: 0; transform: translateY(-5px) scale(0.97); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+}
 .profile-menu-header {
     display: flex;
     gap: 12px;
@@ -2005,7 +2108,7 @@ header {
 .profile-menu-item[hidden] { display: none; }
 .profile-menu-item:hover,
 .profile-menu-item:focus-visible {
-    background: var(--bg-panel);
+    background: var(--overlay-white-2);
     outline: none;
 }
 .profile-menu-item:active { transform: translateY(0.5px); }
@@ -2043,7 +2146,7 @@ header {
     padding: 10px 12px;
     border: 1px solid var(--border);
     border-radius: 12px;
-    background: rgba(255,255,255,0.02);
+    background: var(--overlay-white-1);
 }
 .join-request-meta { min-width: 0; }
 .join-request-name {
@@ -2075,7 +2178,7 @@ header {
 .modal-error {
     margin: -8px 0 14px 0;
     font-size: 0.85rem;
-    color: rgba(247, 118, 142, 0.95);
+    color: var(--danger);
     line-height: 1.3;
 }
 
@@ -2101,15 +2204,15 @@ header {
     align-items: center;
     gap: 10px;
     padding: 10px 16px;
-    border-bottom: 1px solid rgba(41, 46, 66, 0.7);
-    background: rgba(0, 0, 0, 0.12);
+    border-bottom: 1px solid var(--color-border-soft);
+    background: var(--overlay-white-1);
 }
 .move-back-btn {
     width: 30px;
     height: 30px;
     border-radius: 8px;
     border: 1px solid var(--border);
-    background: rgba(255,255,255,0.03);
+    background: var(--overlay-white-1);
     color: var(--text-main);
     display: flex;
     align-items: center;
@@ -2169,8 +2272,8 @@ header {
     transition: background 0.12s ease, border-color 0.12s ease;
 }
 .move-item:hover {
-    background: rgba(255,255,255,0.04);
-    border-color: rgba(41, 46, 66, 0.7);
+    background: var(--overlay-white-1);
+    border-color: var(--color-border-soft);
 }
 .move-item.is-disabled {
     opacity: 0.35;
@@ -2196,7 +2299,7 @@ header {
     text-align: left;
     font-weight: 600;
     font-size: 0.9rem;
-    color: rgba(255,255,255,0.92);
+    color: var(--color-text);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -2570,8 +2673,8 @@ header {
     background: var(--bg-panel);
     transition: transform 0.14s ease, box-shadow 0.14s ease;
 }
-.gallery-cell:hover { transform: translateY(-2px); box-shadow: 0 10px 28px rgba(0,0,0,0.38); }
-.gallery-cell:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(122, 162, 247, 0.7); }
+.gallery-cell:hover { transform: translateY(-2px); box-shadow: var(--shadow-sm); }
+.gallery-cell:focus-visible { outline: none; box-shadow: var(--focus-ring); }
 
 .gallery-thumb {
     width: 100%;
@@ -2585,7 +2688,7 @@ header {
 
 /* Loading shimmer while a thumbnail is being fetched/generated. */
 .gallery-cell.is-loading {
-    background-image: linear-gradient(100deg, var(--bg-panel) 30%, rgba(122, 162, 247, 0.10) 50%, var(--bg-panel) 70%);
+    background-image: linear-gradient(100deg, var(--bg-panel) 30%, var(--overlay-accent-1) 50%, var(--bg-panel) 70%);
     background-size: 200% 100%;
     animation: gallery-shimmer 1.3s ease-in-out infinite;
 }
@@ -4003,7 +4106,7 @@ header {
     border-radius: 12px;
     background: var(--bg-panel);
     border: 1px solid var(--border);
-    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--shadow-md);
 }
 .upload-menu-item {
     display: flex;
@@ -4022,7 +4125,7 @@ header {
     transition: background 0.15s ease, color 0.15s ease;
 }
 .upload-menu-item:hover,
-.upload-menu-item:focus-visible { background: rgba(122, 162, 247, 0.12); color: var(--accent); outline: none; }
+.upload-menu-item:focus-visible { background: var(--overlay-accent-1); color: var(--accent); outline: none; }
 .upload-menu-item svg { width: 18px; height: 18px; flex-shrink: 0; }
 
 /* Import dialog: the "will be skipped" note for oversize files. */

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,45 +1,6 @@
 @import './ui/theme/theme-palettes.css';
 
 :root {
-    color-scheme: dark;
-
-    --color-canvas: #1a1b26;
-    --color-surface-0: #16161e;
-    --color-surface-1: #1f2335;
-    --color-surface-2: #24283b;
-    --color-surface-3: #2f3650;
-    --color-text: #f5f7ff;
-    --color-text-soft: #c0caf5;
-    --color-text-muted: #8b95c5;
-    --color-text-subtle: #6f789e;
-    --color-border: #2f3650;
-    --color-border-soft: #292e42;
-    --color-accent: #7aa2f7;
-    --color-accent-hover: #8fb4ff;
-    --color-accent-strong: #5d85e0;
-    --color-on-accent: #16161e;
-    --color-danger: #f7768e;
-    --color-on-danger: #16161e;
-    --color-warning: #e0af68;
-    --color-success: #34c759;
-
-    --overlay-white-1: rgba(255, 255, 255, 0.04);
-    --overlay-white-2: rgba(255, 255, 255, 0.08);
-    --overlay-white-3: rgba(255, 255, 255, 0.12);
-    --overlay-accent-1: rgba(122, 162, 247, 0.10);
-    --overlay-accent-2: rgba(122, 162, 247, 0.16);
-    --overlay-accent-3: rgba(122, 162, 247, 0.32);
-    --overlay-danger-1: rgba(247, 118, 142, 0.10);
-    --overlay-danger-2: rgba(247, 118, 142, 0.28);
-    --overlay-warning-1: rgba(224, 175, 104, 0.12);
-    --overlay-warning-2: rgba(224, 175, 104, 0.30);
-    --overlay-success-1: rgba(52, 199, 89, 0.12);
-    --overlay-success-2: rgba(52, 199, 89, 0.30);
-    --glass-bg: rgba(36, 40, 59, 0.88);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --glass-highlight: rgba(255, 255, 255, 0.04);
-    --scrim: rgba(0, 0, 0, 0.55);
-
     --radius-xs: 4px;
     --radius-sm: 6px;
     --radius-md: 8px;
@@ -54,11 +15,6 @@
     --space-5: 20px;
     --space-6: 24px;
     --space-8: 32px;
-
-    --shadow-sm: 0 8px 24px rgba(0, 0, 0, 0.24);
-    --shadow-md: 0 16px 44px rgba(0, 0, 0, 0.36);
-    --shadow-lg: 0 24px 72px rgba(0, 0, 0, 0.48);
-    --focus-ring: 0 0 0 3px rgba(122, 162, 247, 0.34);
 
     --motion-fast: 120ms;
     --motion-med: 180ms;
@@ -110,14 +66,14 @@ body { background-color: var(--bg-dark); color: var(--text-main); height: 100vh;
    it. Older WebView2/WebKitGTK builds receive the quieter app-settle fallback
    below, while reduced-motion users always get an immediate palette swap. */
 ::view-transition-old(root) {
-    animation: theme-old-fade 300ms var(--ease-standard) both;
+    animation: theme-old-fade 600ms var(--ease-standard) both;
 }
 ::view-transition-new(root) {
-    animation: theme-new-reveal 480ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: theme-new-reveal 1000ms cubic-bezier(0.16, 1, 0.3, 1) both;
     clip-path: circle(150vmax at var(--theme-origin-x, 50vw) var(--theme-origin-y, 50vh));
 }
 html.theme-transition-fallback #app {
-    animation: theme-app-settle 340ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: theme-app-settle 1000ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 @keyframes theme-old-fade {
     to { opacity: 0.84; filter: saturate(0.92); }
@@ -1327,7 +1283,7 @@ header {
 .file-viewer-overlay {
     align-items: stretch;
     justify-content: stretch;
-    background: rgba(4, 6, 11, 0.94);
+    background: var(--viewer-scrim);
     padding: 28px;
 }
 
@@ -1340,10 +1296,10 @@ header {
     max-width: none;
     padding: 0;
     overflow: hidden;
-    background: #080a0f;
-    border: 1px solid var(--border);
+    background: var(--viewer-surface-1);
+    border: 1px solid var(--viewer-border);
     border-radius: var(--radius-lg);
-    box-shadow: 0 18px 54px rgba(0, 0, 0, 0.42);
+    box-shadow: var(--viewer-shadow);
 }
 
 .file-viewer-topbar {
@@ -1353,8 +1309,8 @@ header {
     gap: var(--space-5);
     min-height: 72px;
     padding: 14px 18px;
-    border-bottom: 1px solid var(--border);
-    background: #0b0d14;
+    border-bottom: 1px solid var(--viewer-border-soft);
+    background: var(--viewer-surface-2);
 }
 
 .file-viewer-identity {
@@ -1371,10 +1327,10 @@ header {
     flex: 0 0 auto;
     width: 42px;
     height: 42px;
-    color: var(--color-accent);
-    border: 1px solid var(--border);
+    color: var(--viewer-accent);
+    border: 1px solid var(--viewer-border);
     border-radius: var(--radius-md);
-    background: var(--overlay-white-1);
+    background: var(--viewer-overlay-1);
 }
 
 .file-viewer-kind-mark svg {
@@ -1389,7 +1345,7 @@ header {
 .file-viewer-title {
     max-width: min(72vw, 980px);
     overflow: hidden;
-    color: var(--color-text);
+    color: var(--viewer-text);
     font-size: 1.05rem;
     font-weight: 800;
     line-height: 1.2;
@@ -1402,7 +1358,7 @@ header {
     align-items: center;
     gap: 8px;
     margin-top: 4px;
-    color: var(--color-text-muted);
+    color: var(--viewer-text-muted);
     font-size: var(--type-xs);
     font-weight: 700;
     letter-spacing: 0.02em;
@@ -1424,9 +1380,9 @@ header {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid var(--border);
-    background: rgba(255, 255, 255, 0.035);
-    color: var(--color-text-soft);
+    border: 1px solid var(--viewer-border);
+    background: var(--viewer-overlay-1);
+    color: var(--viewer-text-muted);
     appearance: none;
     cursor: pointer;
     transition: background var(--motion-fast) var(--ease-standard),
@@ -1470,9 +1426,9 @@ header {
 .file-viewer-close:hover,
 .audio-play:hover,
 .audio-mute:hover {
-    background: var(--overlay-white-2);
-    border-color: var(--color-border);
-    color: var(--color-text);
+    background: var(--viewer-control-hover);
+    border-color: var(--viewer-border);
+    color: var(--viewer-text);
 }
 
 .file-viewer-action:active,
@@ -1495,14 +1451,14 @@ header {
 .audio-seek:focus-visible,
 .audio-volume:focus-visible {
     outline: none;
-    box-shadow: var(--focus-ring);
+    box-shadow: var(--viewer-focus-ring);
 }
 
 .file-viewer-stage {
     min-height: 0;
     height: 100%;
     overflow: hidden;
-    background: #05070c;
+    background: var(--viewer-surface-0);
 }
 
 .file-viewer-state {
@@ -1511,7 +1467,7 @@ header {
     justify-content: center;
     min-height: 180px;
     padding: var(--space-6);
-    color: var(--color-text-soft);
+    color: var(--viewer-text-muted);
     font-size: var(--type-base);
     font-weight: 800;
     text-align: center;
@@ -1522,7 +1478,7 @@ header {
     display: flex;
     height: 100%;
     min-height: 0;
-    background: #05070c;
+    background: var(--viewer-surface-0);
 }
 
 .pdf-frame {
@@ -1532,7 +1488,7 @@ header {
     flex: 1 1 auto;
     min-height: 0;
     border: 0;
-    background: #05070c;
+    background: var(--viewer-surface-0);
 }
 
 .pdf-frame-overlay {
@@ -1543,7 +1499,7 @@ header {
     justify-content: center;
     padding: var(--space-6);
     background: rgba(5, 7, 12, 0.78);
-    color: var(--color-text-soft);
+    color: var(--viewer-text-muted);
     font-size: var(--type-base);
     font-weight: 800;
     text-align: center;
@@ -1574,10 +1530,10 @@ header {
     justify-content: center;
     width: 112px;
     height: 112px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--viewer-border);
     border-radius: var(--radius-md);
-    background: #10131d;
-    color: var(--color-accent);
+    background: var(--viewer-surface-2);
+    color: var(--viewer-accent);
 }
 
 .audio-art svg {
@@ -1591,7 +1547,7 @@ header {
 
 .audio-title {
     overflow: hidden;
-    color: var(--color-text);
+    color: var(--viewer-text);
     font-size: 1.16rem;
     font-weight: 800;
     line-height: 1.25;
@@ -1601,7 +1557,7 @@ header {
 
 .audio-subtitle {
     margin-top: 6px;
-    color: var(--color-text-muted);
+    color: var(--viewer-text-muted);
     font-size: var(--type-sm);
     font-weight: 700;
 }
@@ -1632,9 +1588,9 @@ header {
 .audio-play {
     width: 50px;
     height: 50px;
-    color: var(--color-text);
-    border-color: var(--overlay-accent-3);
-    background: var(--overlay-accent-1);
+    color: var(--viewer-text);
+    border-color: var(--viewer-accent);
+    background: var(--viewer-control-hover);
 }
 
 .audio-play svg,
@@ -1644,7 +1600,7 @@ header {
 }
 
 .audio-time {
-    color: var(--color-text);
+    color: var(--viewer-text);
     font-size: var(--type-sm);
     font-variant-numeric: tabular-nums;
     font-weight: 800;
@@ -1663,7 +1619,7 @@ header {
     min-width: 0;
     height: 18px;
     background: transparent;
-    accent-color: var(--color-accent);
+    accent-color: var(--viewer-accent);
     appearance: none;
 }
 
@@ -1671,7 +1627,7 @@ header {
 .audio-volume::-webkit-slider-runnable-track {
     height: 4px;
     border-radius: var(--radius-pill);
-    background: var(--overlay-white-3);
+    background: var(--viewer-overlay-3);
 }
 
 .audio-seek::-webkit-slider-thumb,
@@ -1681,7 +1637,7 @@ header {
     margin-top: -5px;
     border: 0;
     border-radius: var(--radius-pill);
-    background: var(--color-text);
+    background: var(--viewer-text);
     appearance: none;
 }
 
@@ -1689,7 +1645,7 @@ header {
 .audio-volume::-moz-range-track {
     height: 4px;
     border-radius: var(--radius-pill);
-    background: var(--overlay-white-3);
+    background: var(--viewer-overlay-3);
 }
 
 .audio-seek::-moz-range-thumb,
@@ -1698,7 +1654,7 @@ header {
     height: 14px;
     border: 0;
     border-radius: var(--radius-pill);
-    background: var(--color-text);
+    background: var(--viewer-text);
 }
 
 .text-viewer {
@@ -1706,7 +1662,7 @@ header {
     grid-template-rows: minmax(0, 1fr) auto;
     height: 100%;
     min-height: 0;
-    background: #05070c;
+    background: var(--viewer-surface-0);
 }
 
 .text-viewer-scroll {
@@ -1721,10 +1677,10 @@ header {
     min-height: 100%;
     margin: 0 auto;
     padding: 26px 28px;
-    color: var(--color-text-soft);
-    border: 1px solid var(--border);
+    color: var(--viewer-text-muted);
+    border: 1px solid var(--viewer-border);
     border-radius: var(--radius-md);
-    background: #0b0d14;
+    background: var(--viewer-surface-2);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     font-size: 0.88rem;
     line-height: 1.72;
@@ -1749,7 +1705,7 @@ header {
 }
 
 .text-viewer-body.is-markdown {
-    color: var(--color-text);
+    color: var(--viewer-text);
 }
 
 .text-viewer-body.is-markdown > :first-child,
@@ -1767,7 +1723,7 @@ header {
 .text-viewer-body.is-markdown h3,
 .text-viewer-body.is-markdown h4 {
     margin: 1.6em 0 0.6em;
-    color: var(--color-text);
+    color: var(--viewer-text);
     font-weight: 800;
     line-height: 1.18;
 }
@@ -1802,7 +1758,7 @@ header {
 }
 
 .text-viewer-body.is-markdown a {
-    color: var(--color-accent);
+    color: var(--viewer-accent);
     text-decoration: none;
 }
 
@@ -1812,9 +1768,9 @@ header {
 
 .text-viewer-body.is-markdown code {
     padding: 0.14em 0.4em;
-    border: 1px solid rgba(143, 155, 206, 0.14);
+    border: 1px solid var(--viewer-border-soft);
     border-radius: 8px;
-    background: rgba(143, 155, 206, 0.08);
+    background: var(--viewer-overlay-1);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     font-size: 0.9em;
 }
@@ -1829,10 +1785,10 @@ header {
 .text-viewer-body.is-code code.hljs {
     display: block;
     padding: 18px 20px;
-    border: 1px solid rgba(143, 155, 206, 0.14);
+    border: 1px solid var(--viewer-border-soft);
     border-radius: var(--radius-md);
-    background: #0f1320;
-    color: var(--color-text);
+    background: var(--viewer-surface-2);
+    color: var(--viewer-text);
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     font-size: 0.88rem;
     line-height: 1.72;
@@ -1844,12 +1800,12 @@ header {
 
 .text-viewer-body.is-markdown blockquote {
     padding-left: 16px;
-    color: var(--color-text-muted);
-    border-left: 2px solid rgba(143, 155, 206, 0.26);
+    color: var(--viewer-text-muted);
+    border-left: 2px solid var(--viewer-border);
 }
 
 .text-viewer-body.is-code {
-    color: var(--color-text);
+    color: var(--viewer-text);
 }
 
 .text-viewer-body.is-code .hljs-attr,
@@ -1875,7 +1831,7 @@ header {
 
 .text-viewer-body.is-code .hljs-comment,
 .text-viewer-body.is-code .hljs-quote {
-    color: rgba(245, 247, 255, 0.42);
+    color: var(--viewer-text-subtle);
 }
 
 .text-viewer-footer {
@@ -1884,9 +1840,9 @@ header {
     justify-content: flex-end;
     gap: var(--space-3);
     padding: var(--space-3) var(--space-4);
-    color: var(--color-text-muted);
-    border-top: 1px solid var(--border);
-    background: #0b0d14;
+    color: var(--viewer-text-muted);
+    border-top: 1px solid var(--viewer-border-soft);
+    background: var(--viewer-surface-2);
     font-size: var(--type-sm);
     font-weight: 700;
 }
@@ -1896,9 +1852,9 @@ header {
     align-items: center;
     gap: 4px;
     padding: 4px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--viewer-border);
     border-radius: var(--radius-pill);
-    background: rgba(143, 155, 206, 0.06);
+    background: var(--viewer-overlay-1);
 }
 
 .text-viewer-toggle button {
@@ -1907,24 +1863,24 @@ header {
     border: 0;
     border-radius: calc(var(--radius-pill) - 4px);
     background: transparent;
-    color: var(--color-text-muted);
+    color: var(--viewer-text-muted);
     font: inherit;
     cursor: pointer;
     transition: background 0.14s ease, color 0.14s ease;
 }
 
 .text-viewer-toggle button:hover {
-    color: var(--color-text);
+    color: var(--viewer-text);
 }
 
 .text-viewer-toggle button.active {
-    background: rgba(122, 162, 247, 0.16);
-    color: var(--color-text);
+    background: var(--viewer-control-hover);
+    color: var(--viewer-text);
 }
 
 .text-viewer-toggle button:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 2px var(--color-accent-ring);
+    box-shadow: var(--viewer-focus-ring);
 }
 
 @media (max-width: 760px) {
@@ -2895,7 +2851,7 @@ header {
     border-radius: 8px;
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: rgba(255, 255, 255, 0.04);
-    color: var(--accent);
+    color: var(--viewer-accent);
     font-size: 0.82rem;
     font-weight: 700;
     cursor: pointer;
@@ -2965,7 +2921,7 @@ header {
 .preview-unlock-bar:focus-within {
     border-color: rgba(122, 162, 247, 0.6);
 }
-.preview-unlock-lock { width: 18px; height: 18px; flex-shrink: 0; color: var(--text-muted); }
+.preview-unlock-lock { width: 18px; height: 18px; flex-shrink: 0; color: var(--viewer-text-muted); }
 .preview-unlock-bar input {
     flex: 1;
     min-width: 0;
@@ -2973,13 +2929,13 @@ header {
     padding: 12px 0;
     border: none;
     background: transparent;
-    color: var(--text-main);
+    color: var(--viewer-text);
     font-size: 1rem;
     letter-spacing: 0.01em;
     outline: none;
 }
 .preview-unlock-bar input:focus { box-shadow: none; }
-.preview-unlock-bar input::placeholder { color: var(--text-muted); }
+.preview-unlock-bar input::placeholder { color: var(--viewer-text-muted); }
 /* Secondary action: a ghost show/hide toggle, muted so it doesn't compete. */
 .preview-unlock-eye {
     flex-shrink: 0;
@@ -2991,11 +2947,11 @@ header {
     border: none;
     border-radius: 10px;
     background: transparent;
-    color: var(--text-muted);
+    color: var(--viewer-text-muted);
     cursor: pointer;
     transition: color 0.15s ease, background 0.15s ease;
 }
-.preview-unlock-eye:hover { color: var(--text-main); background: rgba(255, 255, 255, 0.06); }
+.preview-unlock-eye:hover { color: var(--viewer-text); background: var(--viewer-overlay-2); }
 .preview-unlock-eye svg { width: 18px; height: 18px; }
 /* Primary action: the single filled accent button (the one strong CTA), flat. */
 .preview-unlock-go {
@@ -3007,8 +2963,8 @@ header {
     justify-content: center;
     border: none;
     border-radius: 12px;
-    background: var(--accent);
-    color: var(--bg-dark);
+    background: var(--viewer-accent);
+    color: var(--viewer-on-accent);
     cursor: pointer;
     transition: filter 0.15s ease, transform 0.15s ease;
 }
@@ -3018,14 +2974,14 @@ header {
 .preview-unlock-go svg { width: 18px; height: 18px; }
 .preview-unlock-error {
     margin-top: 16px;
-    color: var(--danger);
+    color: var(--viewer-danger);
     font-family: system-ui, -apple-system, "SF Pro Text", "Segoe UI", sans-serif;
     font-size: 0.8rem;
     text-align: center;
 }
 .preview-unlock-hint {
     margin-top: 16px;
-    color: var(--text-muted);
+    color: var(--viewer-text-muted);
     font-family: system-ui, -apple-system, "SF Pro Text", "Segoe UI", sans-serif;
     font-size: 0.8rem;
     font-weight: 500;
@@ -3044,11 +3000,11 @@ header {
 
 /* ----- Video player ----- */
 .video-overlay {
-    --video-accent: var(--accent);
+    --video-accent: var(--viewer-accent);
     --video-accent-bg: rgba(122, 162, 247, 0.2);
     --video-accent-border: rgba(122, 162, 247, 0.58);
     --video-accent-ring: rgba(122, 162, 247, 0.28);
-    background: rgba(4, 6, 11, 0.94);
+    background: var(--viewer-scrim);
     backdrop-filter: blur(16px);
     z-index: 2400;
     align-items: stretch;
@@ -3065,7 +3021,7 @@ header {
     height: 100%;
     min-width: 0;
     min-height: 0;
-    background: #05070c;
+    background: var(--viewer-surface-0);
     overflow: hidden;
     outline: none;
     user-select: none;
@@ -3077,7 +3033,7 @@ header {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #05070c;
+    background: var(--viewer-surface-0);
     cursor: inherit;
 }
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -66,14 +66,14 @@ body { background-color: var(--bg-dark); color: var(--text-main); height: 100vh;
    it. Older WebView2/WebKitGTK builds receive the quieter app-settle fallback
    below, while reduced-motion users always get an immediate palette swap. */
 ::view-transition-old(root) {
-    animation: theme-old-fade 600ms var(--ease-standard) both;
+    animation: theme-old-fade 720ms var(--ease-standard) both;
 }
 ::view-transition-new(root) {
-    animation: theme-new-reveal 1000ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: theme-new-reveal 1200ms cubic-bezier(0.16, 1, 0.3, 1) both;
     clip-path: circle(150vmax at var(--theme-origin-x, 50vw) var(--theme-origin-y, 50vh));
 }
 html.theme-transition-fallback #app {
-    animation: theme-app-settle 1000ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: theme-app-settle 1200ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 @keyframes theme-old-fade {
     to { opacity: 0.84; filter: saturate(0.92); }

--- a/frontend/src/ui/Button.svelte
+++ b/frontend/src/ui/Button.svelte
@@ -80,7 +80,7 @@
     }
 
     .is-primary {
-        color: var(--color-surface-0);
+        color: var(--color-on-accent);
         background: var(--accent);
         border-color: var(--accent);
     }
@@ -103,7 +103,7 @@
     }
 
     .is-danger {
-        color: var(--color-surface-0);
+        color: var(--color-on-danger);
         background: var(--danger);
         border-color: var(--danger);
     }

--- a/frontend/src/ui/auth/AuthScreens.svelte
+++ b/frontend/src/ui/auth/AuthScreens.svelte
@@ -9,6 +9,7 @@
     import { tick } from 'svelte';
     import { eventOccurredWithin } from '../event-path';
     import AppearancePanel from '../theme/AppearancePanel.svelte';
+    import { recoverThemeTransitionClick } from '../theme/theme-interaction';
     import { authCodeReset, authHint, authPhone, authScreen } from './auth-store';
 
     interface Props {
@@ -29,6 +30,7 @@
     let revealPassword = $state(false);
     let appearanceOpen = $state(false);
     let appearanceRoot = $state<HTMLElement | null>(null);
+    let appearancePopover = $state<HTMLElement | null>(null);
     let appearanceTrigger = $state<HTMLButtonElement | null>(null);
 
     let apiIdEl = $state<HTMLInputElement | null>(null);
@@ -94,7 +96,10 @@
     }
 
     function onDocumentClick(event: MouseEvent): void {
-        if (!appearanceOpen || eventOccurredWithin(event, appearanceRoot)) return;
+        if (!appearanceOpen
+            || eventOccurredWithin(event, appearanceRoot)
+            || recoverThemeTransitionClick(event, appearancePopover)
+            || recoverThemeTransitionClick(event, appearanceRoot)) return;
         closeAppearance();
     }
 </script>
@@ -107,6 +112,7 @@
         <button
             bind:this={appearanceTrigger}
             id="auth-appearance-trigger"
+            data-theme-hit-target
             class="auth-appearance-trigger"
             type="button"
             aria-label="Customize appearance"
@@ -119,7 +125,13 @@
             <PaletteIcon size={18} strokeWidth={2} aria-hidden="true" />
         </button>
         {#if appearanceOpen}
-            <div id="auth-appearance-popover" class="auth-appearance-popover" role="dialog" aria-label="Appearance settings">
+            <div
+                bind:this={appearancePopover}
+                id="auth-appearance-popover"
+                class="auth-appearance-popover"
+                role="dialog"
+                aria-label="Appearance settings"
+            >
                 <AppearancePanel autofocus />
             </div>
         {/if}

--- a/frontend/src/ui/auth/AuthScreens.svelte
+++ b/frontend/src/ui/auth/AuthScreens.svelte
@@ -7,6 +7,7 @@
     import PaletteIcon from '@lucide/svelte/icons/palette';
     import SettingsIcon from '@lucide/svelte/icons/settings';
     import { tick } from 'svelte';
+    import { eventOccurredWithin } from '../event-path';
     import AppearancePanel from '../theme/AppearancePanel.svelte';
     import { authCodeReset, authHint, authPhone, authScreen } from './auth-store';
 
@@ -93,7 +94,7 @@
     }
 
     function onDocumentClick(event: MouseEvent): void {
-        if (!appearanceOpen || appearanceRoot?.contains(event.target as Node)) return;
+        if (!appearanceOpen || eventOccurredWithin(event, appearanceRoot)) return;
         closeAppearance();
     }
 </script>

--- a/frontend/src/ui/auth/AuthScreens.svelte
+++ b/frontend/src/ui/auth/AuthScreens.svelte
@@ -4,8 +4,10 @@
     import KeyRoundIcon from '@lucide/svelte/icons/key-round';
     import LockKeyholeIcon from '@lucide/svelte/icons/lock-keyhole';
     import MailIcon from '@lucide/svelte/icons/mail';
+    import PaletteIcon from '@lucide/svelte/icons/palette';
     import SettingsIcon from '@lucide/svelte/icons/settings';
     import { tick } from 'svelte';
+    import AppearancePanel from '../theme/AppearancePanel.svelte';
     import { authCodeReset, authHint, authPhone, authScreen } from './auth-store';
 
     interface Props {
@@ -24,6 +26,9 @@
     let code = $state('');
     let password = $state('');
     let revealPassword = $state(false);
+    let appearanceOpen = $state(false);
+    let appearanceRoot = $state<HTMLElement | null>(null);
+    let appearanceTrigger = $state<HTMLButtonElement | null>(null);
 
     let apiIdEl = $state<HTMLInputElement | null>(null);
     let phoneEl = $state<HTMLInputElement | null>(null);
@@ -35,6 +40,7 @@
     let lastScreen: string | null = null;
     $effect(() => {
         const screen = $authScreen;
+        if (!screen) appearanceOpen = false;
         if (screen === lastScreen) return;
         lastScreen = screen;
         if (screen === 'code') code = '';
@@ -44,6 +50,7 @@
         }
         void tick().then(() => {
             if ($authScreen !== screen) return;
+            if (appearanceOpen) return;
             const el = screen === 'setup' ? apiIdEl
                 : screen === 'phone' ? phoneEl
                 : screen === 'code' ? codeEl
@@ -69,7 +76,54 @@
             action();
         }
     }
+
+    function closeAppearance(returnFocus = false): void {
+        appearanceOpen = false;
+        if (returnFocus) void tick().then(() => appearanceTrigger?.focus());
+    }
+
+    function toggleAppearance(): void {
+        appearanceOpen = !appearanceOpen;
+    }
+
+    function onWindowKeydown(event: KeyboardEvent): void {
+        if (event.key !== 'Escape' || !appearanceOpen) return;
+        event.preventDefault();
+        closeAppearance(true);
+    }
+
+    function onDocumentClick(event: MouseEvent): void {
+        if (!appearanceOpen || appearanceRoot?.contains(event.target as Node)) return;
+        closeAppearance();
+    }
 </script>
+
+<svelte:window onkeydown={onWindowKeydown} />
+<svelte:document onclickcapture={onDocumentClick} />
+
+{#if $authScreen}
+    <div class="auth-appearance-control" bind:this={appearanceRoot}>
+        <button
+            bind:this={appearanceTrigger}
+            id="auth-appearance-trigger"
+            class="auth-appearance-trigger"
+            type="button"
+            aria-label="Customize appearance"
+            aria-haspopup="dialog"
+            aria-expanded={appearanceOpen}
+            aria-controls="auth-appearance-popover"
+            title="Customize appearance"
+            onclick={toggleAppearance}
+        >
+            <PaletteIcon size={18} strokeWidth={2} aria-hidden="true" />
+        </button>
+        {#if appearanceOpen}
+            <div id="auth-appearance-popover" class="auth-appearance-popover" role="dialog" aria-label="Appearance settings">
+                <AppearancePanel onBack={() => closeAppearance(true)} backLabel="Close appearance settings" autofocus />
+            </div>
+        {/if}
+    </div>
+{/if}
 
 {#if $authScreen === 'setup'}
     <div class="auth-box">

--- a/frontend/src/ui/auth/AuthScreens.svelte
+++ b/frontend/src/ui/auth/AuthScreens.svelte
@@ -119,7 +119,7 @@
         </button>
         {#if appearanceOpen}
             <div id="auth-appearance-popover" class="auth-appearance-popover" role="dialog" aria-label="Appearance settings">
-                <AppearancePanel onBack={() => closeAppearance(true)} backLabel="Close appearance settings" autofocus />
+                <AppearancePanel autofocus />
             </div>
         {/if}
     </div>

--- a/frontend/src/ui/auth/auth.dom.test.ts
+++ b/frontend/src/ui/auth/auth.dom.test.ts
@@ -53,7 +53,8 @@ describe('AuthScreens field reset', () => {
         await tick();
         expect(host.querySelector('#auth-appearance-popover')).not.toBeNull();
         expect(trigger?.getAttribute('aria-expanded')).toBe('true');
-        expect(host.querySelector('.appearance-back')).toBe(document.activeElement);
+        expect(host.querySelector('.appearance-back')).toBeNull();
+        expect(host.querySelector('#appearance-mode-system')).toBe(document.activeElement);
 
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
         flushSync();

--- a/frontend/src/ui/auth/auth.dom.test.ts
+++ b/frontend/src/ui/auth/auth.dom.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, tick, unmount } from 'svelte';
 import AuthScreens from './AuthScreens.svelte';
+import { setPreferredTheme, setThemeMode, themeController } from '../theme/theme-controller';
 import { authCodeReset, authPhone, authScreen } from './auth-store';
 
 let host: HTMLElement;
@@ -35,6 +36,10 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+    setPreferredTheme('light', 'tdrive-light');
+    setPreferredTheme('dark', 'tokyo-night');
+    setThemeMode('dark');
+    themeController.destroy();
     authScreen.set(null);
     flushSync();
     await unmount(app);
@@ -54,7 +59,16 @@ describe('AuthScreens field reset', () => {
         expect(host.querySelector('#auth-appearance-popover')).not.toBeNull();
         expect(trigger?.getAttribute('aria-expanded')).toBe('true');
         expect(host.querySelector('.appearance-back')).toBeNull();
-        expect(host.querySelector('#appearance-mode-system')).toBe(document.activeElement);
+        expect(host.querySelector('[data-appearance-mode="dark"]')).toBe(document.activeElement);
+
+        host.querySelector<HTMLButtonElement>('#appearance-theme-dracula')?.click();
+        flushSync();
+        await tick();
+        host.querySelector<HTMLButtonElement>('#appearance-theme-nord')?.click();
+        flushSync();
+        await tick();
+        expect(host.querySelector('#auth-appearance-popover')).not.toBeNull();
+        expect(host.querySelector('#appearance-theme-nord')?.getAttribute('aria-checked')).toBe('true');
 
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
         flushSync();

--- a/frontend/src/ui/auth/auth.dom.test.ts
+++ b/frontend/src/ui/auth/auth.dom.test.ts
@@ -3,7 +3,7 @@
 // keeps the user on the same screen (where a screen-value change cannot fire).
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
+import { flushSync, mount, tick, unmount } from 'svelte';
 import AuthScreens from './AuthScreens.svelte';
 import { authCodeReset, authPhone, authScreen } from './auth-store';
 
@@ -42,6 +42,41 @@ afterEach(async () => {
 });
 
 describe('AuthScreens field reset', () => {
+    it('opens and dismisses appearance settings before login', async () => {
+        authScreen.set('phone');
+        flushSync();
+
+        const trigger = host.querySelector<HTMLButtonElement>('#auth-appearance-trigger');
+        trigger?.click();
+        flushSync();
+        await tick();
+        await tick();
+        expect(host.querySelector('#auth-appearance-popover')).not.toBeNull();
+        expect(trigger?.getAttribute('aria-expanded')).toBe('true');
+        expect(host.querySelector('.appearance-back')).toBe(document.activeElement);
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        flushSync();
+        expect(host.querySelector('#auth-appearance-popover')).toBeNull();
+        expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('does not reopen appearance settings after the auth flow unmounts and returns', () => {
+        authScreen.set('phone');
+        flushSync();
+        host.querySelector<HTMLButtonElement>('#auth-appearance-trigger')?.click();
+        flushSync();
+        expect(host.querySelector('#auth-appearance-popover')).not.toBeNull();
+
+        authScreen.set(null);
+        flushSync();
+        authScreen.set('setup');
+        flushSync();
+
+        expect(host.querySelector('#auth-appearance-popover')).toBeNull();
+        expect(host.querySelector('#auth-appearance-trigger')?.getAttribute('aria-expanded')).toBe('false');
+    });
+
     it('clears the code field when transitioning onto the code screen', () => {
         authScreen.set('code');
         flushSync();

--- a/frontend/src/ui/auth/auth.dom.test.ts
+++ b/frontend/src/ui/auth/auth.dom.test.ts
@@ -5,7 +5,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, tick, unmount } from 'svelte';
 import AuthScreens from './AuthScreens.svelte';
-import { setPreferredTheme, setThemeMode, themeController } from '../theme/theme-controller';
+import {
+    setPreferredTheme,
+    setThemeMode,
+    THEME_TRANSITION_CLASS,
+    themeController,
+} from '../theme/theme-controller';
 import { authCodeReset, authPhone, authScreen } from './auth-store';
 
 let host: HTMLElement;
@@ -15,6 +20,20 @@ function codeInput(): HTMLInputElement {
     const el = host.querySelector('.code-input') as HTMLInputElement | null;
     if (!el) throw new Error('code input not rendered');
     return el;
+}
+
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+    return {
+        x: left,
+        y: top,
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+        width,
+        height,
+        toJSON: () => ({}),
+    };
 }
 
 beforeEach(() => {
@@ -90,6 +109,34 @@ describe('AuthScreens field reset', () => {
 
         expect(host.querySelector('#auth-appearance-popover')).toBeNull();
         expect(host.querySelector('#auth-appearance-trigger')?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('recovers a rapid palette click intercepted by the root transition layer', async () => {
+        authScreen.set('phone');
+        flushSync();
+        host.querySelector<HTMLButtonElement>('#auth-appearance-trigger')?.click();
+        flushSync();
+        await tick();
+
+        const popover = host.querySelector<HTMLElement>('#auth-appearance-popover');
+        const nord = host.querySelector<HTMLButtonElement>('#appearance-theme-nord');
+        if (!popover || !nord) throw new Error('appearance controls did not render');
+        vi.spyOn(popover, 'getBoundingClientRect').mockReturnValue(rect(100, 100, 360, 640));
+        vi.spyOn(nord, 'getBoundingClientRect').mockReturnValue(rect(280, 360, 160, 100));
+        document.documentElement.classList.add(THEME_TRANSITION_CLASS);
+
+        document.documentElement.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 320,
+            clientY: 400,
+        }));
+        flushSync();
+        await tick();
+
+        expect(host.querySelector('#auth-appearance-popover')).not.toBeNull();
+        expect(host.querySelector('#appearance-theme-nord')?.getAttribute('aria-checked')).toBe('true');
+        expect(document.activeElement).toBe(host.querySelector('#appearance-theme-nord'));
     });
 
     it('clears the code field when transitioning onto the code screen', () => {

--- a/frontend/src/ui/auth/auth.test.ts
+++ b/frontend/src/ui/auth/auth.test.ts
@@ -36,6 +36,8 @@ describe('AuthScreens', () => {
         const { body } = render(AuthScreens, { props });
         expect(body).toContain('Welcome Back');
         expect(body).toContain('Send Code');
+        expect(body).toContain('id="auth-appearance-trigger"');
+        expect(body).toContain('Customize appearance');
     });
 
     it('shows the sent-to pill on the code screen only when a phone is set', () => {

--- a/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
+++ b/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, tick, unmount } from 'svelte';
 import ProfileMenu from './ProfileMenu.svelte';
+import { setPreferredTheme, setThemeMode, themeController } from '../theme/theme-controller';
 import { encryptionEntryVisible, profileLoaded, profileUser } from './profile-store';
 
 let component: Record<string, unknown> | null = null;
@@ -28,6 +29,10 @@ function click(selector: string): void {
 }
 
 afterEach(async () => {
+    setPreferredTheme('light', 'tdrive-light');
+    setPreferredTheme('dark', 'tokyo-night');
+    setThemeMode('dark');
+    themeController.destroy();
     if (component) await unmount(component);
     host?.remove();
     component = null;
@@ -48,10 +53,10 @@ describe('ProfileMenu appearance navigation', () => {
         const menu = host?.querySelector<HTMLElement>('#profile-menu');
         expect(menu?.getAttribute('role')).toBe('dialog');
         expect(menu?.getAttribute('aria-labelledby')).toBe('appearance-title');
-        expect(host?.textContent).toContain('System');
+        expect(host?.textContent).not.toContain('System');
         expect(host?.textContent).not.toContain('Automatic pair');
         expect(host?.querySelector('.appearance-back')).toBeNull();
-        const selectedMode = host?.querySelector('[data-appearance-mode="system"]');
+        const selectedMode = host?.querySelector('[data-appearance-mode="dark"]');
         expect(selectedMode).toBe(document.activeElement);
 
         menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
@@ -62,5 +67,23 @@ describe('ProfileMenu appearance navigation', () => {
         expect(menu?.hidden).toBe(false);
         expect(menu?.getAttribute('role')).toBe('menu');
         expect(host?.querySelector('#profile-menu-appearance')).toBe(document.activeElement);
+    });
+
+    it('stays open while previewing multiple palettes', async () => {
+        setup();
+        click('#profile-trigger');
+        click('#profile-menu-appearance');
+        await tick();
+
+        click('#appearance-theme-dracula');
+        await tick();
+        click('#appearance-theme-nord');
+        await tick();
+
+        const menu = host?.querySelector<HTMLElement>('#profile-menu');
+        expect(menu?.hidden).toBe(false);
+        expect(menu?.getAttribute('role')).toBe('dialog');
+        expect(host?.querySelector('#appearance-theme-nord')?.getAttribute('aria-checked')).toBe('true');
+        expect(host?.textContent).toContain('Nord is active.');
     });
 });

--- a/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
+++ b/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
@@ -51,7 +51,8 @@ describe('ProfileMenu appearance navigation', () => {
         expect(host?.textContent).toContain('System');
         expect(host?.textContent).not.toContain('Automatic pair');
         expect(host?.querySelector('.appearance-back')).toBeNull();
-        expect(host?.querySelector('#appearance-mode-system')).toBe(document.activeElement);
+        const selectedMode = host?.querySelector('[data-appearance-mode="system"]');
+        expect(selectedMode).toBe(document.activeElement);
 
         menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
         flushSync();

--- a/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
+++ b/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, tick, unmount } from 'svelte';
+import ProfileMenu from './ProfileMenu.svelte';
+import { encryptionEntryVisible, profileLoaded, profileUser } from './profile-store';
+
+let component: Record<string, unknown> | null = null;
+let host: HTMLElement | null = null;
+
+function setup(): void {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    component = mount(ProfileMenu, {
+        target: host,
+        props: {
+            onOpen: vi.fn(),
+            onEncryptionSettings: vi.fn(),
+            onLogout: vi.fn(),
+        },
+    });
+    flushSync();
+}
+
+function click(selector: string): void {
+    const element = host?.querySelector<HTMLElement>(selector);
+    if (!element) throw new Error(`missing ${selector}`);
+    element.click();
+    flushSync();
+}
+
+afterEach(async () => {
+    if (component) await unmount(component);
+    host?.remove();
+    component = null;
+    host = null;
+    profileUser.set(null);
+    profileLoaded.set(false);
+    encryptionEntryVisible.set(false);
+});
+
+describe('ProfileMenu appearance navigation', () => {
+    it('uses Escape to return to the account menu before closing the popover', async () => {
+        setup();
+        click('#profile-trigger');
+        click('#profile-menu-appearance');
+        await tick();
+        await Promise.resolve();
+
+        const menu = host?.querySelector<HTMLElement>('#profile-menu');
+        expect(menu?.getAttribute('role')).toBe('dialog');
+        expect(menu?.getAttribute('aria-labelledby')).toBe('appearance-title');
+        expect(host?.textContent).toContain('Automatic pair');
+        expect(host?.querySelector('.appearance-back')).toBe(document.activeElement);
+
+        menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        flushSync();
+        await tick();
+        await Promise.resolve();
+
+        expect(menu?.hidden).toBe(false);
+        expect(menu?.getAttribute('role')).toBe('menu');
+        expect(host?.querySelector('#profile-menu-appearance')).toBe(document.activeElement);
+    });
+});

--- a/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
+++ b/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { flushSync, mount, tick, unmount } from 'svelte';
 import ProfileMenu from './ProfileMenu.svelte';
-import { setPreferredTheme, setThemeMode, themeController } from '../theme/theme-controller';
+import {
+    setPreferredTheme,
+    setThemeMode,
+    THEME_TRANSITION_CLASS,
+    themeController,
+} from '../theme/theme-controller';
 import { encryptionEntryVisible, profileLoaded, profileUser } from './profile-store';
 
 let component: Record<string, unknown> | null = null;
@@ -26,6 +31,20 @@ function click(selector: string): void {
     if (!element) throw new Error(`missing ${selector}`);
     element.click();
     flushSync();
+}
+
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+    return {
+        x: left,
+        y: top,
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+        width,
+        height,
+        toJSON: () => ({}),
+    };
 }
 
 afterEach(async () => {
@@ -85,5 +104,34 @@ describe('ProfileMenu appearance navigation', () => {
         expect(menu?.getAttribute('role')).toBe('dialog');
         expect(host?.querySelector('#appearance-theme-nord')?.getAttribute('aria-checked')).toBe('true');
         expect(host?.textContent).toContain('Nord is active.');
+    });
+
+    it('recovers a rapid palette click intercepted by the root transition layer', async () => {
+        setup();
+        click('#profile-trigger');
+        click('#profile-menu-appearance');
+        await tick();
+        await Promise.resolve();
+
+        const menu = host?.querySelector<HTMLElement>('#profile-menu');
+        const nord = host?.querySelector<HTMLButtonElement>('#appearance-theme-nord');
+        if (!menu || !nord) throw new Error('appearance controls did not render');
+        vi.spyOn(menu, 'getBoundingClientRect').mockReturnValue(rect(100, 100, 390, 680));
+        vi.spyOn(nord, 'getBoundingClientRect').mockReturnValue(rect(290, 360, 180, 100));
+        document.documentElement.classList.add(THEME_TRANSITION_CLASS);
+
+        document.documentElement.dispatchEvent(new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 340,
+            clientY: 410,
+        }));
+        flushSync();
+        await tick();
+
+        expect(menu.hidden).toBe(false);
+        expect(menu.getAttribute('role')).toBe('dialog');
+        expect(host?.querySelector('#appearance-theme-nord')?.getAttribute('aria-checked')).toBe('true');
+        expect(document.activeElement).toBe(host?.querySelector('#appearance-theme-nord'));
     });
 });

--- a/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
+++ b/frontend/src/ui/chrome/ProfileMenu.dom.test.ts
@@ -48,8 +48,10 @@ describe('ProfileMenu appearance navigation', () => {
         const menu = host?.querySelector<HTMLElement>('#profile-menu');
         expect(menu?.getAttribute('role')).toBe('dialog');
         expect(menu?.getAttribute('aria-labelledby')).toBe('appearance-title');
-        expect(host?.textContent).toContain('Automatic pair');
-        expect(host?.querySelector('.appearance-back')).toBe(document.activeElement);
+        expect(host?.textContent).toContain('System');
+        expect(host?.textContent).not.toContain('Automatic pair');
+        expect(host?.querySelector('.appearance-back')).toBeNull();
+        expect(host?.querySelector('#appearance-mode-system')).toBe(document.activeElement);
 
         menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
         flushSync();

--- a/frontend/src/ui/chrome/ProfileMenu.svelte
+++ b/frontend/src/ui/chrome/ProfileMenu.svelte
@@ -60,7 +60,7 @@
     async function openAppearance(): Promise<void> {
         view = 'appearance';
         await tick();
-        menuEl?.querySelector<HTMLElement>('[aria-label="Appearance mode"] [aria-checked="true"]')?.focus();
+        menuEl?.querySelector<HTMLElement>('[data-appearance-mode][aria-checked="true"]')?.focus();
     }
 
     async function closeAppearance(): Promise<void> {

--- a/frontend/src/ui/chrome/ProfileMenu.svelte
+++ b/frontend/src/ui/chrome/ProfileMenu.svelte
@@ -4,6 +4,7 @@
     import LogOutIcon from '@lucide/svelte/icons/log-out';
     import PaletteIcon from '@lucide/svelte/icons/palette';
     import { tick } from 'svelte';
+    import { eventOccurredWithin } from '../event-path';
     import AppearancePanel from '../theme/AppearancePanel.svelte';
     import Avatar from './Avatar.svelte';
     import { encryptionEntryVisible, profileLoaded, profileUser } from './profile-store';
@@ -117,8 +118,7 @@
 
     function onDocumentClick(event: MouseEvent): void {
         if (!open) return;
-        const target = event.target as Node;
-        if (menuEl?.contains(target) || triggerEl?.contains(target)) return;
+        if (eventOccurredWithin(event, menuEl) || eventOccurredWithin(event, triggerEl)) return;
         closeMenu();
     }
 </script>

--- a/frontend/src/ui/chrome/ProfileMenu.svelte
+++ b/frontend/src/ui/chrome/ProfileMenu.svelte
@@ -2,7 +2,9 @@
     import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
     import LockKeyholeIcon from '@lucide/svelte/icons/lock-keyhole';
     import LogOutIcon from '@lucide/svelte/icons/log-out';
+    import PaletteIcon from '@lucide/svelte/icons/palette';
     import { tick } from 'svelte';
+    import AppearancePanel from '../theme/AppearancePanel.svelte';
     import Avatar from './Avatar.svelte';
     import { encryptionEntryVisible, profileLoaded, profileUser } from './profile-store';
 
@@ -16,6 +18,7 @@
     let { onOpen, onEncryptionSettings, onLogout }: Props = $props();
 
     let open = $state(false);
+    let view = $state<'account' | 'appearance'>('account');
     let triggerEl = $state<HTMLButtonElement | null>(null);
     let menuEl = $state<HTMLElement | null>(null);
 
@@ -31,6 +34,7 @@
     }
 
     async function openMenu(): Promise<void> {
+        view = 'account';
         open = true;
         onOpen();
         await tick();
@@ -39,6 +43,7 @@
 
     function closeMenu(returnFocus = false): void {
         open = false;
+        view = 'account';
         if (returnFocus) triggerEl?.focus();
     }
 
@@ -52,13 +57,33 @@
         action();
     }
 
+    async function openAppearance(): Promise<void> {
+        view = 'appearance';
+        await tick();
+        menuEl?.querySelector<HTMLElement>('.appearance-back')?.focus();
+    }
+
+    async function closeAppearance(): Promise<void> {
+        view = 'account';
+        await tick();
+        menuEl?.querySelector<HTMLElement>('#profile-menu-appearance')?.focus();
+    }
+
     function onMenuKeydown(event: KeyboardEvent): void {
         if (!open) return;
         if (event.key === 'Escape') {
             event.preventDefault();
+            // Keep the window-level Escape handler from also closing the
+            // popover after this view has handled the first navigation step.
+            event.stopPropagation();
+            if (view === 'appearance') {
+                void closeAppearance();
+                return;
+            }
             closeMenu(true);
             return;
         }
+        if (view !== 'account') return;
         if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
 
         const items = menuItems();
@@ -122,44 +147,59 @@
 <div
     bind:this={menuEl}
     id="profile-menu"
+    class:appearance-view={view === 'appearance'}
     class="profile-menu"
-    role="menu"
-    aria-labelledby="profile-trigger"
+    role={view === 'account' ? 'menu' : 'dialog'}
+    aria-labelledby={view === 'account' ? 'profile-trigger' : 'appearance-title'}
     tabindex="-1"
     hidden={!open}
     onkeydown={onMenuKeydown}
 >
-    <div class="profile-menu-header">
-        <Avatar user={$profileUser} large />
-        <div class="profile-menu-meta">
-            <div id="profile-menu-name" class="profile-menu-name">{displayName}</div>
-            {#if handle}
-                <div id="profile-menu-handle" class="profile-menu-handle">@{handle}</div>
-            {/if}
+    {#if view === 'appearance'}
+        <AppearancePanel onBack={() => void closeAppearance()} backLabel="Back to account menu" />
+    {:else}
+        <div class="profile-menu-header">
+            <Avatar user={$profileUser} large />
+            <div class="profile-menu-meta">
+                <div id="profile-menu-name" class="profile-menu-name">{displayName}</div>
+                {#if handle}
+                    <div id="profile-menu-handle" class="profile-menu-handle">@{handle}</div>
+                {/if}
+            </div>
         </div>
-    </div>
-    <div class="profile-menu-divider" role="separator"></div>
-    {#if $encryptionEntryVisible}
+        <div class="profile-menu-divider" role="separator"></div>
         <button
-            id="profile-menu-encryption-settings"
+            id="profile-menu-appearance"
             class="profile-menu-item"
             type="button"
             role="menuitem"
-            onclick={() => activate(onEncryptionSettings)}
+            onclick={() => void openAppearance()}
         >
-            <LockKeyholeIcon size={20} strokeWidth={2} aria-hidden="true" />
-            <span>Encryption settings</span>
+            <PaletteIcon size={20} strokeWidth={2} aria-hidden="true" />
+            <span>Appearance</span>
+        </button>
+        {#if $encryptionEntryVisible}
+            <button
+                id="profile-menu-encryption-settings"
+                class="profile-menu-item"
+                type="button"
+                role="menuitem"
+                onclick={() => activate(onEncryptionSettings)}
+            >
+                <LockKeyholeIcon size={20} strokeWidth={2} aria-hidden="true" />
+                <span>Encryption settings</span>
+            </button>
+        {/if}
+        <div class="profile-menu-divider" role="separator"></div>
+        <button
+            id="profile-menu-logout"
+            class="profile-menu-item danger-text"
+            type="button"
+            role="menuitem"
+            onclick={() => activate(onLogout)}
+        >
+            <LogOutIcon size={20} strokeWidth={2} aria-hidden="true" />
+            <span>Log out</span>
         </button>
     {/if}
-    <div class="profile-menu-divider" role="separator"></div>
-    <button
-        id="profile-menu-logout"
-        class="profile-menu-item danger-text"
-        type="button"
-        role="menuitem"
-        onclick={() => activate(onLogout)}
-    >
-        <LogOutIcon size={20} strokeWidth={2} aria-hidden="true" />
-        <span>Log out</span>
-    </button>
 </div>

--- a/frontend/src/ui/chrome/ProfileMenu.svelte
+++ b/frontend/src/ui/chrome/ProfileMenu.svelte
@@ -6,6 +6,7 @@
     import { tick } from 'svelte';
     import { eventOccurredWithin } from '../event-path';
     import AppearancePanel from '../theme/AppearancePanel.svelte';
+    import { recoverThemeTransitionClick } from '../theme/theme-interaction';
     import Avatar from './Avatar.svelte';
     import { encryptionEntryVisible, profileLoaded, profileUser } from './profile-store';
 
@@ -119,6 +120,8 @@
     function onDocumentClick(event: MouseEvent): void {
         if (!open) return;
         if (eventOccurredWithin(event, menuEl) || eventOccurredWithin(event, triggerEl)) return;
+        if (recoverThemeTransitionClick(event, menuEl)
+            || recoverThemeTransitionClick(event, triggerEl)) return;
         closeMenu();
     }
 </script>
@@ -129,6 +132,7 @@
 <button
     bind:this={triggerEl}
     id="profile-trigger"
+    data-theme-hit-target
     class="profile-trigger"
     type="button"
     aria-haspopup="menu"

--- a/frontend/src/ui/chrome/ProfileMenu.svelte
+++ b/frontend/src/ui/chrome/ProfileMenu.svelte
@@ -60,7 +60,7 @@
     async function openAppearance(): Promise<void> {
         view = 'appearance';
         await tick();
-        menuEl?.querySelector<HTMLElement>('.appearance-back')?.focus();
+        menuEl?.querySelector<HTMLElement>('[aria-label="Appearance mode"] [aria-checked="true"]')?.focus();
     }
 
     async function closeAppearance(): Promise<void> {
@@ -156,7 +156,7 @@
     onkeydown={onMenuKeydown}
 >
     {#if view === 'appearance'}
-        <AppearancePanel onBack={() => void closeAppearance()} backLabel="Back to account menu" />
+        <AppearancePanel />
     {:else}
         <div class="profile-menu-header">
             <Avatar user={$profileUser} large />

--- a/frontend/src/ui/event-path.dom.test.ts
+++ b/frontend/src/ui/event-path.dom.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { eventOccurredWithin } from './event-path';
+
+describe('event path containment', () => {
+    it('keeps an interaction inside when reactive DOM updates detach its target', () => {
+        const container = document.createElement('div');
+        const target = document.createElement('button');
+        container.appendChild(target);
+        target.remove();
+
+        const event = {
+            target,
+            composedPath: () => [target, container, document, window],
+        } as unknown as Event;
+
+        expect(container.contains(target)).toBe(false);
+        expect(eventOccurredWithin(event, container)).toBe(true);
+    });
+
+    it('falls back to live containment when composedPath is unavailable', () => {
+        const container = document.createElement('div');
+        const target = document.createElement('button');
+        container.appendChild(target);
+        const event = { target } as unknown as Event;
+
+        expect(eventOccurredWithin(event, container)).toBe(true);
+        expect(eventOccurredWithin(event, null)).toBe(false);
+    });
+});

--- a/frontend/src/ui/event-path.ts
+++ b/frontend/src/ui/event-path.ts
@@ -1,0 +1,19 @@
+/**
+ * Tests the immutable event path before falling back to live DOM containment.
+ * Reactive updates can detach a click target before a delegated document
+ * handler runs, while composedPath() still describes where the click began.
+ */
+export function eventOccurredWithin(event: Event, container: Node | null): boolean {
+    if (!container) return false;
+
+    try {
+        if (typeof event.composedPath === 'function' && event.composedPath().includes(container)) {
+            return true;
+        }
+    } catch {
+        // A closing webview can invalidate the composed path; use the target.
+    }
+
+    const target = event.target;
+    return Boolean(target && 'nodeType' in target && container.contains(target as Node));
+}

--- a/frontend/src/ui/theme/AppearancePanel.dom.test.ts
+++ b/frontend/src/ui/theme/AppearancePanel.dom.test.ts
@@ -1,0 +1,99 @@
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import AppearancePanel from './AppearancePanel.svelte';
+import { setPreferredTheme, setThemeMode, themeController, themeState } from './theme-controller';
+
+let component: Record<string, unknown> | null = null;
+let host: HTMLElement | null = null;
+
+function setup(onBack = vi.fn()): typeof onBack {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    component = mount(AppearancePanel, { target: host, props: { onBack } });
+    flushSync();
+    return onBack;
+}
+
+function click(selector: string): void {
+    const element = host?.querySelector<HTMLElement>(selector);
+    if (!element) throw new Error(`missing ${selector}`);
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 80, clientY: 64 }));
+    flushSync();
+}
+
+afterEach(async () => {
+    setPreferredTheme('light', 'tdrive-light');
+    setPreferredTheme('dark', 'tokyo-night');
+    setThemeMode('system');
+    themeController.destroy();
+    if (component) await unmount(component);
+    host?.remove();
+    component = null;
+    host = null;
+});
+
+describe('AppearancePanel behavior', () => {
+    it('lets System users configure the day and night palettes independently', () => {
+        setup();
+
+        click('[role="tab"][aria-selected="false"]');
+        expect(host?.textContent).toContain('Tokyo Night');
+        expect(host?.textContent).toContain('Dracula');
+
+        click('#appearance-theme-dracula');
+        expect(get(themeState).preference.darkThemeId).toBe('dracula');
+        expect(get(themeState).preference.lightThemeId).toBe('tdrive-light');
+    });
+
+    it('supports arrow-key navigation through appearance modes', () => {
+        setup();
+        const automatic = host?.querySelector<HTMLElement>('#appearance-mode-system');
+        if (!automatic) throw new Error('missing automatic mode');
+
+        automatic.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+        flushSync();
+
+        expect(get(themeState).preference.mode).toBe('light');
+        expect(host?.querySelector('#appearance-mode-light')?.getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('supports keyboard navigation across the automatic day and night pair', () => {
+        setup();
+        const dayTab = host?.querySelector<HTMLElement>('#appearance-system-light');
+        if (!dayTab) throw new Error('missing day palette tab');
+
+        dayTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+        flushSync();
+
+        expect(host?.querySelector('#appearance-system-dark')?.getAttribute('aria-selected')).toBe('true');
+        expect(host?.textContent).toContain('Tokyo Night');
+
+        host?.querySelector<HTMLElement>('#appearance-system-dark')?.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+        );
+        flushSync();
+        expect(host?.querySelector('#appearance-system-light')?.getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('uses roving keyboard selection across the visible palette cards', () => {
+        setup();
+        click('#appearance-mode-dark');
+        const tokyoNight = host?.querySelector<HTMLElement>('#appearance-theme-tokyo-night');
+        if (!tokyoNight) throw new Error('missing Tokyo Night theme');
+
+        tokyoNight.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+        flushSync();
+
+        expect(get(themeState).preference.darkThemeId).toBe('catppuccin-mocha');
+        expect(host?.querySelector('#appearance-theme-catppuccin-mocha')?.getAttribute('aria-checked')).toBe('true');
+    });
+
+    it('returns focus ownership to the account menu through its back action', () => {
+        const onBack = setup();
+
+        click('.appearance-back');
+
+        expect(onBack).toHaveBeenCalledOnce();
+    });
+});

--- a/frontend/src/ui/theme/AppearancePanel.dom.test.ts
+++ b/frontend/src/ui/theme/AppearancePanel.dom.test.ts
@@ -24,7 +24,7 @@ function click(selector: string): void {
 afterEach(async () => {
     setPreferredTheme('light', 'tdrive-light');
     setPreferredTheme('dark', 'tokyo-night');
-    setThemeMode('system');
+    setThemeMode('dark');
     themeController.destroy();
     if (component) await unmount(component);
     host?.remove();
@@ -33,25 +33,27 @@ afterEach(async () => {
 });
 
 describe('AppearancePanel behavior', () => {
-    it('keeps System mode free of nested palette controls', () => {
+    it('shows only Light and Dark modes with the selected palette', () => {
         setup();
 
-        expect(host?.textContent).toContain('System');
+        expect(host?.textContent).not.toContain('System');
+        expect(host?.querySelectorAll('[data-appearance-mode]')).toHaveLength(2);
         expect(host?.textContent).not.toContain('Automatic pair');
         expect(host?.querySelector('.appearance-toggle')).toBeNull();
-        expect(host?.querySelector('.palette-section')).toBeNull();
+        expect(host?.querySelector('.palette-section')).not.toBeNull();
     });
 
     it('supports arrow-key navigation through appearance modes', () => {
         setup();
-        const system = host?.querySelector<HTMLElement>('#appearance-mode-system');
-        if (!system) throw new Error('missing system mode');
+        click('#appearance-mode-light');
+        const light = host?.querySelector<HTMLElement>('#appearance-mode-light');
+        if (!light) throw new Error('missing light mode');
 
-        system.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+        light.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
         flushSync();
 
-        expect(get(themeState).preference.mode).toBe('light');
-        expect(host?.querySelector('#appearance-mode-light')?.getAttribute('aria-checked')).toBe('true');
+        expect(get(themeState).preference.mode).toBe('dark');
+        expect(host?.querySelector('#appearance-mode-dark')?.getAttribute('aria-checked')).toBe('true');
     });
 
     it('uses roving keyboard selection across the visible palette cards', () => {
@@ -69,14 +71,15 @@ describe('AppearancePanel behavior', () => {
 
     it('supports keyboard boundaries without changing selection for unrelated keys', () => {
         setup();
-        const system = host?.querySelector<HTMLElement>('#appearance-mode-system');
-        if (!system) throw new Error('missing system mode');
+        click('#appearance-mode-light');
+        const light = host?.querySelector<HTMLElement>('#appearance-mode-light');
+        if (!light) throw new Error('missing light mode');
 
-        system.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+        light.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
         flushSync();
-        expect(get(themeState).preference.mode).toBe('system');
+        expect(get(themeState).preference.mode).toBe('light');
 
-        system.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+        light.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
         flushSync();
         expect(get(themeState).preference.mode).toBe('dark');
 
@@ -106,21 +109,21 @@ describe('AppearancePanel behavior', () => {
         expect(get(themeState).preference.darkThemeId).toBe('gruvbox-dark');
     });
 
-    it('remembers Light and Dark choices when returning to System', () => {
+    it('remembers palette choices while switching between Light and Dark', () => {
         setup();
 
         click('#appearance-mode-light');
         click('#appearance-theme-catppuccin-latte');
         click('#appearance-mode-dark');
         click('#appearance-theme-dracula');
-        click('#appearance-mode-system');
+        click('#appearance-mode-light');
 
         expect(get(themeState).preference).toMatchObject({
-            mode: 'system',
+            mode: 'light',
             lightThemeId: 'catppuccin-latte',
             darkThemeId: 'dracula',
         });
-        expect(host?.querySelector('.palette-section')).toBeNull();
+        expect(host?.querySelector('#appearance-theme-catppuccin-latte')?.getAttribute('aria-checked')).toBe('true');
     });
 
     it('shows palette names without descriptions or auxiliary footer copy', () => {
@@ -143,6 +146,6 @@ describe('AppearancePanel behavior', () => {
         await tick();
         await Promise.resolve();
 
-        expect(host?.querySelector('#appearance-mode-system')).toBe(document.activeElement);
+        expect(host?.querySelector('#appearance-mode-dark')).toBe(document.activeElement);
     });
 });

--- a/frontend/src/ui/theme/AppearancePanel.dom.test.ts
+++ b/frontend/src/ui/theme/AppearancePanel.dom.test.ts
@@ -127,7 +127,11 @@ describe('AppearancePanel behavior', () => {
         setup();
         click('#appearance-mode-dark');
 
+        const tokyoNight = host?.querySelector('#appearance-theme-tokyo-night');
+        const preview = tokyoNight?.querySelector('.theme-preview');
+        const label = tokyoNight?.querySelector('.theme-label');
         expect(host?.textContent).toContain('Tokyo Night');
+        expect(label?.previousElementSibling).toBe(preview);
         expect(host?.textContent).not.toContain('TDrive’s original midnight-blue glow.');
         expect(host?.textContent).not.toContain('Changes are previewed instantly and saved on this device.');
         expect(host?.querySelector('.theme-description')).toBeNull();

--- a/frontend/src/ui/theme/AppearancePanel.dom.test.ts
+++ b/frontend/src/ui/theme/AppearancePanel.dom.test.ts
@@ -1,18 +1,17 @@
 import { get } from 'svelte/store';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { flushSync, mount, tick, unmount } from 'svelte';
 import AppearancePanel from './AppearancePanel.svelte';
 import { setPreferredTheme, setThemeMode, themeController, themeState } from './theme-controller';
 
 let component: Record<string, unknown> | null = null;
 let host: HTMLElement | null = null;
 
-function setup(onBack = vi.fn()): typeof onBack {
+function setup(autofocus = false): void {
     host = document.createElement('div');
     document.body.appendChild(host);
-    component = mount(AppearancePanel, { target: host, props: { onBack } });
+    component = mount(AppearancePanel, { target: host, props: { autofocus } });
     flushSync();
-    return onBack;
 }
 
 function click(selector: string): void {
@@ -34,46 +33,25 @@ afterEach(async () => {
 });
 
 describe('AppearancePanel behavior', () => {
-    it('lets System users configure the day and night palettes independently', () => {
+    it('keeps System mode free of nested palette controls', () => {
         setup();
 
-        click('[role="tab"][aria-selected="false"]');
-        expect(host?.textContent).toContain('Tokyo Night');
-        expect(host?.textContent).toContain('Dracula');
-
-        click('#appearance-theme-dracula');
-        expect(get(themeState).preference.darkThemeId).toBe('dracula');
-        expect(get(themeState).preference.lightThemeId).toBe('tdrive-light');
+        expect(host?.textContent).toContain('System');
+        expect(host?.textContent).not.toContain('Automatic pair');
+        expect(host?.querySelector('.appearance-toggle')).toBeNull();
+        expect(host?.querySelector('.palette-section')).toBeNull();
     });
 
     it('supports arrow-key navigation through appearance modes', () => {
         setup();
-        const automatic = host?.querySelector<HTMLElement>('#appearance-mode-system');
-        if (!automatic) throw new Error('missing automatic mode');
+        const system = host?.querySelector<HTMLElement>('#appearance-mode-system');
+        if (!system) throw new Error('missing system mode');
 
-        automatic.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+        system.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
         flushSync();
 
         expect(get(themeState).preference.mode).toBe('light');
         expect(host?.querySelector('#appearance-mode-light')?.getAttribute('aria-checked')).toBe('true');
-    });
-
-    it('supports keyboard navigation across the automatic day and night pair', () => {
-        setup();
-        const dayTab = host?.querySelector<HTMLElement>('#appearance-system-light');
-        if (!dayTab) throw new Error('missing day palette tab');
-
-        dayTab.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
-        flushSync();
-
-        expect(host?.querySelector('#appearance-system-dark')?.getAttribute('aria-selected')).toBe('true');
-        expect(host?.textContent).toContain('Tokyo Night');
-
-        host?.querySelector<HTMLElement>('#appearance-system-dark')?.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
-        );
-        flushSync();
-        expect(host?.querySelector('#appearance-system-light')?.getAttribute('aria-selected')).toBe('true');
     });
 
     it('uses roving keyboard selection across the visible palette cards', () => {
@@ -89,11 +67,78 @@ describe('AppearancePanel behavior', () => {
         expect(host?.querySelector('#appearance-theme-catppuccin-mocha')?.getAttribute('aria-checked')).toBe('true');
     });
 
-    it('returns focus ownership to the account menu through its back action', () => {
-        const onBack = setup();
+    it('supports keyboard boundaries without changing selection for unrelated keys', () => {
+        setup();
+        const system = host?.querySelector<HTMLElement>('#appearance-mode-system');
+        if (!system) throw new Error('missing system mode');
 
-        click('.appearance-back');
+        system.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+        flushSync();
+        expect(get(themeState).preference.mode).toBe('system');
 
-        expect(onBack).toHaveBeenCalledOnce();
+        system.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+        flushSync();
+        expect(get(themeState).preference.mode).toBe('dark');
+
+        const tokyoNight = host?.querySelector<HTMLElement>('#appearance-theme-tokyo-night');
+        if (!tokyoNight) throw new Error('missing Tokyo Night theme');
+        tokyoNight.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+        tokyoNight.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+        flushSync();
+        expect(get(themeState).preference.darkThemeId).toBe('nord');
+
+        host?.querySelector<HTMLElement>('#appearance-theme-nord')?.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Home', bubbles: true }),
+        );
+        flushSync();
+        expect(get(themeState).preference.darkThemeId).toBe('tokyo-night');
+
+        host?.querySelector<HTMLElement>('#appearance-theme-tokyo-night')?.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+        );
+        flushSync();
+        expect(get(themeState).preference.darkThemeId).toBe('nord');
+
+        host?.querySelector<HTMLElement>('#appearance-theme-nord')?.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }),
+        );
+        flushSync();
+        expect(get(themeState).preference.darkThemeId).toBe('gruvbox-dark');
+    });
+
+    it('remembers Light and Dark choices when returning to System', () => {
+        setup();
+
+        click('#appearance-mode-light');
+        click('#appearance-theme-catppuccin-latte');
+        click('#appearance-mode-dark');
+        click('#appearance-theme-dracula');
+        click('#appearance-mode-system');
+
+        expect(get(themeState).preference).toMatchObject({
+            mode: 'system',
+            lightThemeId: 'catppuccin-latte',
+            darkThemeId: 'dracula',
+        });
+        expect(host?.querySelector('.palette-section')).toBeNull();
+    });
+
+    it('shows palette names without descriptions or auxiliary footer copy', () => {
+        setup();
+        click('#appearance-mode-dark');
+
+        expect(host?.textContent).toContain('Tokyo Night');
+        expect(host?.textContent).not.toContain('TDrive’s original midnight-blue glow.');
+        expect(host?.textContent).not.toContain('Changes are previewed instantly and saved on this device.');
+        expect(host?.querySelector('.theme-description')).toBeNull();
+        expect(host?.querySelector('.appearance-back')).toBeNull();
+    });
+
+    it('autofocuses the selected mode when opened as a dialog', async () => {
+        setup(true);
+        await tick();
+        await Promise.resolve();
+
+        expect(host?.querySelector('#appearance-mode-system')).toBe(document.activeElement);
     });
 });

--- a/frontend/src/ui/theme/AppearancePanel.svelte
+++ b/frontend/src/ui/theme/AppearancePanel.svelte
@@ -117,6 +117,7 @@
                 <button
                     id={`appearance-mode-${option.id}`}
                     data-appearance-mode={option.id}
+                    data-theme-hit-target
                     class:selected
                     class="mode-card"
                     type="button"
@@ -143,6 +144,7 @@
                 {@const selected = selectedThemeId === theme.id}
                 <button
                     id={`appearance-theme-${theme.id}`}
+                    data-theme-hit-target
                     class:selected
                     class="theme-card"
                     type="button"

--- a/frontend/src/ui/theme/AppearancePanel.svelte
+++ b/frontend/src/ui/theme/AppearancePanel.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import CheckIcon from '@lucide/svelte/icons/check';
-    import LaptopIcon from '@lucide/svelte/icons/laptop';
     import MoonIcon from '@lucide/svelte/icons/moon';
     import SunIcon from '@lucide/svelte/icons/sun';
     import { onMount, tick } from 'svelte';
@@ -25,28 +24,23 @@
     interface ModeOption {
         id: ThemeMode;
         label: string;
-        icon: typeof LaptopIcon;
+        icon: typeof SunIcon;
     }
 
     let { autofocus = false }: Props = $props();
     let panel = $state<HTMLElement | null>(null);
 
     const modeOptions: readonly ModeOption[] = [
-        { id: 'system', label: 'System', icon: LaptopIcon },
         { id: 'light', label: 'Light', icon: SunIcon },
         { id: 'dark', label: 'Dark', icon: MoonIcon },
     ];
 
-    const activeAppearance = $derived<ThemeAppearance | null>(
-        $themeState.preference.mode === 'system' ? null : $themeState.preference.mode,
-    );
-    const visibleThemes = $derived(activeAppearance ? themesForAppearance(activeAppearance) : []);
+    const activeAppearance = $derived<ThemeAppearance>($themeState.preference.mode);
+    const visibleThemes = $derived(themesForAppearance(activeAppearance));
     const selectedThemeId = $derived(
         activeAppearance === 'light'
             ? $themeState.preference.lightThemeId
-            : activeAppearance === 'dark'
-                ? $themeState.preference.darkThemeId
-                : null,
+            : $themeState.preference.darkThemeId,
     );
     const resolvedThemeName = $derived(getThemeDefinition($themeState.resolvedThemeId).name);
 
@@ -139,49 +133,47 @@
         </div>
     </div>
 
-    {#if activeAppearance}
-        <div id="appearance-palette-panel" class="appearance-section palette-section">
-            <div class="section-heading">
-                <span>{activeAppearance === 'light' ? 'Light palettes' : 'Dark palettes'}</span>
-                <span class="theme-count">{visibleThemes.length}</span>
-            </div>
-            <div class="theme-grid" role="radiogroup" aria-label="Theme palette">
-                {#each visibleThemes as theme, index (theme.id)}
-                    {@const selected = selectedThemeId === theme.id}
-                    <button
-                        id={`appearance-theme-${theme.id}`}
-                        class:selected
-                        class="theme-card"
-                        type="button"
-                        role="radio"
-                        aria-checked={selected}
-                        aria-label={theme.name}
-                        tabindex={selected ? 0 : -1}
-                        style={previewStyle(theme)}
-                        onclick={(event) => selectTheme(event, theme)}
-                        onkeydown={(event) => void moveThemeFocus(event, index)}
-                    >
-                        <span class="theme-preview" aria-hidden="true">
-                            <span class="preview-sidebar">
-                                <span></span><span></span><span></span>
-                            </span>
-                            <span class="preview-content">
-                                <span class="preview-topline"></span>
-                                <span class="preview-row"><i></i><b></b></span>
-                                <span class="preview-row short"><i></i><b></b></span>
-                            </span>
-                        </span>
-                        <span class="theme-label">
-                            <span class="theme-name">{theme.name}</span>
-                        </span>
-                        <span class="theme-check" aria-hidden="true">
-                            {#if selected}<CheckIcon size={13} strokeWidth={3} />{/if}
-                        </span>
-                    </button>
-                {/each}
-            </div>
+    <div id="appearance-palette-panel" class="appearance-section palette-section">
+        <div class="section-heading">
+            <span>{activeAppearance === 'light' ? 'Light palettes' : 'Dark palettes'}</span>
+            <span class="theme-count">{visibleThemes.length}</span>
         </div>
-    {/if}
+        <div class="theme-grid" role="radiogroup" aria-label="Theme palette">
+            {#each visibleThemes as theme, index (theme.id)}
+                {@const selected = selectedThemeId === theme.id}
+                <button
+                    id={`appearance-theme-${theme.id}`}
+                    class:selected
+                    class="theme-card"
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    aria-label={theme.name}
+                    tabindex={selected ? 0 : -1}
+                    style={previewStyle(theme)}
+                    onclick={(event) => selectTheme(event, theme)}
+                    onkeydown={(event) => void moveThemeFocus(event, index)}
+                >
+                    <span class="theme-preview" aria-hidden="true">
+                        <span class="preview-sidebar">
+                            <span></span><span></span><span></span>
+                        </span>
+                        <span class="preview-content">
+                            <span class="preview-topline"></span>
+                            <span class="preview-row"><i></i><b></b></span>
+                            <span class="preview-row short"><i></i><b></b></span>
+                        </span>
+                    </span>
+                    <span class="theme-label">
+                        <span class="theme-name">{theme.name}</span>
+                    </span>
+                    <span class="theme-check" aria-hidden="true">
+                        {#if selected}<CheckIcon size={13} strokeWidth={3} />{/if}
+                    </span>
+                </button>
+            {/each}
+        </div>
+    </div>
 
     <p class="appearance-status" aria-live="polite">{resolvedThemeName} is active.</p>
 </section>
@@ -200,7 +192,11 @@
     .appearance-header {
         display: flex;
         align-items: center;
+        justify-content: flex-start;
+        height: auto;
+        min-height: 54px;
         padding: 8px 8px 16px;
+        border-bottom: 1px solid var(--color-border-soft);
     }
 
     .appearance-header h2 {
@@ -212,7 +208,7 @@
     }
 
     .appearance-section { padding: 0 8px 14px; }
-    .mode-section { padding-bottom: 19px; }
+    .mode-section { padding: 14px 8px 19px; }
 
     .section-heading {
         display: flex;
@@ -229,7 +225,7 @@
 
     .mode-grid {
         display: grid;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 7px;
     }
 

--- a/frontend/src/ui/theme/AppearancePanel.svelte
+++ b/frontend/src/ui/theme/AppearancePanel.svelte
@@ -122,6 +122,7 @@
                 {@const selected = $themeState.preference.mode === option.id}
                 <button
                     id={`appearance-mode-${option.id}`}
+                    data-appearance-mode={option.id}
                     class:selected
                     class="mode-card"
                     type="button"

--- a/frontend/src/ui/theme/AppearancePanel.svelte
+++ b/frontend/src/ui/theme/AppearancePanel.svelte
@@ -1,0 +1,561 @@
+<script lang="ts">
+    import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
+    import CheckIcon from '@lucide/svelte/icons/check';
+    import LaptopIcon from '@lucide/svelte/icons/laptop';
+    import MoonIcon from '@lucide/svelte/icons/moon';
+    import SparklesIcon from '@lucide/svelte/icons/sparkles';
+    import SunIcon from '@lucide/svelte/icons/sun';
+    import { onMount, tick } from 'svelte';
+    import {
+        getThemeDefinition,
+        themesForAppearance,
+        type ThemeAppearance,
+        type ThemeDefinition,
+        type ThemeMode,
+    } from './theme-model';
+    import {
+        setPreferredTheme,
+        setThemeMode,
+        themeState,
+        type ThemeChangeOrigin,
+    } from './theme-controller';
+
+    interface Props {
+        onBack: () => void;
+        backLabel?: string;
+        autofocus?: boolean;
+    }
+
+    interface ModeOption {
+        id: ThemeMode;
+        label: string;
+        description: string;
+        icon: typeof LaptopIcon;
+    }
+
+    let { onBack, backLabel = 'Back', autofocus = false }: Props = $props();
+    let backButton = $state<HTMLButtonElement | null>(null);
+    let systemPalette = $state<ThemeAppearance>('light');
+
+    const modeOptions: readonly ModeOption[] = [
+        { id: 'system', label: 'Automatic', description: 'Follow your system', icon: LaptopIcon },
+        { id: 'light', label: 'Light', description: 'Always bright', icon: SunIcon },
+        { id: 'dark', label: 'Dark', description: 'Always dim', icon: MoonIcon },
+    ];
+
+    const activeAppearance = $derived<ThemeAppearance>(
+        $themeState.preference.mode === 'system' ? systemPalette : $themeState.preference.mode,
+    );
+    const visibleThemes = $derived(themesForAppearance(activeAppearance));
+    const selectedThemeId = $derived(
+        activeAppearance === 'light'
+            ? $themeState.preference.lightThemeId
+            : $themeState.preference.darkThemeId,
+    );
+    const resolvedThemeName = $derived(getThemeDefinition($themeState.resolvedThemeId).name);
+
+    onMount(() => {
+        systemPalette = $themeState.systemAppearance;
+        if (autofocus) void tick().then(() => backButton?.focus());
+    });
+
+    function originFrom(event: MouseEvent): ThemeChangeOrigin {
+        return { x: event.clientX, y: event.clientY };
+    }
+
+    function selectMode(event: MouseEvent, mode: ThemeMode): void {
+        setThemeMode(mode, originFrom(event));
+        if (mode !== 'system') systemPalette = mode;
+    }
+
+    function selectTheme(event: MouseEvent, theme: ThemeDefinition): void {
+        setPreferredTheme(theme.appearance, theme.id, originFrom(event));
+    }
+
+    async function moveModeFocus(event: KeyboardEvent, index: number): Promise<void> {
+        const nextIndex = nextRadioIndex(event, index, modeOptions.length);
+        if (nextIndex === null) return;
+
+        event.preventDefault();
+        const nextMode = modeOptions[nextIndex].id;
+        setThemeMode(nextMode);
+        if (nextMode !== 'system') systemPalette = nextMode;
+        await tick();
+        document.getElementById(`appearance-mode-${nextMode}`)?.focus();
+    }
+
+    async function moveThemeFocus(event: KeyboardEvent, index: number): Promise<void> {
+        const nextIndex = nextRadioIndex(event, index, visibleThemes.length);
+        if (nextIndex === null) return;
+
+        event.preventDefault();
+        const nextTheme = visibleThemes[nextIndex];
+        setPreferredTheme(nextTheme.appearance, nextTheme.id);
+        await tick();
+        document.getElementById(`appearance-theme-${nextTheme.id}`)?.focus();
+    }
+
+    async function moveSystemPaletteFocus(event: KeyboardEvent): Promise<void> {
+        if (!['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+            return;
+        }
+
+        event.preventDefault();
+        const nextAppearance = event.key === 'ArrowLeft'
+            || event.key === 'ArrowUp'
+            || event.key === 'Home'
+            ? 'light'
+            : 'dark';
+        systemPalette = nextAppearance;
+        await tick();
+        document.getElementById(`appearance-system-${nextAppearance}`)?.focus();
+    }
+
+    function nextRadioIndex(event: KeyboardEvent, index: number, length: number): number | null {
+        if (event.key === 'Home') return 0;
+        if (event.key === 'End') return length - 1;
+        if (event.key === 'ArrowRight' || event.key === 'ArrowDown') return (index + 1) % length;
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') return (index - 1 + length) % length;
+        return null;
+    }
+
+    function previewStyle(theme: ThemeDefinition): string {
+        const [canvas, surface, accent, text] = theme.preview;
+        return [
+            `--preview-canvas:${canvas}`,
+            `--preview-surface:${surface}`,
+            `--preview-accent:${accent}`,
+            `--preview-text:${text}`,
+        ].join(';');
+    }
+</script>
+
+<section class="appearance-panel" aria-labelledby="appearance-title">
+    <header class="appearance-header">
+        <button bind:this={backButton} class="appearance-back" type="button" onclick={onBack} aria-label={backLabel}>
+            <ArrowLeftIcon size={17} strokeWidth={2.2} aria-hidden="true" />
+        </button>
+        <div>
+            <div class="appearance-eyebrow"><SparklesIcon size={12} aria-hidden="true" /> Personalize</div>
+            <h2 id="appearance-title">Appearance</h2>
+        </div>
+    </header>
+
+    <div class="appearance-section">
+        <div class="section-heading">
+            <span>Mode</span>
+            <span class="section-value">
+                {modeOptions.find((option) => option.id === $themeState.preference.mode)?.description}
+            </span>
+        </div>
+        <div class="mode-grid" role="radiogroup" aria-label="Appearance mode">
+            {#each modeOptions as option, index (option.id)}
+                {@const Icon = option.icon}
+                {@const selected = $themeState.preference.mode === option.id}
+                <button
+                    id={`appearance-mode-${option.id}`}
+                    class:selected
+                    class="mode-card"
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    tabindex={selected ? 0 : -1}
+                    onclick={(event) => selectMode(event, option.id)}
+                    onkeydown={(event) => void moveModeFocus(event, index)}
+                >
+                    <span class="mode-icon"><Icon size={17} strokeWidth={2} aria-hidden="true" /></span>
+                    <span>{option.label}</span>
+                </button>
+            {/each}
+        </div>
+    </div>
+
+    {#if $themeState.preference.mode === 'system'}
+        <div class="system-pair" aria-label="Automatic theme pair">
+            <div class="system-copy">
+                <strong>Automatic pair</strong>
+                <span>Choose a palette for each system appearance.</span>
+            </div>
+            <div class="appearance-toggle" role="tablist" aria-label="System appearance palette">
+                <button
+                    id="appearance-system-light"
+                    class:active={systemPalette === 'light'}
+                    type="button"
+                    role="tab"
+                    aria-selected={systemPalette === 'light'}
+                    aria-controls="appearance-palette-panel"
+                    tabindex={systemPalette === 'light' ? 0 : -1}
+                    onclick={() => (systemPalette = 'light')}
+                    onkeydown={(event) => void moveSystemPaletteFocus(event)}
+                ><SunIcon size={13} aria-hidden="true" /> Day</button>
+                <button
+                    id="appearance-system-dark"
+                    class:active={systemPalette === 'dark'}
+                    type="button"
+                    role="tab"
+                    aria-selected={systemPalette === 'dark'}
+                    aria-controls="appearance-palette-panel"
+                    tabindex={systemPalette === 'dark' ? 0 : -1}
+                    onclick={() => (systemPalette = 'dark')}
+                    onkeydown={(event) => void moveSystemPaletteFocus(event)}
+                ><MoonIcon size={13} aria-hidden="true" /> Night</button>
+            </div>
+        </div>
+    {/if}
+
+    <div
+        id="appearance-palette-panel"
+        class="appearance-section palette-section"
+        role={$themeState.preference.mode === 'system' ? 'tabpanel' : undefined}
+        aria-labelledby={$themeState.preference.mode === 'system' ? `appearance-system-${systemPalette}` : undefined}
+    >
+        <div class="section-heading">
+            <span>{activeAppearance === 'light' ? 'Light palettes' : 'Dark palettes'}</span>
+            <span class="theme-count">{visibleThemes.length}</span>
+        </div>
+        <div class="theme-grid" role="radiogroup" aria-label="Theme palette">
+            {#each visibleThemes as theme, index (theme.id)}
+                {@const selected = selectedThemeId === theme.id}
+                <button
+                    id={`appearance-theme-${theme.id}`}
+                    class:selected
+                    class="theme-card"
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    aria-label={`${theme.name}: ${theme.description}`}
+                    tabindex={selected ? 0 : -1}
+                    style={previewStyle(theme)}
+                    onclick={(event) => selectTheme(event, theme)}
+                    onkeydown={(event) => void moveThemeFocus(event, index)}
+                >
+                    <span class="theme-preview" aria-hidden="true">
+                        <span class="preview-sidebar">
+                            <span></span><span></span><span></span>
+                        </span>
+                        <span class="preview-content">
+                            <span class="preview-topline"></span>
+                            <span class="preview-row"><i></i><b></b></span>
+                            <span class="preview-row short"><i></i><b></b></span>
+                        </span>
+                    </span>
+                    <span class="theme-meta">
+                        <span class="theme-name">{theme.name}</span>
+                        <span class="theme-description">{theme.description}</span>
+                    </span>
+                    <span class="theme-check" aria-hidden="true">
+                        {#if selected}<CheckIcon size={13} strokeWidth={3} />{/if}
+                    </span>
+                </button>
+            {/each}
+        </div>
+    </div>
+
+    <p class="appearance-status" aria-live="polite">{resolvedThemeName} is active.</p>
+</section>
+
+<style>
+    .appearance-panel {
+        width: min(390px, calc(100vw - 32px));
+        max-height: min(680px, calc(100vh - 92px));
+        overflow: auto;
+        scrollbar-width: none;
+        color: var(--color-text);
+    }
+
+    .appearance-panel::-webkit-scrollbar { display: none; }
+
+    .appearance-header {
+        display: flex;
+        align-items: center;
+        gap: 11px;
+        padding: 8px 8px 14px;
+    }
+
+    .appearance-header h2 {
+        margin: 1px 0 0;
+        color: var(--color-text);
+        font-size: 1rem;
+        font-weight: 800;
+        letter-spacing: 0;
+    }
+
+    .appearance-eyebrow {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        color: var(--color-accent);
+        font-size: 0.65rem;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
+
+    .appearance-back {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 34px;
+        height: 34px;
+        padding: 0;
+        color: var(--color-text-soft);
+        background: var(--overlay-white-1);
+        border: 1px solid var(--color-border-soft);
+        border-radius: 10px;
+        cursor: pointer;
+        transition: transform var(--motion-fast) var(--ease-standard),
+            background var(--motion-fast) var(--ease-standard),
+            border-color var(--motion-fast) var(--ease-standard);
+    }
+
+    .appearance-back:hover { background: var(--overlay-white-2); border-color: var(--color-border); }
+    .appearance-back:active { transform: scale(0.95); }
+    .appearance-back:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+    .appearance-section { padding: 0 8px 14px; }
+
+    .section-heading {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        min-height: 20px;
+        margin-bottom: 8px;
+        color: var(--color-text-muted);
+        font-size: 0.69rem;
+        font-weight: 800;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+    }
+
+    .section-value {
+        color: var(--color-text-subtle);
+        font-size: 0.68rem;
+        font-weight: 700;
+        letter-spacing: 0;
+        text-transform: none;
+    }
+
+    .mode-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 7px;
+    }
+
+    .mode-card {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        min-height: 68px;
+        padding: 8px;
+        color: var(--color-text-muted);
+        background: var(--overlay-white-1);
+        border: 1px solid var(--color-border-soft);
+        border-radius: 12px;
+        font-size: 0.75rem;
+        font-weight: 750;
+        cursor: pointer;
+        transition: transform var(--motion-med) var(--ease-standard),
+            background var(--motion-med) var(--ease-standard),
+            border-color var(--motion-med) var(--ease-standard),
+            color var(--motion-med) var(--ease-standard),
+            box-shadow var(--motion-med) var(--ease-standard);
+    }
+
+    .mode-card:hover { transform: translateY(-1px); color: var(--color-text); }
+    .mode-card:active { transform: translateY(0) scale(0.98); }
+    .mode-card:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+    .mode-card.selected {
+        color: var(--color-accent);
+        background: var(--overlay-accent-1);
+        border-color: var(--overlay-accent-3);
+        box-shadow: 0 7px 20px color-mix(in srgb, var(--color-accent) 9%, transparent);
+    }
+
+    .mode-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 26px;
+        height: 26px;
+        border-radius: 8px;
+        background: var(--overlay-white-1);
+    }
+
+    .mode-card.selected .mode-icon { background: var(--overlay-accent-2); }
+
+    .system-pair {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin: 0 8px 14px;
+        padding: 10px 11px;
+        background: linear-gradient(135deg, var(--overlay-accent-1), var(--overlay-white-1));
+        border: 1px solid var(--color-border-soft);
+        border-radius: 12px;
+    }
+
+    .system-copy { display: flex; flex-direction: column; min-width: 0; }
+    .system-copy strong { color: var(--color-text); font-size: 0.76rem; }
+    .system-copy span { margin-top: 2px; color: var(--color-text-muted); font-size: 0.68rem; line-height: 1.3; }
+
+    .appearance-toggle {
+        display: flex;
+        flex: 0 0 auto;
+        padding: 3px;
+        background: var(--color-surface-0);
+        border: 1px solid var(--color-border-soft);
+        border-radius: 9px;
+    }
+
+    .appearance-toggle button {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        min-height: 26px;
+        padding: 0 7px;
+        color: var(--color-text-muted);
+        background: transparent;
+        border: 0;
+        border-radius: 6px;
+        font-size: 0.68rem;
+        font-weight: 750;
+        cursor: pointer;
+    }
+
+    .appearance-toggle button.active {
+        color: var(--color-text);
+        background: var(--color-surface-2);
+        box-shadow: var(--shadow-sm);
+    }
+
+    .appearance-toggle button:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+
+    .palette-section { padding-bottom: 9px; }
+    .theme-count {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 20px;
+        height: 18px;
+        padding: 0 5px;
+        color: var(--color-text-subtle);
+        background: var(--overlay-white-1);
+        border-radius: 999px;
+        font-size: 0.68rem;
+    }
+
+    .theme-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+
+    .theme-card {
+        position: relative;
+        display: grid;
+        grid-template-rows: 62px auto;
+        gap: 8px;
+        min-width: 0;
+        padding: 7px;
+        overflow: hidden;
+        color: var(--color-text);
+        text-align: left;
+        background: var(--overlay-white-1);
+        border: 1px solid var(--color-border-soft);
+        border-radius: 13px;
+        cursor: pointer;
+        transition: transform var(--motion-med) var(--ease-standard),
+            border-color var(--motion-med) var(--ease-standard),
+            box-shadow var(--motion-med) var(--ease-standard),
+            background var(--motion-med) var(--ease-standard);
+    }
+
+    .theme-card:hover { transform: translateY(-2px); border-color: var(--color-border); }
+    .theme-card:active { transform: translateY(0) scale(0.985); }
+    .theme-card:focus-visible { outline: none; box-shadow: var(--focus-ring); }
+    .theme-card.selected {
+        background: var(--overlay-accent-1);
+        border-color: var(--color-accent);
+        box-shadow: 0 9px 24px color-mix(in srgb, var(--color-accent) 12%, transparent);
+    }
+
+    .theme-preview {
+        display: grid;
+        grid-template-columns: 32px 1fr;
+        overflow: hidden;
+        background: var(--preview-canvas);
+        border: 1px solid color-mix(in srgb, var(--preview-text) 13%, transparent);
+        border-radius: 9px;
+        box-shadow: var(--shadow-sm);
+    }
+
+    .preview-sidebar {
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+        padding: 9px 6px;
+        background: var(--preview-surface);
+    }
+
+    .preview-sidebar span { width: 100%; height: 3px; background: color-mix(in srgb, var(--preview-text) 22%, transparent); border-radius: 3px; }
+    .preview-sidebar span:first-child { background: var(--preview-accent); }
+    .preview-sidebar span:last-child { width: 70%; }
+
+    .preview-content { display: flex; flex-direction: column; gap: 7px; padding: 8px; }
+    .preview-topline { width: 72%; height: 4px; background: color-mix(in srgb, var(--preview-text) 62%, transparent); border-radius: 4px; }
+    .preview-row { display: flex; align-items: center; gap: 5px; }
+    .preview-row i { width: 7px; height: 7px; background: var(--preview-accent); border-radius: 2px; }
+    .preview-row b { width: 64%; height: 3px; background: color-mix(in srgb, var(--preview-text) 28%, transparent); border-radius: 4px; }
+    .preview-row.short b { width: 42%; }
+
+    .theme-meta { display: flex; flex-direction: column; min-width: 0; padding: 0 2px 2px; }
+    .theme-name { overflow: hidden; font-size: 0.75rem; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
+    .theme-description { margin-top: 2px; overflow: hidden; color: var(--color-text-muted); font-size: 0.68rem; text-overflow: ellipsis; white-space: nowrap; }
+
+    .theme-check {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        height: 20px;
+        color: var(--color-on-accent);
+        background: var(--color-accent);
+        border: 2px solid var(--preview-canvas);
+        border-radius: 999px;
+        opacity: 0;
+        transform: scale(0.75);
+        transition: opacity var(--motion-med) var(--ease-standard), transform var(--motion-med) var(--ease-standard);
+    }
+
+    .theme-card.selected .theme-check { opacity: 1; transform: scale(1); }
+
+    .appearance-status {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
+    @media (max-width: 460px) {
+        .appearance-panel { width: min(350px, calc(100vw - 24px)); }
+        .theme-grid { grid-template-columns: 1fr; }
+        .system-pair { align-items: flex-start; flex-direction: column; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .appearance-back,
+        .mode-card,
+        .theme-card,
+        .theme-check { transition: none; }
+
+        .mode-card:hover,
+        .theme-card:hover { transform: none; }
+    }
+</style>

--- a/frontend/src/ui/theme/AppearancePanel.svelte
+++ b/frontend/src/ui/theme/AppearancePanel.svelte
@@ -25,7 +25,6 @@
     interface ModeOption {
         id: ThemeMode;
         label: string;
-        description: string;
         icon: typeof LaptopIcon;
     }
 
@@ -33,9 +32,9 @@
     let panel = $state<HTMLElement | null>(null);
 
     const modeOptions: readonly ModeOption[] = [
-        { id: 'system', label: 'System', description: 'Follow your system', icon: LaptopIcon },
-        { id: 'light', label: 'Light', description: 'Always bright', icon: SunIcon },
-        { id: 'dark', label: 'Dark', description: 'Always dim', icon: MoonIcon },
+        { id: 'system', label: 'System', icon: LaptopIcon },
+        { id: 'light', label: 'Light', icon: SunIcon },
+        { id: 'dark', label: 'Dark', icon: MoonIcon },
     ];
 
     const activeAppearance = $derived<ThemeAppearance | null>(
@@ -116,13 +115,7 @@
         <h2 id="appearance-title">Appearance</h2>
     </header>
 
-    <div class="appearance-section">
-        <div class="section-heading">
-            <span>Mode</span>
-            <span class="section-value">
-                {modeOptions.find((option) => option.id === $themeState.preference.mode)?.description}
-            </span>
-        </div>
+    <div class="appearance-section mode-section">
         <div class="mode-grid" role="radiogroup" aria-label="Appearance mode">
             {#each modeOptions as option, index (option.id)}
                 {@const Icon = option.icon}
@@ -177,7 +170,7 @@
                                 <span class="preview-row short"><i></i><b></b></span>
                             </span>
                         </span>
-                        <span class="theme-meta">
+                        <span class="theme-label">
                             <span class="theme-name">{theme.name}</span>
                         </span>
                         <span class="theme-check" aria-hidden="true">
@@ -218,6 +211,7 @@
     }
 
     .appearance-section { padding: 0 8px 14px; }
+    .mode-section { padding-bottom: 19px; }
 
     .section-heading {
         display: flex;
@@ -230,14 +224,6 @@
         font-weight: 800;
         letter-spacing: 0.07em;
         text-transform: uppercase;
-    }
-
-    .section-value {
-        color: var(--color-text-subtle);
-        font-size: 0.68rem;
-        font-weight: 700;
-        letter-spacing: 0;
-        text-transform: none;
     }
 
     .mode-grid {
@@ -308,8 +294,8 @@
 
     .theme-card {
         position: relative;
-        display: grid;
-        grid-template-rows: 62px auto;
+        display: flex;
+        flex-direction: column;
         gap: 8px;
         min-width: 0;
         padding: 7px;
@@ -337,7 +323,10 @@
 
     .theme-preview {
         display: grid;
+        flex: 0 0 62px;
         grid-template-columns: 32px 1fr;
+        width: 100%;
+        height: 62px;
         overflow: hidden;
         background: var(--preview-canvas);
         border: 1px solid color-mix(in srgb, var(--preview-text) 13%, transparent);
@@ -364,8 +353,20 @@
     .preview-row b { width: 64%; height: 3px; background: color-mix(in srgb, var(--preview-text) 28%, transparent); border-radius: 4px; }
     .preview-row.short b { width: 42%; }
 
-    .theme-meta { display: flex; flex-direction: column; min-width: 0; padding: 0 2px 2px; }
-    .theme-name { overflow: hidden; font-size: 0.75rem; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
+    .theme-label {
+        display: block;
+        min-width: 0;
+        padding: 0 3px 2px;
+    }
+    .theme-name {
+        display: block;
+        overflow: hidden;
+        font-size: 0.75rem;
+        font-weight: 800;
+        line-height: 1.25;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 
     .theme-check {
         position: absolute;

--- a/frontend/src/ui/theme/AppearancePanel.svelte
+++ b/frontend/src/ui/theme/AppearancePanel.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-    import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
     import CheckIcon from '@lucide/svelte/icons/check';
     import LaptopIcon from '@lucide/svelte/icons/laptop';
     import MoonIcon from '@lucide/svelte/icons/moon';
-    import SparklesIcon from '@lucide/svelte/icons/sparkles';
     import SunIcon from '@lucide/svelte/icons/sun';
     import { onMount, tick } from 'svelte';
     import {
@@ -21,8 +19,6 @@
     } from './theme-controller';
 
     interface Props {
-        onBack: () => void;
-        backLabel?: string;
         autofocus?: boolean;
     }
 
@@ -33,30 +29,33 @@
         icon: typeof LaptopIcon;
     }
 
-    let { onBack, backLabel = 'Back', autofocus = false }: Props = $props();
-    let backButton = $state<HTMLButtonElement | null>(null);
-    let systemPalette = $state<ThemeAppearance>('light');
+    let { autofocus = false }: Props = $props();
+    let panel = $state<HTMLElement | null>(null);
 
     const modeOptions: readonly ModeOption[] = [
-        { id: 'system', label: 'Automatic', description: 'Follow your system', icon: LaptopIcon },
+        { id: 'system', label: 'System', description: 'Follow your system', icon: LaptopIcon },
         { id: 'light', label: 'Light', description: 'Always bright', icon: SunIcon },
         { id: 'dark', label: 'Dark', description: 'Always dim', icon: MoonIcon },
     ];
 
-    const activeAppearance = $derived<ThemeAppearance>(
-        $themeState.preference.mode === 'system' ? systemPalette : $themeState.preference.mode,
+    const activeAppearance = $derived<ThemeAppearance | null>(
+        $themeState.preference.mode === 'system' ? null : $themeState.preference.mode,
     );
-    const visibleThemes = $derived(themesForAppearance(activeAppearance));
+    const visibleThemes = $derived(activeAppearance ? themesForAppearance(activeAppearance) : []);
     const selectedThemeId = $derived(
         activeAppearance === 'light'
             ? $themeState.preference.lightThemeId
-            : $themeState.preference.darkThemeId,
+            : activeAppearance === 'dark'
+                ? $themeState.preference.darkThemeId
+                : null,
     );
     const resolvedThemeName = $derived(getThemeDefinition($themeState.resolvedThemeId).name);
 
     onMount(() => {
-        systemPalette = $themeState.systemAppearance;
-        if (autofocus) void tick().then(() => backButton?.focus());
+        if (!autofocus) return;
+        void tick().then(() => {
+            panel?.querySelector<HTMLElement>(`#appearance-mode-${$themeState.preference.mode}`)?.focus();
+        });
     });
 
     function originFrom(event: MouseEvent): ThemeChangeOrigin {
@@ -65,7 +64,6 @@
 
     function selectMode(event: MouseEvent, mode: ThemeMode): void {
         setThemeMode(mode, originFrom(event));
-        if (mode !== 'system') systemPalette = mode;
     }
 
     function selectTheme(event: MouseEvent, theme: ThemeDefinition): void {
@@ -79,7 +77,6 @@
         event.preventDefault();
         const nextMode = modeOptions[nextIndex].id;
         setThemeMode(nextMode);
-        if (nextMode !== 'system') systemPalette = nextMode;
         await tick();
         document.getElementById(`appearance-mode-${nextMode}`)?.focus();
     }
@@ -93,22 +90,6 @@
         setPreferredTheme(nextTheme.appearance, nextTheme.id);
         await tick();
         document.getElementById(`appearance-theme-${nextTheme.id}`)?.focus();
-    }
-
-    async function moveSystemPaletteFocus(event: KeyboardEvent): Promise<void> {
-        if (!['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
-            return;
-        }
-
-        event.preventDefault();
-        const nextAppearance = event.key === 'ArrowLeft'
-            || event.key === 'ArrowUp'
-            || event.key === 'Home'
-            ? 'light'
-            : 'dark';
-        systemPalette = nextAppearance;
-        await tick();
-        document.getElementById(`appearance-system-${nextAppearance}`)?.focus();
     }
 
     function nextRadioIndex(event: KeyboardEvent, index: number, length: number): number | null {
@@ -130,15 +111,9 @@
     }
 </script>
 
-<section class="appearance-panel" aria-labelledby="appearance-title">
+<section bind:this={panel} class="appearance-panel" aria-labelledby="appearance-title">
     <header class="appearance-header">
-        <button bind:this={backButton} class="appearance-back" type="button" onclick={onBack} aria-label={backLabel}>
-            <ArrowLeftIcon size={17} strokeWidth={2.2} aria-hidden="true" />
-        </button>
-        <div>
-            <div class="appearance-eyebrow"><SparklesIcon size={12} aria-hidden="true" /> Personalize</div>
-            <h2 id="appearance-title">Appearance</h2>
-        </div>
+        <h2 id="appearance-title">Appearance</h2>
     </header>
 
     <div class="appearance-section">
@@ -170,86 +145,49 @@
         </div>
     </div>
 
-    {#if $themeState.preference.mode === 'system'}
-        <div class="system-pair" aria-label="Automatic theme pair">
-            <div class="system-copy">
-                <strong>Automatic pair</strong>
-                <span>Choose a palette for each system appearance.</span>
+    {#if activeAppearance}
+        <div id="appearance-palette-panel" class="appearance-section palette-section">
+            <div class="section-heading">
+                <span>{activeAppearance === 'light' ? 'Light palettes' : 'Dark palettes'}</span>
+                <span class="theme-count">{visibleThemes.length}</span>
             </div>
-            <div class="appearance-toggle" role="tablist" aria-label="System appearance palette">
-                <button
-                    id="appearance-system-light"
-                    class:active={systemPalette === 'light'}
-                    type="button"
-                    role="tab"
-                    aria-selected={systemPalette === 'light'}
-                    aria-controls="appearance-palette-panel"
-                    tabindex={systemPalette === 'light' ? 0 : -1}
-                    onclick={() => (systemPalette = 'light')}
-                    onkeydown={(event) => void moveSystemPaletteFocus(event)}
-                ><SunIcon size={13} aria-hidden="true" /> Day</button>
-                <button
-                    id="appearance-system-dark"
-                    class:active={systemPalette === 'dark'}
-                    type="button"
-                    role="tab"
-                    aria-selected={systemPalette === 'dark'}
-                    aria-controls="appearance-palette-panel"
-                    tabindex={systemPalette === 'dark' ? 0 : -1}
-                    onclick={() => (systemPalette = 'dark')}
-                    onkeydown={(event) => void moveSystemPaletteFocus(event)}
-                ><MoonIcon size={13} aria-hidden="true" /> Night</button>
+            <div class="theme-grid" role="radiogroup" aria-label="Theme palette">
+                {#each visibleThemes as theme, index (theme.id)}
+                    {@const selected = selectedThemeId === theme.id}
+                    <button
+                        id={`appearance-theme-${theme.id}`}
+                        class:selected
+                        class="theme-card"
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        aria-label={theme.name}
+                        tabindex={selected ? 0 : -1}
+                        style={previewStyle(theme)}
+                        onclick={(event) => selectTheme(event, theme)}
+                        onkeydown={(event) => void moveThemeFocus(event, index)}
+                    >
+                        <span class="theme-preview" aria-hidden="true">
+                            <span class="preview-sidebar">
+                                <span></span><span></span><span></span>
+                            </span>
+                            <span class="preview-content">
+                                <span class="preview-topline"></span>
+                                <span class="preview-row"><i></i><b></b></span>
+                                <span class="preview-row short"><i></i><b></b></span>
+                            </span>
+                        </span>
+                        <span class="theme-meta">
+                            <span class="theme-name">{theme.name}</span>
+                        </span>
+                        <span class="theme-check" aria-hidden="true">
+                            {#if selected}<CheckIcon size={13} strokeWidth={3} />{/if}
+                        </span>
+                    </button>
+                {/each}
             </div>
         </div>
     {/if}
-
-    <div
-        id="appearance-palette-panel"
-        class="appearance-section palette-section"
-        role={$themeState.preference.mode === 'system' ? 'tabpanel' : undefined}
-        aria-labelledby={$themeState.preference.mode === 'system' ? `appearance-system-${systemPalette}` : undefined}
-    >
-        <div class="section-heading">
-            <span>{activeAppearance === 'light' ? 'Light palettes' : 'Dark palettes'}</span>
-            <span class="theme-count">{visibleThemes.length}</span>
-        </div>
-        <div class="theme-grid" role="radiogroup" aria-label="Theme palette">
-            {#each visibleThemes as theme, index (theme.id)}
-                {@const selected = selectedThemeId === theme.id}
-                <button
-                    id={`appearance-theme-${theme.id}`}
-                    class:selected
-                    class="theme-card"
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    aria-label={`${theme.name}: ${theme.description}`}
-                    tabindex={selected ? 0 : -1}
-                    style={previewStyle(theme)}
-                    onclick={(event) => selectTheme(event, theme)}
-                    onkeydown={(event) => void moveThemeFocus(event, index)}
-                >
-                    <span class="theme-preview" aria-hidden="true">
-                        <span class="preview-sidebar">
-                            <span></span><span></span><span></span>
-                        </span>
-                        <span class="preview-content">
-                            <span class="preview-topline"></span>
-                            <span class="preview-row"><i></i><b></b></span>
-                            <span class="preview-row short"><i></i><b></b></span>
-                        </span>
-                    </span>
-                    <span class="theme-meta">
-                        <span class="theme-name">{theme.name}</span>
-                        <span class="theme-description">{theme.description}</span>
-                    </span>
-                    <span class="theme-check" aria-hidden="true">
-                        {#if selected}<CheckIcon size={13} strokeWidth={3} />{/if}
-                    </span>
-                </button>
-            {/each}
-        </div>
-    </div>
 
     <p class="appearance-status" aria-live="polite">{resolvedThemeName} is active.</p>
 </section>
@@ -268,49 +206,16 @@
     .appearance-header {
         display: flex;
         align-items: center;
-        gap: 11px;
-        padding: 8px 8px 14px;
+        padding: 8px 8px 16px;
     }
 
     .appearance-header h2 {
-        margin: 1px 0 0;
+        margin: 0;
         color: var(--color-text);
-        font-size: 1rem;
+        font-size: 1.05rem;
         font-weight: 800;
         letter-spacing: 0;
     }
-
-    .appearance-eyebrow {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        color: var(--color-accent);
-        font-size: 0.65rem;
-        font-weight: 800;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-    }
-
-    .appearance-back {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 34px;
-        height: 34px;
-        padding: 0;
-        color: var(--color-text-soft);
-        background: var(--overlay-white-1);
-        border: 1px solid var(--color-border-soft);
-        border-radius: 10px;
-        cursor: pointer;
-        transition: transform var(--motion-fast) var(--ease-standard),
-            background var(--motion-fast) var(--ease-standard),
-            border-color var(--motion-fast) var(--ease-standard);
-    }
-
-    .appearance-back:hover { background: var(--overlay-white-2); border-color: var(--color-border); }
-    .appearance-back:active { transform: scale(0.95); }
-    .appearance-back:focus-visible { outline: none; box-shadow: var(--focus-ring); }
 
     .appearance-section { padding: 0 8px 14px; }
 
@@ -384,54 +289,6 @@
     }
 
     .mode-card.selected .mode-icon { background: var(--overlay-accent-2); }
-
-    .system-pair {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        margin: 0 8px 14px;
-        padding: 10px 11px;
-        background: linear-gradient(135deg, var(--overlay-accent-1), var(--overlay-white-1));
-        border: 1px solid var(--color-border-soft);
-        border-radius: 12px;
-    }
-
-    .system-copy { display: flex; flex-direction: column; min-width: 0; }
-    .system-copy strong { color: var(--color-text); font-size: 0.76rem; }
-    .system-copy span { margin-top: 2px; color: var(--color-text-muted); font-size: 0.68rem; line-height: 1.3; }
-
-    .appearance-toggle {
-        display: flex;
-        flex: 0 0 auto;
-        padding: 3px;
-        background: var(--color-surface-0);
-        border: 1px solid var(--color-border-soft);
-        border-radius: 9px;
-    }
-
-    .appearance-toggle button {
-        display: inline-flex;
-        align-items: center;
-        gap: 4px;
-        min-height: 26px;
-        padding: 0 7px;
-        color: var(--color-text-muted);
-        background: transparent;
-        border: 0;
-        border-radius: 6px;
-        font-size: 0.68rem;
-        font-weight: 750;
-        cursor: pointer;
-    }
-
-    .appearance-toggle button.active {
-        color: var(--color-text);
-        background: var(--color-surface-2);
-        box-shadow: var(--shadow-sm);
-    }
-
-    .appearance-toggle button:focus-visible { outline: none; box-shadow: var(--focus-ring); }
 
     .palette-section { padding-bottom: 9px; }
     .theme-count {
@@ -509,7 +366,6 @@
 
     .theme-meta { display: flex; flex-direction: column; min-width: 0; padding: 0 2px 2px; }
     .theme-name { overflow: hidden; font-size: 0.75rem; font-weight: 800; text-overflow: ellipsis; white-space: nowrap; }
-    .theme-description { margin-top: 2px; overflow: hidden; color: var(--color-text-muted); font-size: 0.68rem; text-overflow: ellipsis; white-space: nowrap; }
 
     .theme-check {
         position: absolute;
@@ -546,11 +402,9 @@
     @media (max-width: 460px) {
         .appearance-panel { width: min(350px, calc(100vw - 24px)); }
         .theme-grid { grid-template-columns: 1fr; }
-        .system-pair { align-items: flex-start; flex-direction: column; }
     }
 
     @media (prefers-reduced-motion: reduce) {
-        .appearance-back,
         .mode-card,
         .theme-card,
         .theme-check { transition: none; }

--- a/frontend/src/ui/theme/AppearancePanel.test.ts
+++ b/frontend/src/ui/theme/AppearancePanel.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import AppearancePanel from './AppearancePanel.svelte';
+
+describe('AppearancePanel', () => {
+    it('exposes system, light, and dark modes with curated theme previews', () => {
+        const { body } = render(AppearancePanel, { props: { onBack: () => {} } });
+
+        expect(body).toContain('Appearance');
+        expect(body).toContain('Follow your system');
+        expect(body).toContain('Light');
+        expect(body).toContain('Dark');
+        expect(body).toContain('TDrive Light');
+        expect(body).toContain('Catppuccin');
+        expect(body).toContain('Solarized');
+        expect(body).toContain('Gruvbox');
+    });
+
+    it('uses radio semantics for mode and palette selection', () => {
+        const { body } = render(AppearancePanel, { props: { onBack: () => {} } });
+
+        expect(body).toContain('role="radiogroup"');
+        expect(body).toContain('aria-label="Appearance mode"');
+        expect(body).toContain('aria-label="Theme palette"');
+        expect(body).toContain('aria-checked="true"');
+        expect(body).toContain('aria-live="polite"');
+    });
+});

--- a/frontend/src/ui/theme/AppearancePanel.test.ts
+++ b/frontend/src/ui/theme/AppearancePanel.test.ts
@@ -8,9 +8,12 @@ describe('AppearancePanel', () => {
 
         expect(body).toContain('Appearance');
         expect(body).toContain('System');
-        expect(body).toContain('Follow your system');
         expect(body).toContain('Light');
         expect(body).toContain('Dark');
+        expect(body).not.toContain('>Mode<');
+        expect(body).not.toContain('Follow your system');
+        expect(body).not.toContain('Always bright');
+        expect(body).not.toContain('Always dim');
         expect(body).not.toContain('Personalize');
         expect(body).not.toContain('Automatic pair');
         expect(body).not.toContain('System appearance palette');

--- a/frontend/src/ui/theme/AppearancePanel.test.ts
+++ b/frontend/src/ui/theme/AppearancePanel.test.ts
@@ -1,23 +1,26 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { render } from 'svelte/server';
 import AppearancePanel from './AppearancePanel.svelte';
 
+const componentSource = readFileSync(new URL('./AppearancePanel.svelte', import.meta.url), 'utf8');
+const globalCss = readFileSync(new URL('../../style.css', import.meta.url), 'utf8');
+
 describe('AppearancePanel', () => {
-    it('exposes a quiet System, Light, and Dark mode hierarchy', () => {
+    it('exposes only Light and Dark appearance modes', () => {
         const { body } = render(AppearancePanel);
 
         expect(body).toContain('Appearance');
-        expect(body).toContain('System');
         expect(body).toContain('Light');
         expect(body).toContain('Dark');
+        expect(body).not.toContain('System');
         expect(body).not.toContain('>Mode<');
         expect(body).not.toContain('Follow your system');
         expect(body).not.toContain('Always bright');
         expect(body).not.toContain('Always dim');
         expect(body).not.toContain('Personalize');
         expect(body).not.toContain('Automatic pair');
-        expect(body).not.toContain('System appearance palette');
-        expect(body).not.toContain('aria-label="Theme palette"');
+        expect(body).toContain('aria-label="Theme palette"');
     });
 
     it('uses radio semantics for mode selection', () => {
@@ -27,5 +30,13 @@ describe('AppearancePanel', () => {
         expect(body).toContain('aria-label="Appearance mode"');
         expect(body).toContain('aria-checked="true"');
         expect(body).toContain('aria-live="polite"');
+    });
+
+    it('keeps the title divider scoped and leaves breathing room above two mode cards', () => {
+        expect(globalCss).not.toMatch(/^header\s*\{/m);
+        expect(globalCss).toContain('.main-content > header {');
+        expect(componentSource).toContain('grid-template-columns: repeat(2, minmax(0, 1fr));');
+        expect(componentSource).toContain('.mode-section { padding: 14px 8px 19px; }');
+        expect(componentSource).toContain('border-bottom: 1px solid var(--color-border-soft);');
     });
 });

--- a/frontend/src/ui/theme/AppearancePanel.test.ts
+++ b/frontend/src/ui/theme/AppearancePanel.test.ts
@@ -3,25 +3,25 @@ import { render } from 'svelte/server';
 import AppearancePanel from './AppearancePanel.svelte';
 
 describe('AppearancePanel', () => {
-    it('exposes system, light, and dark modes with curated theme previews', () => {
-        const { body } = render(AppearancePanel, { props: { onBack: () => {} } });
+    it('exposes a quiet System, Light, and Dark mode hierarchy', () => {
+        const { body } = render(AppearancePanel);
 
         expect(body).toContain('Appearance');
+        expect(body).toContain('System');
         expect(body).toContain('Follow your system');
         expect(body).toContain('Light');
         expect(body).toContain('Dark');
-        expect(body).toContain('TDrive Light');
-        expect(body).toContain('Catppuccin');
-        expect(body).toContain('Solarized');
-        expect(body).toContain('Gruvbox');
+        expect(body).not.toContain('Personalize');
+        expect(body).not.toContain('Automatic pair');
+        expect(body).not.toContain('System appearance palette');
+        expect(body).not.toContain('aria-label="Theme palette"');
     });
 
-    it('uses radio semantics for mode and palette selection', () => {
-        const { body } = render(AppearancePanel, { props: { onBack: () => {} } });
+    it('uses radio semantics for mode selection', () => {
+        const { body } = render(AppearancePanel);
 
         expect(body).toContain('role="radiogroup"');
         expect(body).toContain('aria-label="Appearance mode"');
-        expect(body).toContain('aria-label="Theme palette"');
         expect(body).toContain('aria-checked="true"');
         expect(body).toContain('aria-live="polite"');
     });

--- a/frontend/src/ui/theme/native-theme.test.ts
+++ b/frontend/src/ui/theme/native-theme.test.ts
@@ -1,10 +1,13 @@
+import { readFileSync } from 'node:fs';
 import { writable } from 'svelte/store';
 import { describe, expect, it, vi } from 'vitest';
 import type { ThemeState } from './theme-controller';
 import { connectNativeTheme, type NativeThemeRuntime } from './native-theme';
-import { getThemeDefinition, normalizeThemePreference } from './theme-model';
+import { getThemeDefinition, normalizeThemePreference, type ThemeMode } from './theme-model';
 
-function state(mode: 'system' | 'light' | 'dark', resolvedThemeId: ThemeState['resolvedThemeId']): ThemeState {
+const nativeThemeSource = readFileSync(new URL('./native-theme.ts', import.meta.url), 'utf8');
+
+function state(mode: ThemeMode, resolvedThemeId: ThemeState['resolvedThemeId']): ThemeState {
     const activeTheme = getThemeDefinition(resolvedThemeId);
     return {
         preference: normalizeThemePreference({
@@ -12,7 +15,6 @@ function state(mode: 'system' | 'light' | 'dark', resolvedThemeId: ThemeState['r
             lightThemeId: 'tdrive-light',
             darkThemeId: resolvedThemeId === 'dracula' ? 'dracula' : 'tokyo-night',
         }),
-        systemAppearance: activeTheme.appearance,
         resolvedAppearance: activeTheme.appearance,
         resolvedThemeId,
     };
@@ -21,7 +23,6 @@ function state(mode: 'system' | 'light' | 'dark', resolvedThemeId: ThemeState['r
 function runtime() {
     return {
         setBackgroundColour: vi.fn<NativeThemeRuntime['setBackgroundColour']>(),
-        setSystemTheme: vi.fn<NativeThemeRuntime['setSystemTheme']>(),
         setLightTheme: vi.fn<NativeThemeRuntime['setLightTheme']>(),
         setDarkTheme: vi.fn<NativeThemeRuntime['setDarkTheme']>(),
     } satisfies NativeThemeRuntime;
@@ -39,12 +40,12 @@ describe('native theme bridge', () => {
         disconnect();
     });
 
-    it('synchronizes the Windows titlebar without overriding System mode', () => {
-        const theme = writable(state('system', 'tdrive-light'));
+    it('synchronizes the Windows titlebar from explicit light and dark modes', () => {
+        const theme = writable(state('light', 'tdrive-light'));
         const native = runtime();
         const disconnect = connectNativeTheme(theme, 'windows', native);
 
-        expect(native.setSystemTheme).toHaveBeenCalledOnce();
+        expect(native.setLightTheme).toHaveBeenCalledOnce();
 
         theme.set(state('dark', 'dracula'));
         expect(native.setDarkTheme).toHaveBeenCalledOnce();
@@ -59,15 +60,18 @@ describe('native theme bridge', () => {
         const disconnect = connectNativeTheme(theme, 'windows', native);
 
         expect(native.setLightTheme).toHaveBeenCalledOnce();
-        expect(native.setSystemTheme).not.toHaveBeenCalled();
         disconnect();
+    });
+
+    it('does not retain the removed native System-theme runtime surface', () => {
+        expect(nativeThemeSource).not.toContain('WindowSetSystemDefaultTheme');
+        expect(nativeThemeSource).not.toContain('setSystemTheme');
     });
 
     it('isolates native-window teardown errors from frontend theme state', () => {
         const theme = writable(state('dark', 'tokyo-night'));
         const native: NativeThemeRuntime = {
             setBackgroundColour: () => { throw new Error('window closed'); },
-            setSystemTheme: () => { throw new Error('window closed'); },
             setLightTheme: () => { throw new Error('window closed'); },
             setDarkTheme: () => { throw new Error('window closed'); },
         };

--- a/frontend/src/ui/theme/native-theme.test.ts
+++ b/frontend/src/ui/theme/native-theme.test.ts
@@ -1,0 +1,89 @@
+import { writable } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+import type { ThemeState } from './theme-controller';
+import { connectNativeTheme, type NativeThemeRuntime } from './native-theme';
+import { getThemeDefinition, normalizeThemePreference } from './theme-model';
+
+function state(mode: 'system' | 'light' | 'dark', resolvedThemeId: ThemeState['resolvedThemeId']): ThemeState {
+    const activeTheme = getThemeDefinition(resolvedThemeId);
+    return {
+        preference: normalizeThemePreference({
+            mode,
+            lightThemeId: 'tdrive-light',
+            darkThemeId: resolvedThemeId === 'dracula' ? 'dracula' : 'tokyo-night',
+        }),
+        systemAppearance: activeTheme.appearance,
+        resolvedAppearance: activeTheme.appearance,
+        resolvedThemeId,
+    };
+}
+
+function runtime() {
+    return {
+        setBackgroundColour: vi.fn<NativeThemeRuntime['setBackgroundColour']>(),
+        setSystemTheme: vi.fn<NativeThemeRuntime['setSystemTheme']>(),
+        setLightTheme: vi.fn<NativeThemeRuntime['setLightTheme']>(),
+        setDarkTheme: vi.fn<NativeThemeRuntime['setDarkTheme']>(),
+    } satisfies NativeThemeRuntime;
+}
+
+describe('native theme bridge', () => {
+    it('keeps the native window backdrop aligned with the active palette', () => {
+        const theme = writable(state('light', 'tdrive-light'));
+        const native = runtime();
+
+        const disconnect = connectNativeTheme(theme, 'darwin', native);
+
+        expect(native.setBackgroundColour).toHaveBeenLastCalledWith(243, 245, 249, 255);
+        expect(native.setLightTheme).not.toHaveBeenCalled();
+        disconnect();
+    });
+
+    it('synchronizes the Windows titlebar without overriding System mode', () => {
+        const theme = writable(state('system', 'tdrive-light'));
+        const native = runtime();
+        const disconnect = connectNativeTheme(theme, 'windows', native);
+
+        expect(native.setSystemTheme).toHaveBeenCalledOnce();
+
+        theme.set(state('dark', 'dracula'));
+        expect(native.setDarkTheme).toHaveBeenCalledOnce();
+        expect(native.setBackgroundColour).toHaveBeenLastCalledWith(40, 42, 54, 255);
+        disconnect();
+    });
+
+    it('selects the Windows light titlebar for a fixed light theme', () => {
+        const theme = writable(state('light', 'tdrive-light'));
+        const native = runtime();
+
+        const disconnect = connectNativeTheme(theme, 'windows', native);
+
+        expect(native.setLightTheme).toHaveBeenCalledOnce();
+        expect(native.setSystemTheme).not.toHaveBeenCalled();
+        disconnect();
+    });
+
+    it('isolates native-window teardown errors from frontend theme state', () => {
+        const theme = writable(state('dark', 'tokyo-night'));
+        const native: NativeThemeRuntime = {
+            setBackgroundColour: () => { throw new Error('window closed'); },
+            setSystemTheme: () => { throw new Error('window closed'); },
+            setLightTheme: () => { throw new Error('window closed'); },
+            setDarkTheme: () => { throw new Error('window closed'); },
+        };
+
+        expect(() => connectNativeTheme(theme, 'windows', native)).not.toThrow();
+    });
+
+    it('stops native updates after disconnecting', () => {
+        const theme = writable(state('dark', 'tokyo-night'));
+        const native = runtime();
+        const disconnect = connectNativeTheme(theme, 'windows', native);
+        const callsBeforeDisconnect = native.setBackgroundColour.mock.calls.length;
+
+        disconnect();
+        theme.set(state('light', 'tdrive-light'));
+
+        expect(native.setBackgroundColour).toHaveBeenCalledTimes(callsBeforeDisconnect);
+    });
+});

--- a/frontend/src/ui/theme/native-theme.ts
+++ b/frontend/src/ui/theme/native-theme.ts
@@ -4,21 +4,18 @@ import {
     WindowSetBackgroundColour,
     WindowSetDarkTheme,
     WindowSetLightTheme,
-    WindowSetSystemDefaultTheme,
 } from '../../../wailsjs/runtime/runtime';
 import { themeState, type ThemeState } from './theme-controller';
 import { getThemeDefinition } from './theme-model';
 
 export interface NativeThemeRuntime {
     setBackgroundColour(red: number, green: number, blue: number, alpha: number): void;
-    setSystemTheme(): void;
     setLightTheme(): void;
     setDarkTheme(): void;
 }
 
 const wailsThemeRuntime: NativeThemeRuntime = {
     setBackgroundColour: WindowSetBackgroundColour,
-    setSystemTheme: WindowSetSystemDefaultTheme,
     setLightTheme: WindowSetLightTheme,
     setDarkTheme: WindowSetDarkTheme,
 };
@@ -26,7 +23,7 @@ const wailsThemeRuntime: NativeThemeRuntime = {
 /**
  * Mirrors web theme state into the native Wails window. The backdrop update is
  * cross-platform; titlebar theme calls are intentionally limited to Windows,
- * where Wails exposes explicit light/dark/system controls.
+ * where Wails exposes explicit light/dark controls.
  */
 export function connectNativeTheme(
     state: Readable<ThemeState>,
@@ -40,9 +37,7 @@ export function connectNativeTheme(
         safely(() => runtime.setBackgroundColour(red, green, blue, 255));
         if (platform !== 'windows') return;
 
-        if (themeState.preference.mode === 'system') {
-            safely(runtime.setSystemTheme);
-        } else if (themeState.resolvedAppearance === 'light') {
+        if (themeState.preference.mode === 'light') {
             safely(runtime.setLightTheme);
         } else {
             safely(runtime.setDarkTheme);

--- a/frontend/src/ui/theme/native-theme.ts
+++ b/frontend/src/ui/theme/native-theme.ts
@@ -1,0 +1,80 @@
+import type { Readable } from 'svelte/store';
+import {
+    Environment,
+    WindowSetBackgroundColour,
+    WindowSetDarkTheme,
+    WindowSetLightTheme,
+    WindowSetSystemDefaultTheme,
+} from '../../../wailsjs/runtime/runtime';
+import { themeState, type ThemeState } from './theme-controller';
+import { getThemeDefinition } from './theme-model';
+
+export interface NativeThemeRuntime {
+    setBackgroundColour(red: number, green: number, blue: number, alpha: number): void;
+    setSystemTheme(): void;
+    setLightTheme(): void;
+    setDarkTheme(): void;
+}
+
+const wailsThemeRuntime: NativeThemeRuntime = {
+    setBackgroundColour: WindowSetBackgroundColour,
+    setSystemTheme: WindowSetSystemDefaultTheme,
+    setLightTheme: WindowSetLightTheme,
+    setDarkTheme: WindowSetDarkTheme,
+};
+
+/**
+ * Mirrors web theme state into the native Wails window. The backdrop update is
+ * cross-platform; titlebar theme calls are intentionally limited to Windows,
+ * where Wails exposes explicit light/dark/system controls.
+ */
+export function connectNativeTheme(
+    state: Readable<ThemeState>,
+    platform: string,
+    runtime: NativeThemeRuntime,
+): () => void {
+    return state.subscribe((themeState) => {
+        const canvas = getThemeDefinition(themeState.resolvedThemeId).preview[0];
+        const [red, green, blue] = parseHexColor(canvas);
+
+        safely(() => runtime.setBackgroundColour(red, green, blue, 255));
+        if (platform !== 'windows') return;
+
+        if (themeState.preference.mode === 'system') {
+            safely(runtime.setSystemTheme);
+        } else if (themeState.resolvedAppearance === 'light') {
+            safely(runtime.setLightTheme);
+        } else {
+            safely(runtime.setDarkTheme);
+        }
+    });
+}
+
+/** Starts native synchronization after the Wails runtime has become ready. */
+export async function initializeNativeTheme(): Promise<() => void> {
+    try {
+        const environment = await Environment();
+        return connectNativeTheme(themeState, environment.platform, wailsThemeRuntime);
+    } catch (error) {
+        // Vite's browser preview has no Wails runtime; the web theme still works.
+        console.warn('Native theme synchronization unavailable:', error);
+        return () => {};
+    }
+}
+
+function parseHexColor(hex: string): readonly [number, number, number] {
+    const normalized = /^#[\da-f]{6}$/i.test(hex) ? hex.slice(1) : '1a1b26';
+    return [
+        Number.parseInt(normalized.slice(0, 2), 16),
+        Number.parseInt(normalized.slice(2, 4), 16),
+        Number.parseInt(normalized.slice(4, 6), 16),
+    ];
+}
+
+function safely(action: () => void): void {
+    try {
+        action();
+    } catch {
+        // Native windows can disappear before frontend teardown completes.
+    }
+}

--- a/frontend/src/ui/theme/theme-bootstrap.test.ts
+++ b/frontend/src/ui/theme/theme-bootstrap.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { describe, expect, it } from 'vitest';
+import { THEME_STORAGE_KEY } from './theme-controller';
+import { THEME_DEFINITIONS } from './theme-model';
+
+const html = readFileSync(new URL('../../../index.html', import.meta.url), 'utf8');
+const bootstrap = /<script>([\s\S]*?)<\/script>/.exec(html)?.[1];
+
+function runBootstrap(saved: string | null, systemIsDark: boolean): Record<string, string> {
+    if (!bootstrap) throw new Error('missing pre-paint appearance bootstrap');
+    const dataset: Record<string, string> = {};
+
+    runInNewContext(bootstrap, {
+        document: { documentElement: { dataset } },
+        localStorage: { getItem: () => saved },
+        matchMedia: () => ({ matches: systemIsDark }),
+    });
+
+    return dataset;
+}
+
+describe('pre-paint theme bootstrap', () => {
+    it('runs before the theme stylesheet to avoid a startup flash', () => {
+        expect(html.indexOf('<script>')).toBeGreaterThan(0);
+        expect(html.indexOf('<script>')).toBeLessThan(html.indexOf('<link rel="stylesheet"'));
+    });
+
+    it('keeps the synchronous whitelist aligned with the typed catalogue', () => {
+        expect(bootstrap).toContain(`'${THEME_STORAGE_KEY}'`);
+        for (const theme of THEME_DEFINITIONS) {
+            expect(bootstrap).toContain(`'${theme.id}'`);
+        }
+    });
+
+    it('resolves the saved System pair from the OS before application boot', () => {
+        const saved = JSON.stringify({
+            mode: 'system',
+            lightThemeId: 'catppuccin-latte',
+            darkThemeId: 'nord',
+        });
+
+        expect(runBootstrap(saved, true)).toEqual({ theme: 'nord', themeAppearance: 'dark' });
+        expect(runBootstrap(saved, false)).toEqual({ theme: 'catppuccin-latte', themeAppearance: 'light' });
+    });
+
+    it('normalizes unknown persisted values to a valid default palette', () => {
+        const invalid = JSON.stringify({ mode: 'sepia', lightThemeId: 'dracula', darkThemeId: 'missing' });
+
+        expect(runBootstrap(invalid, false)).toEqual({ theme: 'tdrive-light', themeAppearance: 'light' });
+        expect(runBootstrap(invalid, true)).toEqual({ theme: 'tokyo-night', themeAppearance: 'dark' });
+    });
+});

--- a/frontend/src/ui/theme/theme-bootstrap.test.ts
+++ b/frontend/src/ui/theme/theme-bootstrap.test.ts
@@ -7,14 +7,13 @@ import { THEME_DEFINITIONS } from './theme-model';
 const html = readFileSync(new URL('../../../index.html', import.meta.url), 'utf8');
 const bootstrap = /<script>([\s\S]*?)<\/script>/.exec(html)?.[1];
 
-function runBootstrap(saved: string | null, systemIsDark: boolean): Record<string, string> {
+function runBootstrap(saved: string | null): Record<string, string> {
     if (!bootstrap) throw new Error('missing pre-paint appearance bootstrap');
     const dataset: Record<string, string> = {};
 
     runInNewContext(bootstrap, {
         document: { documentElement: { dataset } },
         localStorage: { getItem: () => saved },
-        matchMedia: () => ({ matches: systemIsDark }),
     });
 
     return dataset;
@@ -33,21 +32,22 @@ describe('pre-paint theme bootstrap', () => {
         }
     });
 
-    it('resolves the saved System pair from the OS before application boot', () => {
+    it('migrates a saved System pair to its explicit dark palette before application boot', () => {
         const saved = JSON.stringify({
             mode: 'system',
             lightThemeId: 'catppuccin-latte',
             darkThemeId: 'nord',
         });
 
-        expect(runBootstrap(saved, true)).toEqual({ theme: 'nord', themeAppearance: 'dark' });
-        expect(runBootstrap(saved, false)).toEqual({ theme: 'catppuccin-latte', themeAppearance: 'light' });
+        expect(runBootstrap(saved)).toEqual({ theme: 'nord', themeAppearance: 'dark' });
     });
 
-    it('normalizes unknown persisted values to a valid default palette', () => {
+    it('normalizes missing and unknown persisted values to the dark default without OS lookup', () => {
         const invalid = JSON.stringify({ mode: 'sepia', lightThemeId: 'dracula', darkThemeId: 'missing' });
 
-        expect(runBootstrap(invalid, false)).toEqual({ theme: 'tdrive-light', themeAppearance: 'light' });
-        expect(runBootstrap(invalid, true)).toEqual({ theme: 'tokyo-night', themeAppearance: 'dark' });
+        expect(runBootstrap(null)).toEqual({ theme: 'tokyo-night', themeAppearance: 'dark' });
+        expect(runBootstrap(invalid)).toEqual({ theme: 'tokyo-night', themeAppearance: 'dark' });
+        expect(bootstrap).not.toContain('matchMedia');
+        expect(bootstrap).not.toContain('prefers-color-scheme');
     });
 });

--- a/frontend/src/ui/theme/theme-controller.dom.test.ts
+++ b/frontend/src/ui/theme/theme-controller.dom.test.ts
@@ -1,0 +1,240 @@
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createThemeController, THEME_STORAGE_KEY } from './theme-controller';
+import type { ThemeAppearance, ThemeId, ThemeMode } from './theme-model';
+
+type MediaChangeListener = (event: MediaQueryListEvent) => void;
+let storage: Storage;
+
+function createStorage(): Storage {
+    const values = new Map<string, string>();
+    return {
+        get length() {
+            return values.size;
+        },
+        clear: () => values.clear(),
+        getItem: (key) => values.get(key) ?? null,
+        key: (index) => Array.from(values.keys())[index] ?? null,
+        removeItem: (key) => values.delete(key),
+        setItem: (key, value) => values.set(key, value),
+    };
+}
+
+function createMediaQuery(initialMatches: boolean): MediaQueryList & { setMatches(value: boolean): void } {
+    let matches = initialMatches;
+    const listeners = new Set<MediaChangeListener>();
+
+    return {
+        media: '(prefers-color-scheme: dark)',
+        onchange: null,
+        get matches() {
+            return matches;
+        },
+        addEventListener: (_type: string, listener: EventListenerOrEventListenerObject) =>
+            listeners.add(listener as MediaChangeListener),
+        removeEventListener: (_type: string, listener: EventListenerOrEventListenerObject) =>
+            listeners.delete(listener as MediaChangeListener),
+        addListener: (listener) => listeners.add(listener as MediaChangeListener),
+        removeListener: (listener) => listeners.delete(listener as MediaChangeListener),
+        dispatchEvent: () => true,
+        setMatches(value: boolean) {
+            matches = value;
+            const event = { matches: value, media: this.media } as MediaQueryListEvent;
+            listeners.forEach((listener) => listener(event));
+        },
+    };
+}
+
+beforeEach(() => {
+    storage = createStorage();
+    Reflect.deleteProperty(document, 'startViewTransition');
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-theme-appearance');
+    document.documentElement.removeAttribute('style');
+});
+
+afterEach(() => {
+    Reflect.deleteProperty(document, 'startViewTransition');
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+describe('theme controller', () => {
+    it('applies the system theme immediately and follows later OS changes', () => {
+        const colorScheme = createMediaQuery(false);
+        const controller = createThemeController({
+            document,
+            storage,
+            colorScheme,
+            reducedMotion: createMediaQuery(true),
+        });
+
+        controller.start();
+        expect(document.documentElement.dataset.theme).toBe('tdrive-light');
+        expect(document.documentElement.dataset.themeAppearance).toBe('light');
+
+        colorScheme.setMatches(true);
+        expect(document.documentElement.dataset.theme).toBe('tokyo-night');
+        expect(document.documentElement.dataset.themeAppearance).toBe('dark');
+
+        controller.destroy();
+    });
+
+    it('persists immutable preference updates and restores them on restart', () => {
+        const environment = {
+            document,
+            storage,
+            colorScheme: createMediaQuery(true),
+            reducedMotion: createMediaQuery(true),
+        };
+        const first = createThemeController(environment);
+        first.start();
+        const before = get(first.state).preference;
+
+        first.setPreferredTheme('dark', 'dracula');
+        first.setMode('dark');
+
+        const after = get(first.state).preference;
+        expect(after).not.toBe(before);
+        expect(before.darkThemeId).toBe('tokyo-night');
+        expect(after).toEqual({
+            mode: 'dark',
+            lightThemeId: 'tdrive-light',
+            darkThemeId: 'dracula',
+        });
+        expect(JSON.parse(storage.getItem(THEME_STORAGE_KEY) ?? '')).toEqual(after);
+        first.destroy();
+
+        const restored = createThemeController(environment);
+        restored.start();
+        expect(get(restored.state).preference).toEqual(after);
+        expect(document.documentElement.dataset.theme).toBe('dracula');
+        restored.destroy();
+    });
+
+    it('uses a view transition for a user-driven change when motion is allowed', () => {
+        const finished = Promise.resolve();
+        const startViewTransition = vi.fn((update: () => void) => {
+            update();
+            return { finished };
+        });
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            value: startViewTransition,
+        });
+        const controller = createThemeController({
+            document,
+            storage,
+            colorScheme: createMediaQuery(true),
+            reducedMotion: createMediaQuery(false),
+        });
+        controller.start();
+
+        controller.setPreferredTheme('dark', 'nord', { x: 120, y: 84 });
+
+        expect(startViewTransition).toHaveBeenCalledOnce();
+        expect(document.documentElement.dataset.theme).toBe('nord');
+        expect(document.documentElement.style.getPropertyValue('--theme-origin-x')).toBe('120px');
+        expect(document.documentElement.style.getPropertyValue('--theme-origin-y')).toBe('84px');
+        controller.destroy();
+    });
+
+    it('changes instantly when the user requests reduced motion', () => {
+        const startViewTransition = vi.fn((update: () => void) => {
+            update();
+            return { finished: Promise.resolve() };
+        });
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            value: startViewTransition,
+        });
+        const controller = createThemeController({
+            document,
+            storage,
+            colorScheme: createMediaQuery(true),
+            reducedMotion: createMediaQuery(true),
+        });
+        controller.start();
+
+        controller.setPreferredTheme('dark', 'catppuccin-mocha', { x: 10, y: 10 });
+
+        expect(startViewTransition).not.toHaveBeenCalled();
+        expect(document.documentElement.dataset.theme).toBe('catppuccin-mocha');
+        controller.destroy();
+    });
+
+    it('uses and cleans up the CSS fallback on webviews without View Transitions', () => {
+        vi.useFakeTimers();
+        const controller = createThemeController({
+            document,
+            storage,
+            colorScheme: createMediaQuery(true),
+            reducedMotion: createMediaQuery(false),
+        });
+        controller.start();
+
+        controller.setPreferredTheme('dark', 'dracula');
+
+        expect(document.documentElement.dataset.theme).toBe('dracula');
+        expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(true);
+        expect(document.documentElement.style.getPropertyValue('--theme-origin-x')).toBe(`${window.innerWidth / 2}px`);
+
+        vi.advanceTimersByTime(420);
+        expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(false);
+        controller.destroy();
+    });
+
+    it('keeps working when storage is unavailable and ignores invalid runtime input', () => {
+        const unavailableStorage = {
+            getItem: () => { throw new Error('blocked'); },
+            setItem: () => { throw new Error('blocked'); },
+        };
+        const controller = createThemeController({
+            document,
+            storage: unavailableStorage,
+            colorScheme: createMediaQuery(false),
+            reducedMotion: createMediaQuery(true),
+        });
+
+        expect(() => controller.start()).not.toThrow();
+        const initial = get(controller.state);
+        (controller.setMode as (mode: string) => void)('sepia');
+        controller.setPreferredTheme('light', 'dracula' as ThemeId);
+        controller.setPreferredTheme('sepia' as ThemeAppearance, 'tdrive-light');
+        expect(get(controller.state)).toBe(initial);
+
+        expect(() => controller.setMode('dark' as ThemeMode)).not.toThrow();
+        expect(get(controller.state).preference.mode).toBe('dark');
+        controller.destroy();
+    });
+
+    it('composes rapid preference changes while a view transition is pending', () => {
+        const pendingUpdates: Array<() => void> = [];
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            value: vi.fn((update: () => void) => {
+                pendingUpdates.push(update);
+                return { finished: new Promise<void>(() => {}) };
+            }),
+        });
+        const controller = createThemeController({
+            document,
+            storage,
+            colorScheme: createMediaQuery(true),
+            reducedMotion: createMediaQuery(false),
+        });
+        controller.start();
+
+        controller.setMode('light');
+        controller.setPreferredTheme('light', 'catppuccin-latte');
+        pendingUpdates[pendingUpdates.length - 1]?.();
+
+        expect(get(controller.state).preference).toEqual({
+            mode: 'light',
+            lightThemeId: 'catppuccin-latte',
+            darkThemeId: 'tokyo-night',
+        });
+        expect(document.documentElement.dataset.theme).toBe('catppuccin-latte');
+        controller.destroy();
+    });
+});

--- a/frontend/src/ui/theme/theme-controller.dom.test.ts
+++ b/frontend/src/ui/theme/theme-controller.dom.test.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createThemeController, THEME_STORAGE_KEY } from './theme-controller';
-import type { ThemeAppearance, ThemeId, ThemeMode } from './theme-model';
+import type { ThemeAppearance, ThemeId } from './theme-model';
 
 type MediaChangeListener = (event: MediaQueryListEvent) => void;
 let storage: Storage;
@@ -25,7 +25,7 @@ function createMediaQuery(initialMatches: boolean): MediaQueryList & { setMatche
     const listeners = new Set<MediaChangeListener>();
 
     return {
-        media: '(prefers-color-scheme: dark)',
+        media: '(prefers-reduced-motion: reduce)',
         onchange: null,
         get matches() {
             return matches;
@@ -60,23 +60,44 @@ afterEach(() => {
 });
 
 describe('theme controller', () => {
-    it('applies the system theme immediately and follows later OS changes', () => {
-        const colorScheme = createMediaQuery(false);
+    it('applies the explicit dark default without exposing OS appearance state', () => {
         const controller = createThemeController({
             document,
             storage,
-            colorScheme,
             reducedMotion: createMediaQuery(true),
         });
 
         controller.start();
-        expect(document.documentElement.dataset.theme).toBe('tdrive-light');
-        expect(document.documentElement.dataset.themeAppearance).toBe('light');
-
-        colorScheme.setMatches(true);
         expect(document.documentElement.dataset.theme).toBe('tokyo-night');
         expect(document.documentElement.dataset.themeAppearance).toBe('dark');
+        expect(get(controller.state)).not.toHaveProperty('systemAppearance');
 
+        controller.destroy();
+    });
+
+    it('migrates a persisted System preference to explicit dark', () => {
+        storage.setItem(THEME_STORAGE_KEY, JSON.stringify({
+            mode: 'system',
+            lightThemeId: 'catppuccin-latte',
+            darkThemeId: 'nord',
+        }));
+        const controller = createThemeController({
+            document,
+            storage,
+            reducedMotion: createMediaQuery(true),
+        });
+
+        controller.start();
+
+        expect(get(controller.state).preference).toEqual({
+            mode: 'dark',
+            lightThemeId: 'catppuccin-latte',
+            darkThemeId: 'nord',
+        });
+        expect(document.documentElement.dataset.theme).toBe('nord');
+        expect(JSON.parse(storage.getItem(THEME_STORAGE_KEY) ?? '')).toEqual(
+            get(controller.state).preference,
+        );
         controller.destroy();
     });
 
@@ -84,7 +105,6 @@ describe('theme controller', () => {
         const environment = {
             document,
             storage,
-            colorScheme: createMediaQuery(true),
             reducedMotion: createMediaQuery(true),
         };
         const first = createThemeController(environment);
@@ -125,7 +145,6 @@ describe('theme controller', () => {
         const controller = createThemeController({
             document,
             storage,
-            colorScheme: createMediaQuery(true),
             reducedMotion: createMediaQuery(false),
         });
         controller.start();
@@ -151,7 +170,6 @@ describe('theme controller', () => {
         const controller = createThemeController({
             document,
             storage,
-            colorScheme: createMediaQuery(true),
             reducedMotion: createMediaQuery(true),
         });
         controller.start();
@@ -168,7 +186,6 @@ describe('theme controller', () => {
         const controller = createThemeController({
             document,
             storage,
-            colorScheme: createMediaQuery(true),
             reducedMotion: createMediaQuery(false),
         });
         controller.start();
@@ -195,19 +212,19 @@ describe('theme controller', () => {
         const controller = createThemeController({
             document,
             storage: unavailableStorage,
-            colorScheme: createMediaQuery(false),
             reducedMotion: createMediaQuery(true),
         });
 
         expect(() => controller.start()).not.toThrow();
         const initial = get(controller.state);
         (controller.setMode as (mode: string) => void)('sepia');
+        (controller.setMode as (mode: string) => void)('system');
         controller.setPreferredTheme('light', 'dracula' as ThemeId);
         controller.setPreferredTheme('sepia' as ThemeAppearance, 'tdrive-light');
         expect(get(controller.state)).toBe(initial);
 
-        expect(() => controller.setMode('dark' as ThemeMode)).not.toThrow();
-        expect(get(controller.state).preference.mode).toBe('dark');
+        expect(() => controller.setMode('light')).not.toThrow();
+        expect(get(controller.state).preference.mode).toBe('light');
         controller.destroy();
     });
 
@@ -223,7 +240,6 @@ describe('theme controller', () => {
         const controller = createThemeController({
             document,
             storage,
-            colorScheme: createMediaQuery(true),
             reducedMotion: createMediaQuery(false),
         });
         controller.start();

--- a/frontend/src/ui/theme/theme-controller.dom.test.ts
+++ b/frontend/src/ui/theme/theme-controller.dom.test.ts
@@ -179,7 +179,7 @@ describe('theme controller', () => {
         expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(true);
         expect(document.documentElement.style.getPropertyValue('--theme-origin-x')).toBe(`${window.innerWidth / 2}px`);
 
-        vi.advanceTimersByTime(499);
+        vi.advanceTimersByTime(1049);
         expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(true);
 
         vi.advanceTimersByTime(1);

--- a/frontend/src/ui/theme/theme-controller.dom.test.ts
+++ b/frontend/src/ui/theme/theme-controller.dom.test.ts
@@ -179,7 +179,10 @@ describe('theme controller', () => {
         expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(true);
         expect(document.documentElement.style.getPropertyValue('--theme-origin-x')).toBe(`${window.innerWidth / 2}px`);
 
-        vi.advanceTimersByTime(420);
+        vi.advanceTimersByTime(499);
+        expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(true);
+
+        vi.advanceTimersByTime(1);
         expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(false);
         controller.destroy();
     });

--- a/frontend/src/ui/theme/theme-controller.dom.test.ts
+++ b/frontend/src/ui/theme/theme-controller.dom.test.ts
@@ -158,6 +158,30 @@ describe('theme controller', () => {
         controller.destroy();
     });
 
+    it('consumes the expected ready rejection when a rapid change skips a transition', async () => {
+        const ready = Promise.reject(new DOMException('Transition was skipped', 'AbortError'));
+        const catchReady = vi.spyOn(ready, 'catch');
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            value: vi.fn((update: () => void) => {
+                update();
+                return { ready, finished: Promise.resolve() };
+            }),
+        });
+        const controller = createThemeController({
+            document,
+            storage,
+            reducedMotion: createMediaQuery(false),
+        });
+        controller.start();
+
+        controller.setPreferredTheme('dark', 'nord');
+        await Promise.resolve();
+
+        expect(catchReady).toHaveBeenCalledOnce();
+        controller.destroy();
+    });
+
     it('changes instantly when the user requests reduced motion', () => {
         const startViewTransition = vi.fn((update: () => void) => {
             update();

--- a/frontend/src/ui/theme/theme-controller.dom.test.ts
+++ b/frontend/src/ui/theme/theme-controller.dom.test.ts
@@ -220,7 +220,7 @@ describe('theme controller', () => {
         expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(true);
         expect(document.documentElement.style.getPropertyValue('--theme-origin-x')).toBe(`${window.innerWidth / 2}px`);
 
-        vi.advanceTimersByTime(1049);
+        vi.advanceTimersByTime(1249);
         expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(true);
 
         vi.advanceTimersByTime(1);

--- a/frontend/src/ui/theme/theme-controller.test.ts
+++ b/frontend/src/ui/theme/theme-controller.test.ts
@@ -1,0 +1,28 @@
+import { get } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+import { createThemeController } from './theme-controller';
+
+describe('theme controller without a browser runtime', () => {
+    it('preserves the dark default when an OS color-scheme signal is unavailable', () => {
+        const controller = createThemeController({
+            storage: { getItem: () => null, setItem: () => {} },
+        });
+
+        controller.start();
+
+        expect(get(controller.state).systemAppearance).toBe('dark');
+        expect(get(controller.state).resolvedThemeId).toBe('tokyo-night');
+        controller.destroy();
+    });
+
+    it('remains usable during SSR and applies preferences without touching the DOM', () => {
+        const controller = createThemeController();
+
+        expect(() => controller.start()).not.toThrow();
+        expect(() => controller.setMode('dark')).not.toThrow();
+        expect(get(controller.state).preference.mode).toBe('dark');
+        expect(get(controller.state).resolvedThemeId).toBe('tokyo-night');
+
+        expect(() => controller.destroy()).not.toThrow();
+    });
+});

--- a/frontend/src/ui/theme/theme-controller.test.ts
+++ b/frontend/src/ui/theme/theme-controller.test.ts
@@ -3,14 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { createThemeController } from './theme-controller';
 
 describe('theme controller without a browser runtime', () => {
-    it('preserves the dark default when an OS color-scheme signal is unavailable', () => {
+    it('preserves the explicit dark default without a browser document', () => {
         const controller = createThemeController({
             storage: { getItem: () => null, setItem: () => {} },
         });
 
         controller.start();
 
-        expect(get(controller.state).systemAppearance).toBe('dark');
+        expect(get(controller.state).preference.mode).toBe('dark');
+        expect(get(controller.state).resolvedAppearance).toBe('dark');
         expect(get(controller.state).resolvedThemeId).toBe('tokyo-night');
         controller.destroy();
     });

--- a/frontend/src/ui/theme/theme-controller.ts
+++ b/frontend/src/ui/theme/theme-controller.ts
@@ -19,7 +19,7 @@ export const THEME_FALLBACK_CLASS = 'theme-transition-fallback';
 
 const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
-const FALLBACK_CLEANUP_DELAY_MS = 420;
+const FALLBACK_CLEANUP_DELAY_MS = 500;
 
 type ThemeStorage = Pick<Storage, 'getItem' | 'setItem'>;
 type MediaChangeHandler = (event: MediaQueryListEvent) => void;

--- a/frontend/src/ui/theme/theme-controller.ts
+++ b/frontend/src/ui/theme/theme-controller.ts
@@ -19,7 +19,7 @@ export const THEME_FALLBACK_CLASS = 'theme-transition-fallback';
 
 const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
-const FALLBACK_CLEANUP_DELAY_MS = 500;
+const FALLBACK_CLEANUP_DELAY_MS = 1050;
 
 type ThemeStorage = Pick<Storage, 'getItem' | 'setItem'>;
 type MediaChangeHandler = (event: MediaQueryListEvent) => void;

--- a/frontend/src/ui/theme/theme-controller.ts
+++ b/frontend/src/ui/theme/theme-controller.ts
@@ -5,7 +5,6 @@ import {
     isThemeForAppearance,
     isThemeMode,
     normalizeThemePreference,
-    resolveThemeAppearance,
     resolveThemeId,
     type ThemeAppearance,
     type ThemeId,
@@ -17,12 +16,10 @@ export const THEME_STORAGE_KEY = 'tdrive.appearance.v1';
 export const THEME_TRANSITION_CLASS = 'theme-transition-active';
 export const THEME_FALLBACK_CLASS = 'theme-transition-fallback';
 
-const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
 const FALLBACK_CLEANUP_DELAY_MS = 1050;
 
 type ThemeStorage = Pick<Storage, 'getItem' | 'setItem'>;
-type MediaChangeHandler = (event: MediaQueryListEvent) => void;
 
 export interface ThemeChangeOrigin {
     readonly x: number;
@@ -31,7 +28,6 @@ export interface ThemeChangeOrigin {
 
 export interface ThemeState {
     readonly preference: ThemePreference;
-    readonly systemAppearance: ThemeAppearance;
     readonly resolvedAppearance: ThemeAppearance;
     readonly resolvedThemeId: ThemeId;
 }
@@ -39,7 +35,6 @@ export interface ThemeState {
 export interface ThemeControllerEnvironment {
     readonly document?: Document;
     readonly storage?: ThemeStorage;
-    readonly colorScheme?: MediaQueryList;
     readonly reducedMotion?: MediaQueryList;
 }
 
@@ -58,7 +53,6 @@ export interface ThemeController {
 interface ResolvedEnvironment {
     readonly document?: Document;
     readonly storage?: ThemeStorage;
-    readonly colorScheme?: MediaQueryList;
     readonly reducedMotion?: MediaQueryList;
 }
 
@@ -66,13 +60,12 @@ export function createThemeController(
     environment: ThemeControllerEnvironment = {},
 ): ThemeController {
     let activeEnvironment: ResolvedEnvironment | undefined;
-    let currentState = createThemeState(DEFAULT_THEME_PREFERENCE, 'light');
+    let currentState = createThemeState(DEFAULT_THEME_PREFERENCE);
     // View Transition callbacks may run a frame after the user's click. Keep
     // the latest intended preference separately so a second quick selection
     // composes with, rather than overwrites, the first pending selection.
     let latestPreference = currentState.preference;
     let started = false;
-    let unsubscribeColorScheme: (() => void) | undefined;
     let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
     let transitionGeneration = 0;
     const store = writable<ThemeState>(currentState);
@@ -170,23 +163,11 @@ export function createThemeController(
         activeEnvironment = resolved;
         started = true;
         const preference = readPreference(resolved.storage);
-        const systemAppearance = readSystemAppearance(resolved.colorScheme);
         latestPreference = preference;
-        applyInstantly(createThemeState(preference, systemAppearance));
-        unsubscribeColorScheme = listenForMediaChanges(resolved.colorScheme, () => {
-            const nextAppearance = readSystemAppearance(resolved.colorScheme);
-            if (nextAppearance === currentState.systemAppearance) return;
-            applyInstantly(createThemeState(latestPreference, nextAppearance));
-        });
+        applyInstantly(createThemeState(preference));
     }
 
     function destroy(): void {
-        try {
-            unsubscribeColorScheme?.();
-        } catch {
-            // A torn-down webview can invalidate MediaQueryList before cleanup.
-        }
-        unsubscribeColorScheme = undefined;
         stopTransition();
         activeEnvironment = undefined;
         started = false;
@@ -197,7 +178,7 @@ export function createThemeController(
 
         latestPreference = preference;
         writePreference(activeEnvironment?.storage, preference);
-        transitionTo(createThemeState(preference, currentState.systemAppearance), origin);
+        transitionTo(createThemeState(preference), origin);
     }
 
     function setMode(mode: ThemeMode, origin?: ThemeChangeOrigin): void {
@@ -249,15 +230,11 @@ export function createThemeController(
     }
 }
 
-function createThemeState(
-    preference: ThemePreference,
-    systemAppearance: ThemeAppearance,
-): ThemeState {
+function createThemeState(preference: ThemePreference): ThemeState {
     return Object.freeze({
         preference,
-        systemAppearance,
-        resolvedAppearance: resolveThemeAppearance(preference, systemAppearance),
-        resolvedThemeId: resolveThemeId(preference, systemAppearance),
+        resolvedAppearance: preference.mode,
+        resolvedThemeId: resolveThemeId(preference),
     });
 }
 
@@ -268,7 +245,6 @@ function resolveEnvironment(environment: ThemeControllerEnvironment): ResolvedEn
     return {
         document: targetDocument,
         storage: environment.storage ?? getBrowserStorage(targetWindow),
-        colorScheme: environment.colorScheme ?? queryMedia(targetWindow, COLOR_SCHEME_QUERY),
         reducedMotion: environment.reducedMotion ?? queryMedia(targetWindow, REDUCED_MOTION_QUERY),
     };
 }
@@ -299,13 +275,23 @@ function queryMedia(targetWindow: Window | undefined, query: string): MediaQuery
 }
 
 function hasRuntimeEnvironment(environment: ResolvedEnvironment): boolean {
-    return Boolean(environment.document || environment.storage || environment.colorScheme);
+    return Boolean(environment.document || environment.storage || environment.reducedMotion);
 }
 
 function readPreference(storage?: ThemeStorage): ThemePreference {
+    let serialized: string | null | undefined;
     try {
-        const serialized = storage?.getItem(THEME_STORAGE_KEY);
-        return serialized ? normalizeThemePreference(JSON.parse(serialized) as unknown) : normalizeThemePreference(null);
+        serialized = storage?.getItem(THEME_STORAGE_KEY);
+    } catch {
+        return normalizeThemePreference(null);
+    }
+
+    if (!serialized) return normalizeThemePreference(null);
+
+    try {
+        const preference = normalizeThemePreference(JSON.parse(serialized) as unknown);
+        if (serialized !== JSON.stringify(preference)) writePreference(storage, preference);
+        return preference;
     } catch {
         return normalizeThemePreference(null);
     }
@@ -319,47 +305,12 @@ function writePreference(storage: ThemeStorage | undefined, preference: ThemePre
     }
 }
 
-function readSystemAppearance(colorScheme?: MediaQueryList): ThemeAppearance {
-    try {
-        // Some older Linux WebKitGTK builds do not expose this media query.
-        // Preserve TDrive's established dark appearance when the OS signal is
-        // unavailable instead of treating "unknown" as an explicit light UI.
-        if (!colorScheme) return 'dark';
-        return colorScheme.matches ? 'dark' : 'light';
-    } catch {
-        return 'dark';
-    }
-}
-
 function prefersReducedMotion(reducedMotion?: MediaQueryList): boolean {
     try {
         return reducedMotion?.matches === true;
     } catch {
         return true;
     }
-}
-
-function listenForMediaChanges(
-    mediaQuery: MediaQueryList | undefined,
-    listener: MediaChangeHandler,
-): (() => void) | undefined {
-    if (!mediaQuery) return undefined;
-
-    if (typeof mediaQuery.addEventListener === 'function') {
-        try {
-            mediaQuery.addEventListener('change', listener);
-            return () => mediaQuery.removeEventListener('change', listener);
-        } catch {
-            // Older Safari exposes the modern methods but only supports addListener.
-        }
-    }
-
-    if (typeof mediaQuery.addListener === 'function') {
-        mediaQuery.addListener(listener);
-        return () => mediaQuery.removeListener(listener);
-    }
-
-    return undefined;
 }
 
 function applyThemeAttributes(targetDocument: Document | undefined, state: ThemeState): void {

--- a/frontend/src/ui/theme/theme-controller.ts
+++ b/frontend/src/ui/theme/theme-controller.ts
@@ -122,6 +122,12 @@ export function createThemeController(
                 stateApplied = true;
                 applyState(nextState);
             });
+            // Starting another transition automatically skips the previous
+            // one in Chromium/WebView2. `ready` rejects in that normal case;
+            // observe it so rapid palette scrubbing stays console-clean.
+            if (transition?.ready) {
+                void Promise.resolve(transition.ready).catch(() => undefined);
+            }
             const cleanUp = () => {
                 if (generation === transitionGeneration && !stateApplied && started) {
                     applyState(nextState);

--- a/frontend/src/ui/theme/theme-controller.ts
+++ b/frontend/src/ui/theme/theme-controller.ts
@@ -1,0 +1,421 @@
+import { writable, type Readable } from 'svelte/store';
+import {
+    DEFAULT_THEME_PREFERENCE,
+    isThemeAppearance,
+    isThemeForAppearance,
+    isThemeMode,
+    normalizeThemePreference,
+    resolveThemeAppearance,
+    resolveThemeId,
+    type ThemeAppearance,
+    type ThemeId,
+    type ThemeMode,
+    type ThemePreference,
+} from './theme-model';
+
+export const THEME_STORAGE_KEY = 'tdrive.appearance.v1';
+export const THEME_TRANSITION_CLASS = 'theme-transition-active';
+export const THEME_FALLBACK_CLASS = 'theme-transition-fallback';
+
+const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+const FALLBACK_CLEANUP_DELAY_MS = 420;
+
+type ThemeStorage = Pick<Storage, 'getItem' | 'setItem'>;
+type MediaChangeHandler = (event: MediaQueryListEvent) => void;
+
+export interface ThemeChangeOrigin {
+    readonly x: number;
+    readonly y: number;
+}
+
+export interface ThemeState {
+    readonly preference: ThemePreference;
+    readonly systemAppearance: ThemeAppearance;
+    readonly resolvedAppearance: ThemeAppearance;
+    readonly resolvedThemeId: ThemeId;
+}
+
+export interface ThemeControllerEnvironment {
+    readonly document?: Document;
+    readonly storage?: ThemeStorage;
+    readonly colorScheme?: MediaQueryList;
+    readonly reducedMotion?: MediaQueryList;
+}
+
+export interface ThemeController {
+    readonly state: Readable<ThemeState>;
+    start(): void;
+    destroy(): void;
+    setMode(mode: ThemeMode, origin?: ThemeChangeOrigin): void;
+    setPreferredTheme(
+        appearance: ThemeAppearance,
+        themeId: ThemeId,
+        origin?: ThemeChangeOrigin,
+    ): void;
+}
+
+interface ResolvedEnvironment {
+    readonly document?: Document;
+    readonly storage?: ThemeStorage;
+    readonly colorScheme?: MediaQueryList;
+    readonly reducedMotion?: MediaQueryList;
+}
+
+export function createThemeController(
+    environment: ThemeControllerEnvironment = {},
+): ThemeController {
+    let activeEnvironment: ResolvedEnvironment | undefined;
+    let currentState = createThemeState(DEFAULT_THEME_PREFERENCE, 'light');
+    // View Transition callbacks may run a frame after the user's click. Keep
+    // the latest intended preference separately so a second quick selection
+    // composes with, rather than overwrites, the first pending selection.
+    let latestPreference = currentState.preference;
+    let started = false;
+    let unsubscribeColorScheme: (() => void) | undefined;
+    let fallbackTimer: ReturnType<typeof setTimeout> | undefined;
+    let transitionGeneration = 0;
+    const store = writable<ThemeState>(currentState);
+
+    function applyState(nextState: ThemeState): void {
+        currentState = nextState;
+        latestPreference = nextState.preference;
+        store.set(nextState);
+        applyThemeAttributes(activeEnvironment?.document, nextState);
+    }
+
+    function stopTransition(): void {
+        transitionGeneration += 1;
+        if (fallbackTimer !== undefined) {
+            clearTimeout(fallbackTimer);
+            fallbackTimer = undefined;
+        }
+        removeTransitionClasses(activeEnvironment?.document);
+    }
+
+    function applyInstantly(nextState: ThemeState): void {
+        stopTransition();
+        applyState(nextState);
+    }
+
+    function applyWithFallback(nextState: ThemeState, origin?: ThemeChangeOrigin): void {
+        const targetDocument = activeEnvironment?.document;
+        const root = targetDocument?.documentElement;
+        if (!root) {
+            applyState(nextState);
+            return;
+        }
+
+        const generation = beginTransition(targetDocument, THEME_FALLBACK_CLASS, origin);
+        applyState(nextState);
+        fallbackTimer = setTimeout(() => {
+            if (generation !== transitionGeneration) return;
+            root.classList.remove(THEME_FALLBACK_CLASS);
+            fallbackTimer = undefined;
+        }, FALLBACK_CLEANUP_DELAY_MS);
+    }
+
+    function applyWithViewTransition(nextState: ThemeState, origin?: ThemeChangeOrigin): boolean {
+        const targetDocument = activeEnvironment?.document;
+        const startViewTransition = targetDocument?.startViewTransition;
+        if (!targetDocument || typeof startViewTransition !== 'function') return false;
+
+        const generation = beginTransition(targetDocument, THEME_TRANSITION_CLASS, origin);
+        let stateApplied = false;
+
+        try {
+            const transition = startViewTransition.call(targetDocument, () => {
+                if (generation !== transitionGeneration || !started) return;
+                stateApplied = true;
+                applyState(nextState);
+            });
+            const cleanUp = () => {
+                if (generation === transitionGeneration && !stateApplied && started) {
+                    applyState(nextState);
+                }
+                finishTransition(targetDocument, generation);
+            };
+            if (transition?.finished) {
+                // A rejected transition is a visual cancellation, not an app error.
+                void Promise.resolve(transition.finished).then(cleanUp, cleanUp);
+            } else {
+                fallbackTimer = setTimeout(cleanUp, FALLBACK_CLEANUP_DELAY_MS);
+            }
+            return true;
+        } catch {
+            finishTransition(targetDocument, generation);
+            if (!stateApplied) applyWithFallback(nextState, origin);
+            return true;
+        }
+    }
+
+    function transitionTo(nextState: ThemeState, origin?: ThemeChangeOrigin): void {
+        const themeChanged = nextState.resolvedThemeId !== currentState.resolvedThemeId;
+        if (!themeChanged || prefersReducedMotion(activeEnvironment?.reducedMotion)) {
+            applyInstantly(nextState);
+            return;
+        }
+
+        if (!applyWithViewTransition(nextState, origin)) {
+            applyWithFallback(nextState, origin);
+        }
+    }
+
+    function start(): void {
+        if (started) return;
+
+        const resolved = resolveEnvironment(environment);
+        if (!hasRuntimeEnvironment(resolved)) return;
+
+        activeEnvironment = resolved;
+        started = true;
+        const preference = readPreference(resolved.storage);
+        const systemAppearance = readSystemAppearance(resolved.colorScheme);
+        latestPreference = preference;
+        applyInstantly(createThemeState(preference, systemAppearance));
+        unsubscribeColorScheme = listenForMediaChanges(resolved.colorScheme, () => {
+            const nextAppearance = readSystemAppearance(resolved.colorScheme);
+            if (nextAppearance === currentState.systemAppearance) return;
+            applyInstantly(createThemeState(latestPreference, nextAppearance));
+        });
+    }
+
+    function destroy(): void {
+        try {
+            unsubscribeColorScheme?.();
+        } catch {
+            // A torn-down webview can invalidate MediaQueryList before cleanup.
+        }
+        unsubscribeColorScheme = undefined;
+        stopTransition();
+        activeEnvironment = undefined;
+        started = false;
+    }
+
+    function updatePreference(preference: ThemePreference, origin?: ThemeChangeOrigin): void {
+        if (preferencesEqual(preference, latestPreference)) return;
+
+        latestPreference = preference;
+        writePreference(activeEnvironment?.storage, preference);
+        transitionTo(createThemeState(preference, currentState.systemAppearance), origin);
+    }
+
+    function setMode(mode: ThemeMode, origin?: ThemeChangeOrigin): void {
+        if (!isThemeMode(mode)) return;
+        start();
+        updatePreference(normalizeThemePreference({ ...latestPreference, mode }), origin);
+    }
+
+    function setPreferredTheme(
+        appearance: ThemeAppearance,
+        themeId: ThemeId,
+        origin?: ThemeChangeOrigin,
+    ): void {
+        if (!isThemeAppearance(appearance) || !isThemeForAppearance(themeId, appearance)) return;
+        start();
+        const preference = appearance === 'light'
+            ? { ...latestPreference, lightThemeId: themeId }
+            : { ...latestPreference, darkThemeId: themeId };
+        updatePreference(normalizeThemePreference(preference), origin);
+    }
+
+    return {
+        state: { subscribe: store.subscribe },
+        start,
+        destroy,
+        setMode,
+        setPreferredTheme,
+    };
+
+    function beginTransition(
+        targetDocument: Document,
+        className: string,
+        origin?: ThemeChangeOrigin,
+    ): number {
+        stopTransition();
+        const generation = transitionGeneration;
+        setTransitionOrigin(targetDocument, origin);
+        targetDocument.documentElement.classList.add(className);
+        return generation;
+    }
+
+    function finishTransition(targetDocument: Document, generation: number): void {
+        if (generation !== transitionGeneration) return;
+        if (fallbackTimer !== undefined) {
+            clearTimeout(fallbackTimer);
+            fallbackTimer = undefined;
+        }
+        removeTransitionClasses(targetDocument);
+    }
+}
+
+function createThemeState(
+    preference: ThemePreference,
+    systemAppearance: ThemeAppearance,
+): ThemeState {
+    return Object.freeze({
+        preference,
+        systemAppearance,
+        resolvedAppearance: resolveThemeAppearance(preference, systemAppearance),
+        resolvedThemeId: resolveThemeId(preference, systemAppearance),
+    });
+}
+
+function resolveEnvironment(environment: ThemeControllerEnvironment): ResolvedEnvironment {
+    const targetDocument = environment.document ?? getBrowserDocument();
+    const targetWindow = targetDocument?.defaultView ?? getBrowserWindow();
+
+    return {
+        document: targetDocument,
+        storage: environment.storage ?? getBrowserStorage(targetWindow),
+        colorScheme: environment.colorScheme ?? queryMedia(targetWindow, COLOR_SCHEME_QUERY),
+        reducedMotion: environment.reducedMotion ?? queryMedia(targetWindow, REDUCED_MOTION_QUERY),
+    };
+}
+
+function getBrowserDocument(): Document | undefined {
+    return typeof document === 'undefined' ? undefined : document;
+}
+
+function getBrowserWindow(): Window | undefined {
+    return typeof window === 'undefined' ? undefined : window;
+}
+
+function getBrowserStorage(targetWindow?: Window): ThemeStorage | undefined {
+    try {
+        return targetWindow?.localStorage;
+    } catch {
+        // Privacy modes and hardened webviews may deny storage access entirely.
+        return undefined;
+    }
+}
+
+function queryMedia(targetWindow: Window | undefined, query: string): MediaQueryList | undefined {
+    try {
+        return targetWindow?.matchMedia?.(query);
+    } catch {
+        return undefined;
+    }
+}
+
+function hasRuntimeEnvironment(environment: ResolvedEnvironment): boolean {
+    return Boolean(environment.document || environment.storage || environment.colorScheme);
+}
+
+function readPreference(storage?: ThemeStorage): ThemePreference {
+    try {
+        const serialized = storage?.getItem(THEME_STORAGE_KEY);
+        return serialized ? normalizeThemePreference(JSON.parse(serialized) as unknown) : normalizeThemePreference(null);
+    } catch {
+        return normalizeThemePreference(null);
+    }
+}
+
+function writePreference(storage: ThemeStorage | undefined, preference: ThemePreference): void {
+    try {
+        storage?.setItem(THEME_STORAGE_KEY, JSON.stringify(preference));
+    } catch {
+        // Appearance remains fully functional when persistence is unavailable.
+    }
+}
+
+function readSystemAppearance(colorScheme?: MediaQueryList): ThemeAppearance {
+    try {
+        // Some older Linux WebKitGTK builds do not expose this media query.
+        // Preserve TDrive's established dark appearance when the OS signal is
+        // unavailable instead of treating "unknown" as an explicit light UI.
+        if (!colorScheme) return 'dark';
+        return colorScheme.matches ? 'dark' : 'light';
+    } catch {
+        return 'dark';
+    }
+}
+
+function prefersReducedMotion(reducedMotion?: MediaQueryList): boolean {
+    try {
+        return reducedMotion?.matches === true;
+    } catch {
+        return true;
+    }
+}
+
+function listenForMediaChanges(
+    mediaQuery: MediaQueryList | undefined,
+    listener: MediaChangeHandler,
+): (() => void) | undefined {
+    if (!mediaQuery) return undefined;
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+        try {
+            mediaQuery.addEventListener('change', listener);
+            return () => mediaQuery.removeEventListener('change', listener);
+        } catch {
+            // Older Safari exposes the modern methods but only supports addListener.
+        }
+    }
+
+    if (typeof mediaQuery.addListener === 'function') {
+        mediaQuery.addListener(listener);
+        return () => mediaQuery.removeListener(listener);
+    }
+
+    return undefined;
+}
+
+function applyThemeAttributes(targetDocument: Document | undefined, state: ThemeState): void {
+    const root = targetDocument?.documentElement;
+    if (!root) return;
+
+    root.dataset.theme = state.resolvedThemeId;
+    root.dataset.themeAppearance = state.resolvedAppearance;
+    root.style.colorScheme = state.resolvedAppearance;
+}
+
+function setTransitionOrigin(targetDocument: Document, origin?: ThemeChangeOrigin): void {
+    const root = targetDocument.documentElement;
+    const viewportWidth = targetDocument.defaultView?.innerWidth || root.clientWidth;
+    const viewportHeight = targetDocument.defaultView?.innerHeight || root.clientHeight;
+    const x = normalizedCoordinate(origin?.x, viewportWidth);
+    const y = normalizedCoordinate(origin?.y, viewportHeight);
+
+    root.style.setProperty('--theme-origin-x', `${x}px`);
+    root.style.setProperty('--theme-origin-y', `${y}px`);
+}
+
+function normalizedCoordinate(value: number | undefined, viewportSize: number): number {
+    const fallback = Math.max(0, viewportSize / 2);
+    if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+    if (viewportSize <= 0) return Math.max(0, value);
+    return Math.min(Math.max(0, value), viewportSize);
+}
+
+function removeTransitionClasses(targetDocument?: Document): void {
+    targetDocument?.documentElement.classList.remove(THEME_TRANSITION_CLASS, THEME_FALLBACK_CLASS);
+}
+
+function preferencesEqual(left: ThemePreference, right: ThemePreference): boolean {
+    return left.mode === right.mode
+        && left.lightThemeId === right.lightThemeId
+        && left.darkThemeId === right.darkThemeId;
+}
+
+export const themeController = createThemeController();
+export const themeState = themeController.state;
+
+/** Initializes the singleton and returns an optional lifecycle cleanup callback. */
+export function initializeTheme(): () => void {
+    themeController.start();
+    return () => themeController.destroy();
+}
+
+export function setThemeMode(mode: ThemeMode, origin?: ThemeChangeOrigin): void {
+    themeController.setMode(mode, origin);
+}
+
+export function setPreferredTheme(
+    appearance: ThemeAppearance,
+    themeId: ThemeId,
+    origin?: ThemeChangeOrigin,
+): void {
+    themeController.setPreferredTheme(appearance, themeId, origin);
+}

--- a/frontend/src/ui/theme/theme-controller.ts
+++ b/frontend/src/ui/theme/theme-controller.ts
@@ -17,7 +17,9 @@ export const THEME_TRANSITION_CLASS = 'theme-transition-active';
 export const THEME_FALLBACK_CLASS = 'theme-transition-fallback';
 
 const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
-const FALLBACK_CLEANUP_DELAY_MS = 1050;
+// Keep the fallback class just beyond the 1.2s CSS animation so WebViews that
+// lack View Transitions never remove the final animation frame prematurely.
+const FALLBACK_CLEANUP_DELAY_MS = 1250;
 
 type ThemeStorage = Pick<Storage, 'getItem' | 'setItem'>;
 

--- a/frontend/src/ui/theme/theme-interaction.dom.test.ts
+++ b/frontend/src/ui/theme/theme-interaction.dom.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { THEME_TRANSITION_CLASS } from './theme-controller';
+import { recoverThemeTransitionClick } from './theme-interaction';
+
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+    return {
+        x: left,
+        y: top,
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+        width,
+        height,
+        toJSON: () => ({}),
+    };
+}
+
+function overlayClick(x: number, y: number): MouseEvent {
+    const event = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+    });
+    Object.defineProperty(event, 'target', { value: document.documentElement });
+    return event;
+}
+
+afterEach(() => {
+    document.documentElement.classList.remove(THEME_TRANSITION_CLASS);
+    document.body.replaceChildren();
+});
+
+describe('theme transition click recovery', () => {
+    it('replays a transition-overlay click onto the appearance control below it', () => {
+        const panel = document.createElement('div');
+        const theme = document.createElement('button');
+        theme.dataset.themeHitTarget = '';
+        panel.appendChild(theme);
+        document.body.appendChild(panel);
+
+        vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue(rect(10, 10, 200, 200));
+        vi.spyOn(theme, 'getBoundingClientRect').mockReturnValue(rect(25, 30, 80, 60));
+        const received = vi.fn();
+        theme.addEventListener('click', received);
+        document.documentElement.classList.add(THEME_TRANSITION_CLASS);
+        const event = overlayClick(50, 55);
+
+        expect(recoverThemeTransitionClick(event, panel)).toBe(true);
+        expect(event.defaultPrevented).toBe(true);
+        expect(received).toHaveBeenCalledOnce();
+        expect(received.mock.calls[0][0]).toMatchObject({ clientX: 50, clientY: 55 });
+        expect(document.activeElement).toBe(theme);
+    });
+
+    it('does not consume clicks outside the panel or without an active transition', () => {
+        const panel = document.createElement('div');
+        document.body.appendChild(panel);
+        vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue(rect(10, 10, 100, 100));
+
+        expect(recoverThemeTransitionClick(overlayClick(50, 50), panel)).toBe(false);
+
+        document.documentElement.classList.add(THEME_TRANSITION_CLASS);
+        expect(recoverThemeTransitionClick(overlayClick(150, 150), panel)).toBe(false);
+        expect(recoverThemeTransitionClick(overlayClick(50, 50), null)).toBe(false);
+    });
+});

--- a/frontend/src/ui/theme/theme-interaction.ts
+++ b/frontend/src/ui/theme/theme-interaction.ts
@@ -1,0 +1,75 @@
+import { THEME_TRANSITION_CLASS } from './theme-controller';
+
+const THEME_HIT_TARGET_SELECTOR = '[data-theme-hit-target]';
+
+/**
+ * Replays a click that the root View Transition snapshot intercepted.
+ *
+ * During an active root transition, browsers intentionally remove the live
+ * document from hit-testing. A rapid follow-up click is therefore retargeted
+ * to <html>, even though the user can still see an Appearance control at that
+ * point. We recover only clicks geometrically inside the supplied container,
+ * and only onto controls explicitly opted into this behavior.
+ */
+export function recoverThemeTransitionClick(
+    event: MouseEvent,
+    container: HTMLElement | null,
+): boolean {
+    if (!container || !isRootTransitionOverlayClick(event, container.ownerDocument)) return false;
+    if (!pointFallsWithin(event.clientX, event.clientY, container.getBoundingClientRect())) return false;
+
+    // Do not let the retargeted <html> click reach outside-click handlers or
+    // unrelated page controls after it has been recovered.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const target = hitTargetAtPoint(container, event.clientX, event.clientY);
+    if (target) dispatchRecoveredClick(target, event);
+    return true;
+}
+
+function isRootTransitionOverlayClick(event: MouseEvent, targetDocument: Document): boolean {
+    const root = targetDocument.documentElement;
+    return event.target === root && root.classList.contains(THEME_TRANSITION_CLASS);
+}
+
+function hitTargetAtPoint(container: HTMLElement, x: number, y: number): HTMLElement | undefined {
+    const targets = container.matches(THEME_HIT_TARGET_SELECTOR)
+        ? [container, ...container.querySelectorAll<HTMLElement>(THEME_HIT_TARGET_SELECTOR)]
+        : [...container.querySelectorAll<HTMLElement>(THEME_HIT_TARGET_SELECTOR)];
+
+    return targets.find((target) => pointFallsWithin(x, y, target.getBoundingClientRect()));
+}
+
+function pointFallsWithin(x: number, y: number, bounds: DOMRect): boolean {
+    return bounds.width > 0
+        && bounds.height > 0
+        && x >= bounds.left
+        && x <= bounds.right
+        && y >= bounds.top
+        && y <= bounds.bottom;
+}
+
+function dispatchRecoveredClick(target: HTMLElement, source: MouseEvent): void {
+    // Native pointer activation would focus a radio control before its click.
+    // The transition overlay prevented that default action, so restore it
+    // explicitly to keep roving tabindex and arrow-key navigation aligned.
+    target.focus({ preventScroll: true });
+    target.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        view: source.view,
+        detail: source.detail,
+        screenX: source.screenX,
+        screenY: source.screenY,
+        clientX: source.clientX,
+        clientY: source.clientY,
+        ctrlKey: source.ctrlKey,
+        shiftKey: source.shiftKey,
+        altKey: source.altKey,
+        metaKey: source.metaKey,
+        button: source.button,
+        buttons: source.buttons,
+    }));
+}

--- a/frontend/src/ui/theme/theme-model.test.ts
+++ b/frontend/src/ui/theme/theme-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     DEFAULT_THEME_PREFERENCE,
     THEME_DEFINITIONS,
+    isThemeMode,
     normalizeThemePreference,
     resolveThemeId,
     themesForAppearance,
@@ -18,7 +19,8 @@ describe('theme model', () => {
         expect(THEME_DEFINITIONS.every((theme) => !('description' in theme))).toBe(true);
     });
 
-    it('normalizes unknown or appearance-incompatible persisted values', () => {
+    it('defaults unknown or appearance-incompatible persisted values to dark', () => {
+        expect(DEFAULT_THEME_PREFERENCE.mode).toBe('dark');
         expect(
             normalizeThemePreference({
                 mode: 'neon',
@@ -28,9 +30,24 @@ describe('theme model', () => {
         ).toEqual(DEFAULT_THEME_PREFERENCE);
     });
 
+    it('migrates the removed System mode to explicit dark without losing valid palettes', () => {
+        expect(
+            normalizeThemePreference({
+                mode: 'system',
+                lightThemeId: 'catppuccin-latte',
+                darkThemeId: 'nord',
+            }),
+        ).toEqual({
+            mode: 'dark',
+            lightThemeId: 'catppuccin-latte',
+            darkThemeId: 'nord',
+        });
+        expect(isThemeMode('system')).toBe(false);
+    });
+
     it('preserves valid preferences without mutating the source value', () => {
         const persisted = {
-            mode: 'system',
+            mode: 'light',
             lightThemeId: 'catppuccin-latte',
             darkThemeId: 'catppuccin-mocha',
         } as const;
@@ -41,25 +58,14 @@ describe('theme model', () => {
         expect(normalized).not.toBe(persisted);
     });
 
-    it('resolves system mode from the operating-system appearance', () => {
+    it('resolves the selected palette from explicit light or dark mode', () => {
         const preference = {
-            mode: 'system',
+            mode: 'light',
             lightThemeId: 'solarized-light',
             darkThemeId: 'nord',
         } as const;
 
-        expect(resolveThemeId(preference, 'light')).toBe('solarized-light');
-        expect(resolveThemeId(preference, 'dark')).toBe('nord');
-    });
-
-    it('lets an explicit light or dark mode override the operating system', () => {
-        const preference = {
-            mode: 'light',
-            lightThemeId: 'gruvbox-light',
-            darkThemeId: 'dracula',
-        } as const;
-
-        expect(resolveThemeId(preference, 'dark')).toBe('gruvbox-light');
-        expect(resolveThemeId({ ...preference, mode: 'dark' }, 'light')).toBe('dracula');
+        expect(resolveThemeId(preference)).toBe('solarized-light');
+        expect(resolveThemeId({ ...preference, mode: 'dark' })).toBe('nord');
     });
 });

--- a/frontend/src/ui/theme/theme-model.test.ts
+++ b/frontend/src/ui/theme/theme-model.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DEFAULT_THEME_PREFERENCE,
+    THEME_DEFINITIONS,
+    normalizeThemePreference,
+    resolveThemeId,
+    themesForAppearance,
+} from './theme-model';
+
+describe('theme model', () => {
+    it('ships a balanced, uniquely identified set of light and dark themes', () => {
+        const ids = THEME_DEFINITIONS.map((theme) => theme.id);
+
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(themesForAppearance('light').length).toBeGreaterThanOrEqual(4);
+        expect(themesForAppearance('dark').length).toBeGreaterThanOrEqual(5);
+        expect(THEME_DEFINITIONS.every((theme) => theme.preview.length === 4)).toBe(true);
+    });
+
+    it('normalizes unknown or appearance-incompatible persisted values', () => {
+        expect(
+            normalizeThemePreference({
+                mode: 'neon',
+                lightThemeId: 'dracula',
+                darkThemeId: 'missing-theme',
+            }),
+        ).toEqual(DEFAULT_THEME_PREFERENCE);
+    });
+
+    it('preserves valid preferences without mutating the source value', () => {
+        const persisted = {
+            mode: 'system',
+            lightThemeId: 'catppuccin-latte',
+            darkThemeId: 'catppuccin-mocha',
+        } as const;
+
+        const normalized = normalizeThemePreference(persisted);
+
+        expect(normalized).toEqual(persisted);
+        expect(normalized).not.toBe(persisted);
+    });
+
+    it('resolves system mode from the operating-system appearance', () => {
+        const preference = {
+            mode: 'system',
+            lightThemeId: 'solarized-light',
+            darkThemeId: 'nord',
+        } as const;
+
+        expect(resolveThemeId(preference, 'light')).toBe('solarized-light');
+        expect(resolveThemeId(preference, 'dark')).toBe('nord');
+    });
+
+    it('lets an explicit light or dark mode override the operating system', () => {
+        const preference = {
+            mode: 'light',
+            lightThemeId: 'gruvbox-light',
+            darkThemeId: 'dracula',
+        } as const;
+
+        expect(resolveThemeId(preference, 'dark')).toBe('gruvbox-light');
+        expect(resolveThemeId({ ...preference, mode: 'dark' }, 'light')).toBe('dracula');
+    });
+});

--- a/frontend/src/ui/theme/theme-model.test.ts
+++ b/frontend/src/ui/theme/theme-model.test.ts
@@ -15,6 +15,7 @@ describe('theme model', () => {
         expect(themesForAppearance('light').length).toBeGreaterThanOrEqual(4);
         expect(themesForAppearance('dark').length).toBeGreaterThanOrEqual(5);
         expect(THEME_DEFINITIONS.every((theme) => theme.preview.length === 4)).toBe(true);
+        expect(THEME_DEFINITIONS.every((theme) => !('description' in theme))).toBe(true);
     });
 
     it('normalizes unknown or appearance-incompatible persisted values', () => {

--- a/frontend/src/ui/theme/theme-model.ts
+++ b/frontend/src/ui/theme/theme-model.ts
@@ -1,0 +1,190 @@
+export const THEME_IDS = [
+    'tdrive-light',
+    'catppuccin-latte',
+    'solarized-light',
+    'gruvbox-light',
+    'tokyo-night',
+    'catppuccin-mocha',
+    'dracula',
+    'solarized-dark',
+    'gruvbox-dark',
+    'nord',
+] as const;
+
+export type ThemeId = (typeof THEME_IDS)[number];
+export type ThemeAppearance = 'light' | 'dark';
+export type ThemeMode = 'system' | ThemeAppearance;
+export type ThemePreview = readonly [canvas: string, surface: string, accent: string, text: string];
+
+export interface ThemeDefinition {
+    readonly id: ThemeId;
+    readonly name: string;
+    readonly appearance: ThemeAppearance;
+    readonly description: string;
+    readonly preview: ThemePreview;
+}
+
+export interface ThemePreference {
+    readonly mode: ThemeMode;
+    readonly lightThemeId: ThemeId;
+    readonly darkThemeId: ThemeId;
+}
+
+function defineTheme(definition: ThemeDefinition): ThemeDefinition {
+    return Object.freeze({
+        ...definition,
+        preview: Object.freeze([...definition.preview]) as ThemePreview,
+    });
+}
+
+/**
+ * The built-in catalogue is intentionally closed and trusted. Preview values are
+ * rendered as inline CSS by the appearance picker, so arbitrary persisted data
+ * must never be promoted into this list.
+ */
+export const THEME_DEFINITIONS: readonly ThemeDefinition[] = Object.freeze([
+    defineTheme({
+        id: 'tdrive-light',
+        name: 'TDrive Light',
+        appearance: 'light',
+        description: 'Crisp, calm, and unmistakably TDrive.',
+        preview: ['#f3f5f9', '#eceff5', '#315fc4', '#101828'],
+    }),
+    defineTheme({
+        id: 'catppuccin-latte',
+        name: 'Catppuccin Latte',
+        appearance: 'light',
+        description: 'Warm pastels with gentle contrast.',
+        preview: ['#eff1f5', '#dfe3eb', '#1d61ea', '#4c4f69'],
+    }),
+    defineTheme({
+        id: 'solarized-light',
+        name: 'Solarized Light',
+        appearance: 'light',
+        description: 'Paper-soft tones for focused work.',
+        preview: ['#fdf6e3', '#eee8d5', '#1676ad', '#073642'],
+    }),
+    defineTheme({
+        id: 'gruvbox-light',
+        name: 'Gruvbox Light',
+        appearance: 'light',
+        description: 'A warm retro palette with earthy depth.',
+        preview: ['#fbf1c7', '#ebdbb2', '#076678', '#282828'],
+    }),
+    defineTheme({
+        id: 'tokyo-night',
+        name: 'Tokyo Night',
+        appearance: 'dark',
+        description: 'TDrive’s original midnight-blue glow.',
+        preview: ['#1a1b26', '#24283b', '#7aa2f7', '#f5f7ff'],
+    }),
+    defineTheme({
+        id: 'catppuccin-mocha',
+        name: 'Catppuccin Mocha',
+        appearance: 'dark',
+        description: 'Velvety dark surfaces and soft pastels.',
+        preview: ['#1e1e2e', '#313244', '#89b4fa', '#f1f3fb'],
+    }),
+    defineTheme({
+        id: 'dracula',
+        name: 'Dracula',
+        appearance: 'dark',
+        description: 'Vivid violet energy on charcoal.',
+        preview: ['#282a36', '#383a4a', '#bd93f9', '#f8f8f2'],
+    }),
+    defineTheme({
+        id: 'solarized-dark',
+        name: 'Solarized Dark',
+        appearance: 'dark',
+        description: 'Low-glare contrast with oceanic accents.',
+        preview: ['#002b36', '#0d414d', '#36a4d9', '#f5efdd'],
+    }),
+    defineTheme({
+        id: 'gruvbox-dark',
+        name: 'Gruvbox Dark',
+        appearance: 'dark',
+        description: 'Cozy earth tones built for long sessions.',
+        preview: ['#282828', '#3c3836', '#83a598', '#fbf1c7'],
+    }),
+    defineTheme({
+        id: 'nord',
+        name: 'Nord',
+        appearance: 'dark',
+        description: 'Cool arctic hues with quiet clarity.',
+        preview: ['#2e3440', '#3b4252', '#88c0d0', '#eceff4'],
+    }),
+]);
+
+export const DEFAULT_THEME_PREFERENCE: ThemePreference = Object.freeze({
+    mode: 'system',
+    lightThemeId: 'tdrive-light',
+    darkThemeId: 'tokyo-night',
+});
+
+const THEME_ID_SET: ReadonlySet<string> = new Set(THEME_IDS);
+const THEME_BY_ID: ReadonlyMap<ThemeId, ThemeDefinition> = new Map(
+    THEME_DEFINITIONS.map((theme) => [theme.id, theme]),
+);
+const THEMES_BY_APPEARANCE: Readonly<Record<ThemeAppearance, readonly ThemeDefinition[]>> = Object.freeze({
+    light: Object.freeze(THEME_DEFINITIONS.filter((theme) => theme.appearance === 'light')),
+    dark: Object.freeze(THEME_DEFINITIONS.filter((theme) => theme.appearance === 'dark')),
+});
+
+export function isThemeAppearance(value: unknown): value is ThemeAppearance {
+    return value === 'light' || value === 'dark';
+}
+
+export function isThemeMode(value: unknown): value is ThemeMode {
+    return value === 'system' || isThemeAppearance(value);
+}
+
+export function isThemeId(value: unknown): value is ThemeId {
+    return typeof value === 'string' && THEME_ID_SET.has(value);
+}
+
+export function getThemeDefinition(themeId: ThemeId): ThemeDefinition {
+    // Every ThemeId originates from THEME_IDS, so this lookup is exhaustive.
+    return THEME_BY_ID.get(themeId) as ThemeDefinition;
+}
+
+export function themesForAppearance(appearance: ThemeAppearance): readonly ThemeDefinition[] {
+    return THEMES_BY_APPEARANCE[appearance];
+}
+
+export function isThemeForAppearance(value: unknown, appearance: ThemeAppearance): value is ThemeId {
+    return isThemeId(value) && getThemeDefinition(value).appearance === appearance;
+}
+
+/** Returns a fresh, validated preference suitable for application state. */
+export function normalizeThemePreference(value: unknown): ThemePreference {
+    const candidate = isRecord(value) ? value : {};
+    const mode = isThemeMode(candidate.mode) ? candidate.mode : DEFAULT_THEME_PREFERENCE.mode;
+    const lightThemeId = isThemeForAppearance(candidate.lightThemeId, 'light')
+        ? candidate.lightThemeId
+        : DEFAULT_THEME_PREFERENCE.lightThemeId;
+    const darkThemeId = isThemeForAppearance(candidate.darkThemeId, 'dark')
+        ? candidate.darkThemeId
+        : DEFAULT_THEME_PREFERENCE.darkThemeId;
+
+    return Object.freeze({ mode, lightThemeId, darkThemeId });
+}
+
+export function resolveThemeAppearance(
+    preference: ThemePreference,
+    systemAppearance: ThemeAppearance,
+): ThemeAppearance {
+    return preference.mode === 'system' ? systemAppearance : preference.mode;
+}
+
+export function resolveThemeId(
+    preference: ThemePreference,
+    systemAppearance: ThemeAppearance,
+): ThemeId {
+    return resolveThemeAppearance(preference, systemAppearance) === 'light'
+        ? preference.lightThemeId
+        : preference.darkThemeId;
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/frontend/src/ui/theme/theme-model.ts
+++ b/frontend/src/ui/theme/theme-model.ts
@@ -20,7 +20,6 @@ export interface ThemeDefinition {
     readonly id: ThemeId;
     readonly name: string;
     readonly appearance: ThemeAppearance;
-    readonly description: string;
     readonly preview: ThemePreview;
 }
 
@@ -47,70 +46,60 @@ export const THEME_DEFINITIONS: readonly ThemeDefinition[] = Object.freeze([
         id: 'tdrive-light',
         name: 'TDrive Light',
         appearance: 'light',
-        description: 'Crisp, calm, and unmistakably TDrive.',
         preview: ['#f3f5f9', '#eceff5', '#315fc4', '#101828'],
     }),
     defineTheme({
         id: 'catppuccin-latte',
         name: 'Catppuccin Latte',
         appearance: 'light',
-        description: 'Warm pastels with gentle contrast.',
         preview: ['#eff1f5', '#dfe3eb', '#1d61ea', '#4c4f69'],
     }),
     defineTheme({
         id: 'solarized-light',
         name: 'Solarized Light',
         appearance: 'light',
-        description: 'Paper-soft tones for focused work.',
         preview: ['#fdf6e3', '#eee8d5', '#1676ad', '#073642'],
     }),
     defineTheme({
         id: 'gruvbox-light',
         name: 'Gruvbox Light',
         appearance: 'light',
-        description: 'A warm retro palette with earthy depth.',
         preview: ['#fbf1c7', '#ebdbb2', '#076678', '#282828'],
     }),
     defineTheme({
         id: 'tokyo-night',
         name: 'Tokyo Night',
         appearance: 'dark',
-        description: 'TDrive’s original midnight-blue glow.',
         preview: ['#1a1b26', '#24283b', '#7aa2f7', '#f5f7ff'],
     }),
     defineTheme({
         id: 'catppuccin-mocha',
         name: 'Catppuccin Mocha',
         appearance: 'dark',
-        description: 'Velvety dark surfaces and soft pastels.',
         preview: ['#1e1e2e', '#313244', '#89b4fa', '#f1f3fb'],
     }),
     defineTheme({
         id: 'dracula',
         name: 'Dracula',
         appearance: 'dark',
-        description: 'Vivid violet energy on charcoal.',
         preview: ['#282a36', '#383a4a', '#bd93f9', '#f8f8f2'],
     }),
     defineTheme({
         id: 'solarized-dark',
         name: 'Solarized Dark',
         appearance: 'dark',
-        description: 'Low-glare contrast with oceanic accents.',
         preview: ['#002b36', '#0d414d', '#36a4d9', '#f5efdd'],
     }),
     defineTheme({
         id: 'gruvbox-dark',
         name: 'Gruvbox Dark',
         appearance: 'dark',
-        description: 'Cozy earth tones built for long sessions.',
         preview: ['#282828', '#3c3836', '#83a598', '#fbf1c7'],
     }),
     defineTheme({
         id: 'nord',
         name: 'Nord',
         appearance: 'dark',
-        description: 'Cool arctic hues with quiet clarity.',
         preview: ['#2e3440', '#3b4252', '#88c0d0', '#eceff4'],
     }),
 ]);

--- a/frontend/src/ui/theme/theme-model.ts
+++ b/frontend/src/ui/theme/theme-model.ts
@@ -52,13 +52,13 @@ export const THEME_DEFINITIONS: readonly ThemeDefinition[] = Object.freeze([
         id: 'catppuccin-latte',
         name: 'Catppuccin Latte',
         appearance: 'light',
-        preview: ['#eff1f5', '#dfe3eb', '#1d61ea', '#4c4f69'],
+        preview: ['#eff1f5', '#dfe3eb', '#1c60e8', '#4c4f69'],
     }),
     defineTheme({
         id: 'solarized-light',
         name: 'Solarized Light',
         appearance: 'light',
-        preview: ['#fdf6e3', '#eee8d5', '#1676ad', '#073642'],
+        preview: ['#fdf6e3', '#eee8d5', '#126d9f', '#073642'],
     }),
     defineTheme({
         id: 'gruvbox-light',

--- a/frontend/src/ui/theme/theme-model.ts
+++ b/frontend/src/ui/theme/theme-model.ts
@@ -13,7 +13,7 @@ export const THEME_IDS = [
 
 export type ThemeId = (typeof THEME_IDS)[number];
 export type ThemeAppearance = 'light' | 'dark';
-export type ThemeMode = 'system' | ThemeAppearance;
+export type ThemeMode = ThemeAppearance;
 export type ThemePreview = readonly [canvas: string, surface: string, accent: string, text: string];
 
 export interface ThemeDefinition {
@@ -105,7 +105,7 @@ export const THEME_DEFINITIONS: readonly ThemeDefinition[] = Object.freeze([
 ]);
 
 export const DEFAULT_THEME_PREFERENCE: ThemePreference = Object.freeze({
-    mode: 'system',
+    mode: 'dark',
     lightThemeId: 'tdrive-light',
     darkThemeId: 'tokyo-night',
 });
@@ -124,7 +124,7 @@ export function isThemeAppearance(value: unknown): value is ThemeAppearance {
 }
 
 export function isThemeMode(value: unknown): value is ThemeMode {
-    return value === 'system' || isThemeAppearance(value);
+    return isThemeAppearance(value);
 }
 
 export function isThemeId(value: unknown): value is ThemeId {
@@ -158,18 +158,8 @@ export function normalizeThemePreference(value: unknown): ThemePreference {
     return Object.freeze({ mode, lightThemeId, darkThemeId });
 }
 
-export function resolveThemeAppearance(
-    preference: ThemePreference,
-    systemAppearance: ThemeAppearance,
-): ThemeAppearance {
-    return preference.mode === 'system' ? systemAppearance : preference.mode;
-}
-
-export function resolveThemeId(
-    preference: ThemePreference,
-    systemAppearance: ThemeAppearance,
-): ThemeId {
-    return resolveThemeAppearance(preference, systemAppearance) === 'light'
+export function resolveThemeId(preference: ThemePreference): ThemeId {
+    return preference.mode === 'light'
         ? preference.lightThemeId
         : preference.darkThemeId;
 }

--- a/frontend/src/ui/theme/theme-motion.test.ts
+++ b/frontend/src/ui/theme/theme-motion.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from 'vitest';
 const globalCss = readFileSync(new URL('../../style.css', import.meta.url), 'utf8');
 
 describe('theme transition motion', () => {
-    it('uses a relaxed but still responsive reveal cadence', () => {
-        expect(globalCss).toContain('theme-old-fade 300ms');
-        expect(globalCss).toContain('theme-new-reveal 480ms');
-        expect(globalCss).toContain('theme-app-settle 340ms');
+    it('uses a deliberate one-second reveal cadence', () => {
+        expect(globalCss).toContain('theme-old-fade 600ms');
+        expect(globalCss).toContain('theme-new-reveal 1000ms');
+        expect(globalCss).toContain('theme-app-settle 1000ms');
     });
 });

--- a/frontend/src/ui/theme/theme-motion.test.ts
+++ b/frontend/src/ui/theme/theme-motion.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from 'vitest';
 const globalCss = readFileSync(new URL('../../style.css', import.meta.url), 'utf8');
 
 describe('theme transition motion', () => {
-    it('uses a deliberate one-second reveal cadence', () => {
-        expect(globalCss).toContain('theme-old-fade 600ms');
-        expect(globalCss).toContain('theme-new-reveal 1000ms');
-        expect(globalCss).toContain('theme-app-settle 1000ms');
+    it('uses a deliberate 1.2-second reveal cadence', () => {
+        expect(globalCss).toContain('theme-old-fade 720ms');
+        expect(globalCss).toContain('theme-new-reveal 1200ms');
+        expect(globalCss).toContain('theme-app-settle 1200ms');
     });
 });

--- a/frontend/src/ui/theme/theme-motion.test.ts
+++ b/frontend/src/ui/theme/theme-motion.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const globalCss = readFileSync(new URL('../../style.css', import.meta.url), 'utf8');
+
+describe('theme transition motion', () => {
+    it('uses a relaxed but still responsive reveal cadence', () => {
+        expect(globalCss).toContain('theme-old-fade 300ms');
+        expect(globalCss).toContain('theme-new-reveal 480ms');
+        expect(globalCss).toContain('theme-app-settle 340ms');
+    });
+});

--- a/frontend/src/ui/theme/theme-palettes.css
+++ b/frontend/src/ui/theme/theme-palettes.css
@@ -5,10 +5,8 @@
  * mapping its visual language onto this contract. Keeping every theme here
  * makes palette changes cheap, predictable, and independent of layout CSS.
  *
- * The unscoped fallback is Tokyo Night, TDrive's original palette. Before the
- * theme controller starts, light-mode operating systems receive TDrive Light
- * through the media-query fallback at the end of this file. This prevents a
- * bright or dark flash without making JavaScript part of first paint.
+ * The unscoped fallback is Tokyo Night, TDrive's original palette, so first
+ * paint remains deterministic before the theme controller starts.
  */
 
 /*
@@ -659,72 +657,4 @@
     --overlay-success-soft: var(--overlay-success-1);
     --overlay-success-strong: var(--overlay-success-2);
 
-}
-
-/*
- * First-paint fallback for system light mode. This selector only applies
- * before the controller has selected an explicit data-theme value.
- */
-@media (prefers-color-scheme: light) {
-    :root:not([data-theme]) {
-        color-scheme: light;
-
-        --color-canvas: #f3f5f9;
-        --color-surface-0: #ffffff;
-        --color-surface-1: #f8f9fc;
-        --color-surface-2: #eceff5;
-        --color-surface-3: #dfe4ed;
-        --color-text: #101828;
-        --color-text-soft: #344054;
-        --color-text-muted: #526078;
-        --color-text-subtle: #626c80;
-        --color-border: #c8d0dc;
-        --color-border-soft: #dce1e9;
-        --color-accent: #315fc4;
-        --color-accent-hover: #2552ae;
-        --color-accent-strong: #1d4699;
-        --color-on-accent: #ffffff;
-        --color-danger: #c52d48;
-        --color-on-danger: #ffffff;
-        --color-warning: #945500;
-        --color-success: #167348;
-
-        --shadow-sm: 0 8px 24px rgba(40, 51, 73, 0.10);
-        --shadow-md: 0 18px 48px rgba(40, 51, 73, 0.14);
-        --shadow-lg: 0 28px 80px rgba(40, 51, 73, 0.18);
-        --focus-ring: 0 0 0 3px rgba(49, 95, 196, 0.24);
-        --glass-bg: rgba(255, 255, 255, 0.84);
-        --glass-border: rgba(16, 24, 40, 0.10);
-        --glass-highlight: rgba(255, 255, 255, 0.72);
-        --scrim: rgba(31, 41, 55, 0.42);
-
-        --overlay-neutral-1: rgba(16, 24, 40, 0.04);
-        --overlay-neutral-2: rgba(16, 24, 40, 0.07);
-        --overlay-neutral-3: rgba(16, 24, 40, 0.12);
-        --overlay-white-1: rgba(16, 24, 40, 0.04);
-        --overlay-white-2: rgba(16, 24, 40, 0.07);
-        --overlay-white-3: rgba(16, 24, 40, 0.12);
-        --overlay-accent-1: rgba(49, 95, 196, 0.09);
-        --overlay-accent-2: rgba(49, 95, 196, 0.15);
-        --overlay-accent-3: rgba(49, 95, 196, 0.27);
-        --overlay-danger-1: rgba(197, 45, 72, 0.09);
-        --overlay-danger-2: rgba(197, 45, 72, 0.22);
-        --overlay-warning-1: rgba(148, 85, 0, 0.10);
-        --overlay-warning-2: rgba(148, 85, 0, 0.23);
-        --overlay-success-1: rgba(22, 115, 72, 0.09);
-        --overlay-success-2: rgba(22, 115, 72, 0.22);
-
-        --overlay-neutral-soft: var(--overlay-neutral-1);
-        --overlay-neutral-hover: var(--overlay-neutral-2);
-        --overlay-neutral-strong: var(--overlay-neutral-3);
-        --overlay-accent-soft: var(--overlay-accent-1);
-        --overlay-accent-strong: var(--overlay-accent-3);
-        --overlay-danger-soft: var(--overlay-danger-1);
-        --overlay-danger-strong: var(--overlay-danger-2);
-        --overlay-warning-soft: var(--overlay-warning-1);
-        --overlay-warning-strong: var(--overlay-warning-2);
-        --overlay-success-soft: var(--overlay-success-1);
-        --overlay-success-strong: var(--overlay-success-2);
-
-    }
 }

--- a/frontend/src/ui/theme/theme-palettes.css
+++ b/frontend/src/ui/theme/theme-palettes.css
@@ -1,0 +1,702 @@
+/*
+ * TDrive theme palettes
+ *
+ * Components consume semantic tokens only; a palette is responsible for
+ * mapping its visual language onto this contract. Keeping every theme here
+ * makes palette changes cheap, predictable, and independent of layout CSS.
+ *
+ * The unscoped fallback is Tokyo Night, TDrive's original palette. Before the
+ * theme controller starts, light-mode operating systems receive TDrive Light
+ * through the media-query fallback at the end of this file. This prevents a
+ * bright or dark flash without making JavaScript part of first paint.
+ */
+
+:root:not([data-theme]),
+:root[data-theme="tokyo-night"] {
+    color-scheme: dark;
+
+    /* Original TDrive / Tokyo Night palette. Keep these values stable. */
+    --color-canvas: #1a1b26;
+    --color-surface-0: #16161e;
+    --color-surface-1: #1f2335;
+    --color-surface-2: #24283b;
+    --color-surface-3: #2f3650;
+    --color-text: #f5f7ff;
+    --color-text-soft: #c0caf5;
+    --color-text-muted: #8b95c5;
+    --color-text-subtle: #6f789e;
+    --color-border: #2f3650;
+    --color-border-soft: #292e42;
+    --color-accent: #7aa2f7;
+    --color-accent-hover: #8fb4ff;
+    --color-accent-strong: #5d85e0;
+    --color-on-accent: #16161e;
+    --color-danger: #f7768e;
+    --color-on-danger: #16161e;
+    --color-warning: #e0af68;
+    --color-success: #34c759;
+
+    --shadow-sm: 0 8px 24px rgba(0, 0, 0, 0.24);
+    --shadow-md: 0 16px 44px rgba(0, 0, 0, 0.36);
+    --shadow-lg: 0 24px 72px rgba(0, 0, 0, 0.48);
+    --focus-ring: 0 0 0 3px rgba(122, 162, 247, 0.34);
+    --glass-bg: rgba(36, 40, 59, 0.88);
+    --glass-border: rgba(255, 255, 255, 0.08);
+    --glass-highlight: rgba(255, 255, 255, 0.04);
+    --scrim: rgba(0, 0, 0, 0.55);
+
+    --overlay-neutral-1: rgba(255, 255, 255, 0.04);
+    --overlay-neutral-2: rgba(255, 255, 255, 0.08);
+    --overlay-neutral-3: rgba(255, 255, 255, 0.12);
+    --overlay-white-1: rgba(255, 255, 255, 0.04);
+    --overlay-white-2: rgba(255, 255, 255, 0.08);
+    --overlay-white-3: rgba(255, 255, 255, 0.12);
+    --overlay-accent-1: rgba(122, 162, 247, 0.10);
+    --overlay-accent-2: rgba(122, 162, 247, 0.16);
+    --overlay-accent-3: rgba(122, 162, 247, 0.32);
+    --overlay-danger-1: rgba(247, 118, 142, 0.10);
+    --overlay-danger-2: rgba(247, 118, 142, 0.28);
+    --overlay-warning-1: rgba(224, 175, 104, 0.12);
+    --overlay-warning-2: rgba(224, 175, 104, 0.30);
+    --overlay-success-1: rgba(52, 199, 89, 0.12);
+    --overlay-success-2: rgba(52, 199, 89, 0.30);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="tdrive-light"] {
+    color-scheme: light;
+
+    --color-canvas: #f3f5f9;
+    --color-surface-0: #ffffff;
+    --color-surface-1: #f8f9fc;
+    --color-surface-2: #eceff5;
+    --color-surface-3: #dfe4ed;
+    --color-text: #101828;
+    --color-text-soft: #344054;
+    --color-text-muted: #526078;
+    --color-text-subtle: #667085;
+    --color-border: #c8d0dc;
+    --color-border-soft: #dce1e9;
+    --color-accent: #315fc4;
+    --color-accent-hover: #2552ae;
+    --color-accent-strong: #1d4699;
+    --color-on-accent: #ffffff;
+    --color-danger: #c52d48;
+    --color-on-danger: #ffffff;
+    --color-warning: #945500;
+    --color-success: #167348;
+
+    --shadow-sm: 0 8px 24px rgba(40, 51, 73, 0.10);
+    --shadow-md: 0 18px 48px rgba(40, 51, 73, 0.14);
+    --shadow-lg: 0 28px 80px rgba(40, 51, 73, 0.18);
+    --focus-ring: 0 0 0 3px rgba(49, 95, 196, 0.24);
+    --glass-bg: rgba(255, 255, 255, 0.84);
+    --glass-border: rgba(16, 24, 40, 0.10);
+    --glass-highlight: rgba(255, 255, 255, 0.72);
+    --scrim: rgba(31, 41, 55, 0.42);
+
+    --overlay-neutral-1: rgba(16, 24, 40, 0.04);
+    --overlay-neutral-2: rgba(16, 24, 40, 0.07);
+    --overlay-neutral-3: rgba(16, 24, 40, 0.12);
+    --overlay-white-1: rgba(16, 24, 40, 0.04);
+    --overlay-white-2: rgba(16, 24, 40, 0.07);
+    --overlay-white-3: rgba(16, 24, 40, 0.12);
+    --overlay-accent-1: rgba(49, 95, 196, 0.09);
+    --overlay-accent-2: rgba(49, 95, 196, 0.15);
+    --overlay-accent-3: rgba(49, 95, 196, 0.27);
+    --overlay-danger-1: rgba(197, 45, 72, 0.09);
+    --overlay-danger-2: rgba(197, 45, 72, 0.22);
+    --overlay-warning-1: rgba(148, 85, 0, 0.10);
+    --overlay-warning-2: rgba(148, 85, 0, 0.23);
+    --overlay-success-1: rgba(22, 115, 72, 0.09);
+    --overlay-success-2: rgba(22, 115, 72, 0.22);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="catppuccin-latte"] {
+    color-scheme: light;
+
+    --color-canvas: #eff1f5;
+    --color-surface-0: #ffffff;
+    --color-surface-1: #e9ecf2;
+    --color-surface-2: #dfe3eb;
+    --color-surface-3: #ccd0da;
+    --color-text: #4c4f69;
+    --color-text-soft: #5c5f77;
+    --color-text-muted: #606378;
+    --color-text-subtle: #676a80;
+    --color-border: #bcc0cc;
+    --color-border-soft: #d3d6df;
+    --color-accent: #1d61ea;
+    --color-accent-hover: #1854ce;
+    --color-accent-strong: #1547b0;
+    --color-on-accent: #ffffff;
+    --color-danger: #c71943;
+    --color-on-danger: #ffffff;
+    --color-warning: #965300;
+    --color-success: #2f7a24;
+
+    --shadow-sm: 0 8px 24px rgba(76, 79, 105, 0.11);
+    --shadow-md: 0 18px 48px rgba(76, 79, 105, 0.15);
+    --shadow-lg: 0 28px 80px rgba(76, 79, 105, 0.20);
+    --focus-ring: 0 0 0 3px rgba(29, 97, 234, 0.23);
+    --glass-bg: rgba(255, 255, 255, 0.84);
+    --glass-border: rgba(76, 79, 105, 0.12);
+    --glass-highlight: rgba(255, 255, 255, 0.72);
+    --scrim: rgba(44, 47, 63, 0.43);
+
+    --overlay-neutral-1: rgba(76, 79, 105, 0.04);
+    --overlay-neutral-2: rgba(76, 79, 105, 0.08);
+    --overlay-neutral-3: rgba(76, 79, 105, 0.13);
+    --overlay-white-1: rgba(76, 79, 105, 0.04);
+    --overlay-white-2: rgba(76, 79, 105, 0.08);
+    --overlay-white-3: rgba(76, 79, 105, 0.13);
+    --overlay-accent-1: rgba(29, 97, 234, 0.09);
+    --overlay-accent-2: rgba(29, 97, 234, 0.15);
+    --overlay-accent-3: rgba(29, 97, 234, 0.27);
+    --overlay-danger-1: rgba(199, 25, 67, 0.09);
+    --overlay-danger-2: rgba(199, 25, 67, 0.23);
+    --overlay-warning-1: rgba(150, 83, 0, 0.10);
+    --overlay-warning-2: rgba(150, 83, 0, 0.24);
+    --overlay-success-1: rgba(47, 122, 36, 0.09);
+    --overlay-success-2: rgba(47, 122, 36, 0.22);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="solarized-light"] {
+    color-scheme: light;
+
+    --color-canvas: #fdf6e3;
+    --color-surface-0: #fffaf0;
+    --color-surface-1: #f4eedc;
+    --color-surface-2: #eee8d5;
+    --color-surface-3: #ddd6c2;
+    --color-text: #073642;
+    --color-text-soft: #3f5961;
+    --color-text-muted: #536970;
+    --color-text-subtle: #61737a;
+    --color-border: #c9c1ad;
+    --color-border-soft: #ded7c4;
+    --color-accent: #1676ad;
+    --color-accent-hover: #0d6699;
+    --color-accent-strong: #075681;
+    --color-on-accent: #ffffff;
+    --color-danger: #c62f35;
+    --color-on-danger: #ffffff;
+    --color-warning: #8a5a00;
+    --color-success: #4e7000;
+
+    --shadow-sm: 0 8px 24px rgba(54, 65, 64, 0.11);
+    --shadow-md: 0 18px 48px rgba(54, 65, 64, 0.15);
+    --shadow-lg: 0 28px 80px rgba(54, 65, 64, 0.20);
+    --focus-ring: 0 0 0 3px rgba(22, 118, 173, 0.24);
+    --glass-bg: rgba(255, 250, 240, 0.86);
+    --glass-border: rgba(7, 54, 66, 0.12);
+    --glass-highlight: rgba(255, 255, 255, 0.64);
+    --scrim: rgba(0, 43, 54, 0.45);
+
+    --overlay-neutral-1: rgba(7, 54, 66, 0.04);
+    --overlay-neutral-2: rgba(7, 54, 66, 0.08);
+    --overlay-neutral-3: rgba(7, 54, 66, 0.13);
+    --overlay-white-1: rgba(7, 54, 66, 0.04);
+    --overlay-white-2: rgba(7, 54, 66, 0.08);
+    --overlay-white-3: rgba(7, 54, 66, 0.13);
+    --overlay-accent-1: rgba(22, 118, 173, 0.09);
+    --overlay-accent-2: rgba(22, 118, 173, 0.15);
+    --overlay-accent-3: rgba(22, 118, 173, 0.28);
+    --overlay-danger-1: rgba(198, 47, 53, 0.09);
+    --overlay-danger-2: rgba(198, 47, 53, 0.23);
+    --overlay-warning-1: rgba(138, 90, 0, 0.10);
+    --overlay-warning-2: rgba(138, 90, 0, 0.24);
+    --overlay-success-1: rgba(78, 112, 0, 0.09);
+    --overlay-success-2: rgba(78, 112, 0, 0.22);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="gruvbox-light"] {
+    color-scheme: light;
+
+    --color-canvas: #fbf1c7;
+    --color-surface-0: #fffaf0;
+    --color-surface-1: #f5e9bd;
+    --color-surface-2: #ebdbb2;
+    --color-surface-3: #d5c4a1;
+    --color-text: #282828;
+    --color-text-soft: #3c3836;
+    --color-text-muted: #5f554d;
+    --color-text-subtle: #6b6056;
+    --color-border: #bdae93;
+    --color-border-soft: #d8c8a3;
+    --color-accent: #076678;
+    --color-accent-hover: #005566;
+    --color-accent-strong: #004552;
+    --color-on-accent: #ffffff;
+    --color-danger: #9d0006;
+    --color-on-danger: #ffffff;
+    --color-warning: #8b5000;
+    --color-success: #586500;
+
+    --shadow-sm: 0 8px 24px rgba(60, 56, 54, 0.11);
+    --shadow-md: 0 18px 48px rgba(60, 56, 54, 0.16);
+    --shadow-lg: 0 28px 80px rgba(60, 56, 54, 0.21);
+    --focus-ring: 0 0 0 3px rgba(7, 102, 120, 0.24);
+    --glass-bg: rgba(255, 250, 240, 0.85);
+    --glass-border: rgba(40, 40, 40, 0.13);
+    --glass-highlight: rgba(255, 255, 255, 0.60);
+    --scrim: rgba(40, 40, 40, 0.45);
+
+    --overlay-neutral-1: rgba(40, 40, 40, 0.04);
+    --overlay-neutral-2: rgba(40, 40, 40, 0.08);
+    --overlay-neutral-3: rgba(40, 40, 40, 0.14);
+    --overlay-white-1: rgba(40, 40, 40, 0.04);
+    --overlay-white-2: rgba(40, 40, 40, 0.08);
+    --overlay-white-3: rgba(40, 40, 40, 0.14);
+    --overlay-accent-1: rgba(7, 102, 120, 0.09);
+    --overlay-accent-2: rgba(7, 102, 120, 0.15);
+    --overlay-accent-3: rgba(7, 102, 120, 0.28);
+    --overlay-danger-1: rgba(157, 0, 6, 0.09);
+    --overlay-danger-2: rgba(157, 0, 6, 0.23);
+    --overlay-warning-1: rgba(139, 80, 0, 0.10);
+    --overlay-warning-2: rgba(139, 80, 0, 0.24);
+    --overlay-success-1: rgba(88, 101, 0, 0.09);
+    --overlay-success-2: rgba(88, 101, 0, 0.22);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="catppuccin-mocha"] {
+    color-scheme: dark;
+
+    --color-canvas: #1e1e2e;
+    --color-surface-0: #181825;
+    --color-surface-1: #242435;
+    --color-surface-2: #313244;
+    --color-surface-3: #45475a;
+    --color-text: #f1f3fb;
+    --color-text-soft: #cdd6f4;
+    --color-text-muted: #a6adc8;
+    --color-text-subtle: #8f96b0;
+    --color-border: #45475a;
+    --color-border-soft: #313244;
+    --color-accent: #89b4fa;
+    --color-accent-hover: #a4c6ff;
+    --color-accent-strong: #6ea2f3;
+    --color-on-accent: #11111b;
+    --color-danger: #f38ba8;
+    --color-on-danger: #1e1e2e;
+    --color-warning: #f9e2af;
+    --color-success: #a6e3a1;
+
+    --shadow-sm: 0 8px 24px rgba(10, 10, 18, 0.26);
+    --shadow-md: 0 16px 44px rgba(10, 10, 18, 0.38);
+    --shadow-lg: 0 24px 72px rgba(10, 10, 18, 0.50);
+    --focus-ring: 0 0 0 3px rgba(137, 180, 250, 0.34);
+    --glass-bg: rgba(24, 24, 37, 0.82);
+    --glass-border: rgba(205, 214, 244, 0.13);
+    --glass-highlight: rgba(205, 214, 244, 0.08);
+    --scrim: rgba(8, 8, 14, 0.73);
+
+    --overlay-neutral-1: rgba(205, 214, 244, 0.04);
+    --overlay-neutral-2: rgba(205, 214, 244, 0.08);
+    --overlay-neutral-3: rgba(205, 214, 244, 0.13);
+    --overlay-white-1: rgba(205, 214, 244, 0.04);
+    --overlay-white-2: rgba(205, 214, 244, 0.08);
+    --overlay-white-3: rgba(205, 214, 244, 0.13);
+    --overlay-accent-1: rgba(137, 180, 250, 0.10);
+    --overlay-accent-2: rgba(137, 180, 250, 0.16);
+    --overlay-accent-3: rgba(137, 180, 250, 0.32);
+    --overlay-danger-1: rgba(243, 139, 168, 0.10);
+    --overlay-danger-2: rgba(243, 139, 168, 0.28);
+    --overlay-warning-1: rgba(249, 226, 175, 0.11);
+    --overlay-warning-2: rgba(249, 226, 175, 0.28);
+    --overlay-success-1: rgba(166, 227, 161, 0.10);
+    --overlay-success-2: rgba(166, 227, 161, 0.27);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="dracula"] {
+    color-scheme: dark;
+
+    --color-canvas: #282a36;
+    --color-surface-0: #21222c;
+    --color-surface-1: #30323f;
+    --color-surface-2: #383a4a;
+    --color-surface-3: #44475a;
+    --color-text: #f8f8f2;
+    --color-text-soft: #e7e7f0;
+    --color-text-muted: #adb4d3;
+    --color-text-subtle: #929cc3;
+    --color-border: #55586f;
+    --color-border-soft: #44475a;
+    --color-accent: #bd93f9;
+    --color-accent-hover: #ccaaff;
+    --color-accent-strong: #a879ec;
+    --color-on-accent: #211a2f;
+    --color-danger: #ff6e7a;
+    --color-on-danger: #2b171c;
+    --color-warning: #f1fa8c;
+    --color-success: #50fa7b;
+
+    --shadow-sm: 0 8px 24px rgba(13, 14, 18, 0.26);
+    --shadow-md: 0 16px 44px rgba(13, 14, 18, 0.38);
+    --shadow-lg: 0 24px 72px rgba(13, 14, 18, 0.50);
+    --focus-ring: 0 0 0 3px rgba(189, 147, 249, 0.34);
+    --glass-bg: rgba(33, 34, 44, 0.82);
+    --glass-border: rgba(248, 248, 242, 0.13);
+    --glass-highlight: rgba(248, 248, 242, 0.08);
+    --scrim: rgba(12, 13, 17, 0.73);
+
+    --overlay-neutral-1: rgba(248, 248, 242, 0.04);
+    --overlay-neutral-2: rgba(248, 248, 242, 0.08);
+    --overlay-neutral-3: rgba(248, 248, 242, 0.13);
+    --overlay-white-1: rgba(248, 248, 242, 0.04);
+    --overlay-white-2: rgba(248, 248, 242, 0.08);
+    --overlay-white-3: rgba(248, 248, 242, 0.13);
+    --overlay-accent-1: rgba(189, 147, 249, 0.10);
+    --overlay-accent-2: rgba(189, 147, 249, 0.16);
+    --overlay-accent-3: rgba(189, 147, 249, 0.32);
+    --overlay-danger-1: rgba(255, 110, 122, 0.10);
+    --overlay-danger-2: rgba(255, 110, 122, 0.28);
+    --overlay-warning-1: rgba(241, 250, 140, 0.11);
+    --overlay-warning-2: rgba(241, 250, 140, 0.27);
+    --overlay-success-1: rgba(80, 250, 123, 0.10);
+    --overlay-success-2: rgba(80, 250, 123, 0.27);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="solarized-dark"] {
+    color-scheme: dark;
+
+    --color-canvas: #002b36;
+    --color-surface-0: #00252f;
+    --color-surface-1: #073642;
+    --color-surface-2: #0d414d;
+    --color-surface-3: #174f5b;
+    --color-text: #f5efdd;
+    --color-text-soft: #c8c5b6;
+    --color-text-muted: #9aa9a7;
+    --color-text-subtle: #849795;
+    --color-border: #315e67;
+    --color-border-soft: #174a55;
+    --color-accent: #36a4d9;
+    --color-accent-hover: #55b5e2;
+    --color-accent-strong: #258ec2;
+    --color-on-accent: #002b36;
+    --color-danger: #f06a61;
+    --color-on-danger: #2b1110;
+    --color-warning: #e3bd47;
+    --color-success: #9fbd45;
+
+    --shadow-sm: 0 8px 24px rgba(0, 19, 24, 0.28);
+    --shadow-md: 0 16px 44px rgba(0, 19, 24, 0.40);
+    --shadow-lg: 0 24px 72px rgba(0, 19, 24, 0.52);
+    --focus-ring: 0 0 0 3px rgba(54, 164, 217, 0.34);
+    --glass-bg: rgba(0, 37, 47, 0.83);
+    --glass-border: rgba(238, 232, 213, 0.14);
+    --glass-highlight: rgba(238, 232, 213, 0.08);
+    --scrim: rgba(0, 18, 23, 0.75);
+
+    --overlay-neutral-1: rgba(238, 232, 213, 0.04);
+    --overlay-neutral-2: rgba(238, 232, 213, 0.08);
+    --overlay-neutral-3: rgba(238, 232, 213, 0.13);
+    --overlay-white-1: rgba(238, 232, 213, 0.04);
+    --overlay-white-2: rgba(238, 232, 213, 0.08);
+    --overlay-white-3: rgba(238, 232, 213, 0.13);
+    --overlay-accent-1: rgba(54, 164, 217, 0.10);
+    --overlay-accent-2: rgba(54, 164, 217, 0.16);
+    --overlay-accent-3: rgba(54, 164, 217, 0.32);
+    --overlay-danger-1: rgba(240, 106, 97, 0.10);
+    --overlay-danger-2: rgba(240, 106, 97, 0.28);
+    --overlay-warning-1: rgba(227, 189, 71, 0.11);
+    --overlay-warning-2: rgba(227, 189, 71, 0.28);
+    --overlay-success-1: rgba(159, 189, 69, 0.10);
+    --overlay-success-2: rgba(159, 189, 69, 0.27);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="gruvbox-dark"] {
+    color-scheme: dark;
+
+    --color-canvas: #282828;
+    --color-surface-0: #1d2021;
+    --color-surface-1: #32302f;
+    --color-surface-2: #3c3836;
+    --color-surface-3: #504945;
+    --color-text: #fbf1c7;
+    --color-text-soft: #ebdbb2;
+    --color-text-muted: #c0ae90;
+    --color-text-subtle: #aa9b80;
+    --color-border: #665c54;
+    --color-border-soft: #504945;
+    --color-accent: #83a598;
+    --color-accent-hover: #9bb7aa;
+    --color-accent-strong: #6a8f83;
+    --color-on-accent: #1d2021;
+    --color-danger: #fb6654;
+    --color-on-danger: #281512;
+    --color-warning: #fabd2f;
+    --color-success: #b8bb26;
+
+    --shadow-sm: 0 8px 24px rgba(14, 15, 15, 0.28);
+    --shadow-md: 0 16px 44px rgba(14, 15, 15, 0.40);
+    --shadow-lg: 0 24px 72px rgba(14, 15, 15, 0.52);
+    --focus-ring: 0 0 0 3px rgba(131, 165, 152, 0.34);
+    --glass-bg: rgba(29, 32, 33, 0.83);
+    --glass-border: rgba(235, 219, 178, 0.14);
+    --glass-highlight: rgba(235, 219, 178, 0.08);
+    --scrim: rgba(14, 15, 15, 0.74);
+
+    --overlay-neutral-1: rgba(235, 219, 178, 0.04);
+    --overlay-neutral-2: rgba(235, 219, 178, 0.08);
+    --overlay-neutral-3: rgba(235, 219, 178, 0.13);
+    --overlay-white-1: rgba(235, 219, 178, 0.04);
+    --overlay-white-2: rgba(235, 219, 178, 0.08);
+    --overlay-white-3: rgba(235, 219, 178, 0.13);
+    --overlay-accent-1: rgba(131, 165, 152, 0.10);
+    --overlay-accent-2: rgba(131, 165, 152, 0.16);
+    --overlay-accent-3: rgba(131, 165, 152, 0.32);
+    --overlay-danger-1: rgba(251, 102, 84, 0.10);
+    --overlay-danger-2: rgba(251, 102, 84, 0.28);
+    --overlay-warning-1: rgba(250, 189, 47, 0.11);
+    --overlay-warning-2: rgba(250, 189, 47, 0.28);
+    --overlay-success-1: rgba(184, 187, 38, 0.10);
+    --overlay-success-2: rgba(184, 187, 38, 0.27);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+:root[data-theme="nord"] {
+    color-scheme: dark;
+
+    --color-canvas: #2e3440;
+    --color-surface-0: #272c36;
+    --color-surface-1: #353c49;
+    --color-surface-2: #3b4252;
+    --color-surface-3: #4c566a;
+    --color-text: #eceff4;
+    --color-text-soft: #d8dee9;
+    --color-text-muted: #adb9ca;
+    --color-text-subtle: #94a2b7;
+    --color-border: #5c687f;
+    --color-border-soft: #434c5e;
+    --color-accent: #88c0d0;
+    --color-accent-hover: #a0d0dc;
+    --color-accent-strong: #6daabb;
+    --color-on-accent: #202731;
+    --color-danger: #df828b;
+    --color-on-danger: #2a171b;
+    --color-warning: #ebcb8b;
+    --color-success: #a3be8c;
+
+    --shadow-sm: 0 8px 24px rgba(17, 20, 26, 0.27);
+    --shadow-md: 0 16px 44px rgba(17, 20, 26, 0.39);
+    --shadow-lg: 0 24px 72px rgba(17, 20, 26, 0.51);
+    --focus-ring: 0 0 0 3px rgba(136, 192, 208, 0.34);
+    --glass-bg: rgba(39, 44, 54, 0.83);
+    --glass-border: rgba(236, 239, 244, 0.13);
+    --glass-highlight: rgba(236, 239, 244, 0.08);
+    --scrim: rgba(14, 17, 22, 0.73);
+
+    --overlay-neutral-1: rgba(236, 239, 244, 0.04);
+    --overlay-neutral-2: rgba(236, 239, 244, 0.08);
+    --overlay-neutral-3: rgba(236, 239, 244, 0.13);
+    --overlay-white-1: rgba(236, 239, 244, 0.04);
+    --overlay-white-2: rgba(236, 239, 244, 0.08);
+    --overlay-white-3: rgba(236, 239, 244, 0.13);
+    --overlay-accent-1: rgba(136, 192, 208, 0.10);
+    --overlay-accent-2: rgba(136, 192, 208, 0.16);
+    --overlay-accent-3: rgba(136, 192, 208, 0.32);
+    --overlay-danger-1: rgba(223, 130, 139, 0.10);
+    --overlay-danger-2: rgba(223, 130, 139, 0.28);
+    --overlay-warning-1: rgba(235, 203, 139, 0.11);
+    --overlay-warning-2: rgba(235, 203, 139, 0.28);
+    --overlay-success-1: rgba(163, 190, 140, 0.10);
+    --overlay-success-2: rgba(163, 190, 140, 0.27);
+
+    --overlay-neutral-soft: var(--overlay-neutral-1);
+    --overlay-neutral-hover: var(--overlay-neutral-2);
+    --overlay-neutral-strong: var(--overlay-neutral-3);
+    --overlay-accent-soft: var(--overlay-accent-1);
+    --overlay-accent-strong: var(--overlay-accent-3);
+    --overlay-danger-soft: var(--overlay-danger-1);
+    --overlay-danger-strong: var(--overlay-danger-2);
+    --overlay-warning-soft: var(--overlay-warning-1);
+    --overlay-warning-strong: var(--overlay-warning-2);
+    --overlay-success-soft: var(--overlay-success-1);
+    --overlay-success-strong: var(--overlay-success-2);
+
+}
+
+/*
+ * First-paint fallback for system light mode. This selector only applies
+ * before the controller has selected an explicit data-theme value.
+ */
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme]) {
+        color-scheme: light;
+
+        --color-canvas: #f3f5f9;
+        --color-surface-0: #ffffff;
+        --color-surface-1: #f8f9fc;
+        --color-surface-2: #eceff5;
+        --color-surface-3: #dfe4ed;
+        --color-text: #101828;
+        --color-text-soft: #344054;
+        --color-text-muted: #526078;
+        --color-text-subtle: #667085;
+        --color-border: #c8d0dc;
+        --color-border-soft: #dce1e9;
+        --color-accent: #315fc4;
+        --color-accent-hover: #2552ae;
+        --color-accent-strong: #1d4699;
+        --color-on-accent: #ffffff;
+        --color-danger: #c52d48;
+        --color-on-danger: #ffffff;
+        --color-warning: #945500;
+        --color-success: #167348;
+
+        --shadow-sm: 0 8px 24px rgba(40, 51, 73, 0.10);
+        --shadow-md: 0 18px 48px rgba(40, 51, 73, 0.14);
+        --shadow-lg: 0 28px 80px rgba(40, 51, 73, 0.18);
+        --focus-ring: 0 0 0 3px rgba(49, 95, 196, 0.24);
+        --glass-bg: rgba(255, 255, 255, 0.84);
+        --glass-border: rgba(16, 24, 40, 0.10);
+        --glass-highlight: rgba(255, 255, 255, 0.72);
+        --scrim: rgba(31, 41, 55, 0.42);
+
+        --overlay-neutral-1: rgba(16, 24, 40, 0.04);
+        --overlay-neutral-2: rgba(16, 24, 40, 0.07);
+        --overlay-neutral-3: rgba(16, 24, 40, 0.12);
+        --overlay-white-1: rgba(16, 24, 40, 0.04);
+        --overlay-white-2: rgba(16, 24, 40, 0.07);
+        --overlay-white-3: rgba(16, 24, 40, 0.12);
+        --overlay-accent-1: rgba(49, 95, 196, 0.09);
+        --overlay-accent-2: rgba(49, 95, 196, 0.15);
+        --overlay-accent-3: rgba(49, 95, 196, 0.27);
+        --overlay-danger-1: rgba(197, 45, 72, 0.09);
+        --overlay-danger-2: rgba(197, 45, 72, 0.22);
+        --overlay-warning-1: rgba(148, 85, 0, 0.10);
+        --overlay-warning-2: rgba(148, 85, 0, 0.23);
+        --overlay-success-1: rgba(22, 115, 72, 0.09);
+        --overlay-success-2: rgba(22, 115, 72, 0.22);
+
+        --overlay-neutral-soft: var(--overlay-neutral-1);
+        --overlay-neutral-hover: var(--overlay-neutral-2);
+        --overlay-neutral-strong: var(--overlay-neutral-3);
+        --overlay-accent-soft: var(--overlay-accent-1);
+        --overlay-accent-strong: var(--overlay-accent-3);
+        --overlay-danger-soft: var(--overlay-danger-1);
+        --overlay-danger-strong: var(--overlay-danger-2);
+        --overlay-warning-soft: var(--overlay-warning-1);
+        --overlay-warning-strong: var(--overlay-warning-2);
+        --overlay-success-soft: var(--overlay-success-1);
+        --overlay-success-strong: var(--overlay-success-2);
+
+    }
+}

--- a/frontend/src/ui/theme/theme-palettes.css
+++ b/frontend/src/ui/theme/theme-palettes.css
@@ -177,7 +177,7 @@
     --color-text-subtle: #616479;
     --color-border: #bcc0cc;
     --color-border-soft: #d3d6df;
-    --color-accent: #1d61ea;
+    --color-accent: #1c60e8;
     --color-accent-hover: #1854ce;
     --color-accent-strong: #1547b0;
     --color-on-accent: #ffffff;
@@ -239,7 +239,7 @@
     --color-text-subtle: #566b72;
     --color-border: #c9c1ad;
     --color-border-soft: #ded7c4;
-    --color-accent: #1676ad;
+    --color-accent: #126d9f;
     --color-accent-hover: #0d6699;
     --color-accent-strong: #075681;
     --color-on-accent: #ffffff;

--- a/frontend/src/ui/theme/theme-palettes.css
+++ b/frontend/src/ui/theme/theme-palettes.css
@@ -11,6 +11,34 @@
  * bright or dark flash without making JavaScript part of first paint.
  */
 
+/*
+ * Content viewers intentionally remain dark so media, documents, and code do
+ * not jump between radically different presentation environments. Defining
+ * this contract once also prevents an app theme from leaking into viewer
+ * chrome through a generic token alias.
+ */
+:root {
+    --viewer-text: #f5f7ff;
+    --viewer-text-muted: #c0caf5;
+    --viewer-text-subtle: #8b95c5;
+    --viewer-surface-0: #05070c;
+    --viewer-surface-1: #080a0f;
+    --viewer-surface-2: #0b0d14;
+    --viewer-control-hover: #202536;
+    --viewer-border: #596487;
+    --viewer-border-soft: #2b3145;
+    --viewer-accent: #7aa2f7;
+    --viewer-on-accent: #11131a;
+    --viewer-danger: #f7768e;
+    --viewer-on-danger: #16161e;
+    --viewer-overlay-1: rgba(255, 255, 255, 0.04);
+    --viewer-overlay-2: rgba(255, 255, 255, 0.08);
+    --viewer-overlay-3: rgba(255, 255, 255, 0.14);
+    --viewer-scrim: rgba(4, 6, 11, 0.94);
+    --viewer-shadow: 0 18px 54px rgba(0, 0, 0, 0.42);
+    --viewer-focus-ring: 0 0 0 3px rgba(122, 162, 247, 0.42);
+}
+
 :root:not([data-theme]),
 :root[data-theme="tokyo-night"] {
     color-scheme: dark;
@@ -24,7 +52,7 @@
     --color-text: #f5f7ff;
     --color-text-soft: #c0caf5;
     --color-text-muted: #8b95c5;
-    --color-text-subtle: #6f789e;
+    --color-text-subtle: #848ebb;
     --color-border: #2f3650;
     --color-border-soft: #292e42;
     --color-accent: #7aa2f7;
@@ -86,7 +114,7 @@
     --color-text: #101828;
     --color-text-soft: #344054;
     --color-text-muted: #526078;
-    --color-text-subtle: #667085;
+    --color-text-subtle: #626c80;
     --color-border: #c8d0dc;
     --color-border-soft: #dce1e9;
     --color-accent: #315fc4;
@@ -148,7 +176,7 @@
     --color-text: #4c4f69;
     --color-text-soft: #5c5f77;
     --color-text-muted: #606378;
-    --color-text-subtle: #676a80;
+    --color-text-subtle: #616479;
     --color-border: #bcc0cc;
     --color-border-soft: #d3d6df;
     --color-accent: #1d61ea;
@@ -210,7 +238,7 @@
     --color-text: #073642;
     --color-text-soft: #3f5961;
     --color-text-muted: #536970;
-    --color-text-subtle: #61737a;
+    --color-text-subtle: #566b72;
     --color-border: #c9c1ad;
     --color-border-soft: #ded7c4;
     --color-accent: #1676ad;
@@ -272,7 +300,7 @@
     --color-text: #282828;
     --color-text-soft: #3c3836;
     --color-text-muted: #5f554d;
-    --color-text-subtle: #6b6056;
+    --color-text-subtle: #695e55;
     --color-border: #bdae93;
     --color-border-soft: #d8c8a3;
     --color-accent: #076678;
@@ -334,7 +362,7 @@
     --color-text: #f1f3fb;
     --color-text-soft: #cdd6f4;
     --color-text-muted: #a6adc8;
-    --color-text-subtle: #8f96b0;
+    --color-text-subtle: #949bb6;
     --color-border: #45475a;
     --color-border-soft: #313244;
     --color-accent: #89b4fa;
@@ -396,7 +424,7 @@
     --color-text: #f8f8f2;
     --color-text-soft: #e7e7f0;
     --color-text-muted: #adb4d3;
-    --color-text-subtle: #929cc3;
+    --color-text-subtle: #99a4ca;
     --color-border: #55586f;
     --color-border-soft: #44475a;
     --color-accent: #bd93f9;
@@ -458,7 +486,7 @@
     --color-text: #f5efdd;
     --color-text-soft: #c8c5b6;
     --color-text-muted: #9aa9a7;
-    --color-text-subtle: #849795;
+    --color-text-subtle: #99a8a6;
     --color-border: #315e67;
     --color-border-soft: #174a55;
     --color-accent: #36a4d9;
@@ -520,7 +548,7 @@
     --color-text: #fbf1c7;
     --color-text-soft: #ebdbb2;
     --color-text-muted: #c0ae90;
-    --color-text-subtle: #aa9b80;
+    --color-text-subtle: #b1a085;
     --color-border: #665c54;
     --color-border-soft: #504945;
     --color-accent: #83a598;
@@ -582,7 +610,7 @@
     --color-text: #eceff4;
     --color-text-soft: #d8dee9;
     --color-text-muted: #adb9ca;
-    --color-text-subtle: #94a2b7;
+    --color-text-subtle: #a4b0c3;
     --color-border: #5c687f;
     --color-border-soft: #434c5e;
     --color-accent: #88c0d0;
@@ -649,7 +677,7 @@
         --color-text: #101828;
         --color-text-soft: #344054;
         --color-text-muted: #526078;
-        --color-text-subtle: #667085;
+        --color-text-subtle: #626c80;
         --color-border: #c8d0dc;
         --color-border-soft: #dce1e9;
         --color-accent: #315fc4;

--- a/frontend/src/ui/theme/theme-palettes.test.ts
+++ b/frontend/src/ui/theme/theme-palettes.test.ts
@@ -112,6 +112,11 @@ function expectReadablePair(
 }
 
 describe('theme palettes', () => {
+    it('uses Tokyo Night as the deterministic pre-controller fallback', () => {
+        expect(paletteSource).toContain(':root:not([data-theme])');
+        expect(paletteSource).not.toContain('prefers-color-scheme');
+    });
+
     it('defines the complete semantic color contract for every theme', () => {
         for (const theme of THEME_DEFINITIONS) {
             const block = paletteBlock(theme.id);

--- a/frontend/src/ui/theme/theme-palettes.test.ts
+++ b/frontend/src/ui/theme/theme-palettes.test.ts
@@ -153,6 +153,9 @@ describe('theme palettes', () => {
                 ['--color-text-subtle', '--color-surface-0'],
                 ['--color-text-subtle', '--color-surface-1'],
                 ['--color-text-subtle', '--color-surface-2'],
+                ['--color-accent', '--color-surface-1'],
+                ['--color-warning', '--color-surface-1'],
+                ['--color-success', '--color-surface-1'],
                 ['--color-on-accent', '--color-accent'],
                 ['--color-on-danger', '--color-danger'],
             ] as const;

--- a/frontend/src/ui/theme/theme-palettes.test.ts
+++ b/frontend/src/ui/theme/theme-palettes.test.ts
@@ -28,10 +28,40 @@ const requiredTokens = [
     '--scrim',
 ] as const;
 
+const requiredViewerTokens = [
+    '--viewer-text',
+    '--viewer-text-muted',
+    '--viewer-text-subtle',
+    '--viewer-surface-0',
+    '--viewer-surface-1',
+    '--viewer-surface-2',
+    '--viewer-control-hover',
+    '--viewer-border',
+    '--viewer-border-soft',
+    '--viewer-accent',
+    '--viewer-on-accent',
+    '--viewer-danger',
+    '--viewer-on-danger',
+    '--viewer-overlay-1',
+    '--viewer-overlay-2',
+    '--viewer-overlay-3',
+    '--viewer-scrim',
+    '--viewer-shadow',
+    '--viewer-focus-ring',
+] as const;
+
 function paletteBlock(themeId: string): string {
     const selector = new RegExp(`data-theme=["']${themeId}["']`);
     const match = selector.exec(paletteSource);
     if (!match) throw new Error(`missing palette selector for ${themeId}`);
+    const openBrace = paletteSource.indexOf('{', match.index);
+    const closeBrace = paletteSource.indexOf('}', openBrace);
+    return paletteSource.slice(openBrace + 1, closeBrace);
+}
+
+function sharedRootBlock(): string {
+    const match = /^:root\s*\{/m.exec(paletteSource);
+    if (!match) throw new Error('missing shared :root theme contract');
     const openBrace = paletteSource.indexOf('{', match.index);
     const closeBrace = paletteSource.indexOf('}', openBrace);
     return paletteSource.slice(openBrace + 1, closeBrace);
@@ -58,6 +88,27 @@ function contrast(foreground: string, background: string): number {
     const lighter = Math.max(luminance(foreground), luminance(background));
     const darker = Math.min(luminance(foreground), luminance(background));
     return (lighter + 0.05) / (darker + 0.05);
+}
+
+function expectReadablePair(
+    block: string,
+    label: string,
+    foregroundToken: string,
+    backgroundToken: string,
+    minimum = 4.5,
+): void {
+    const foreground = tokenValue(block, foregroundToken);
+    const background = tokenValue(block, backgroundToken);
+    expect(foreground, `${label} ${foregroundToken} must be an auditable six-digit hex color`).toMatch(
+        /^#[\da-f]{6}$/i,
+    );
+    expect(background, `${label} ${backgroundToken} must be an auditable six-digit hex color`).toMatch(
+        /^#[\da-f]{6}$/i,
+    );
+    expect(
+        contrast(foreground, background),
+        `${label} ${foregroundToken} on ${backgroundToken}`,
+    ).toBeGreaterThanOrEqual(minimum);
 }
 
 describe('theme palettes', () => {
@@ -93,19 +144,59 @@ describe('theme palettes', () => {
                 ['--color-text-muted', '--color-surface-0'],
                 ['--color-text-muted', '--color-surface-1'],
                 ['--color-text-muted', '--color-surface-2'],
+                ['--color-text-subtle', '--color-canvas'],
+                ['--color-text-subtle', '--color-surface-0'],
+                ['--color-text-subtle', '--color-surface-1'],
+                ['--color-text-subtle', '--color-surface-2'],
                 ['--color-on-accent', '--color-accent'],
                 ['--color-on-danger', '--color-danger'],
             ] as const;
 
             for (const [foregroundToken, backgroundToken] of pairs) {
-                const foreground = tokenValue(block, foregroundToken);
-                const background = tokenValue(block, backgroundToken);
-                expect(
-                    contrast(foreground, background),
-                    `${theme.id} ${foregroundToken} on ${backgroundToken}`,
-                ).toBeGreaterThanOrEqual(4.5);
+                expectReadablePair(block, theme.id, foregroundToken, backgroundToken);
             }
         }
+    });
+
+    it('defines one fixed-dark semantic contract for content viewers', () => {
+        const block = sharedRootBlock();
+
+        for (const token of requiredViewerTokens) {
+            expect(tokenValue(block, token), `viewer contract is missing ${token}`).not.toBe('');
+        }
+    });
+
+    it('keeps fixed-dark viewer text, controls, and statuses WCAG AA readable', () => {
+        const block = sharedRootBlock();
+        const pairs = [
+            ['--viewer-text', '--viewer-surface-0'],
+            ['--viewer-text', '--viewer-surface-1'],
+            ['--viewer-text', '--viewer-surface-2'],
+            ['--viewer-text-muted', '--viewer-surface-0'],
+            ['--viewer-text-muted', '--viewer-surface-1'],
+            ['--viewer-text-muted', '--viewer-surface-2'],
+            ['--viewer-text-subtle', '--viewer-surface-0'],
+            ['--viewer-text-subtle', '--viewer-surface-1'],
+            ['--viewer-text-subtle', '--viewer-surface-2'],
+            ['--viewer-text', '--viewer-control-hover'],
+            ['--viewer-text-muted', '--viewer-control-hover'],
+            ['--viewer-accent', '--viewer-surface-2'],
+            ['--viewer-danger', '--viewer-surface-2'],
+            ['--viewer-on-accent', '--viewer-accent'],
+            ['--viewer-on-danger', '--viewer-danger'],
+        ] as const;
+
+        for (const [foregroundToken, backgroundToken] of pairs) {
+            expectReadablePair(block, 'fixed viewer', foregroundToken, backgroundToken);
+        }
+
+        expectReadablePair(
+            block,
+            'fixed viewer control boundary',
+            '--viewer-border',
+            '--viewer-surface-2',
+            3,
+        );
     });
 
     it('keeps selector previews synchronized with the applied palette', () => {

--- a/frontend/src/ui/theme/theme-palettes.test.ts
+++ b/frontend/src/ui/theme/theme-palettes.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { THEME_DEFINITIONS } from './theme-model';
+
+const paletteSource = readFileSync(new URL('./theme-palettes.css', import.meta.url), 'utf8');
+const requiredTokens = [
+    '--color-canvas',
+    '--color-surface-0',
+    '--color-surface-1',
+    '--color-surface-2',
+    '--color-surface-3',
+    '--color-text',
+    '--color-text-soft',
+    '--color-text-muted',
+    '--color-text-subtle',
+    '--color-border',
+    '--color-border-soft',
+    '--color-accent',
+    '--color-accent-hover',
+    '--color-accent-strong',
+    '--color-on-accent',
+    '--color-danger',
+    '--color-on-danger',
+    '--color-warning',
+    '--color-success',
+    '--glass-bg',
+    '--glass-border',
+    '--scrim',
+] as const;
+
+function paletteBlock(themeId: string): string {
+    const selector = new RegExp(`data-theme=["']${themeId}["']`);
+    const match = selector.exec(paletteSource);
+    if (!match) throw new Error(`missing palette selector for ${themeId}`);
+    const openBrace = paletteSource.indexOf('{', match.index);
+    const closeBrace = paletteSource.indexOf('}', openBrace);
+    return paletteSource.slice(openBrace + 1, closeBrace);
+}
+
+function tokenValue(block: string, token: string): string {
+    const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = new RegExp(`${escaped}\\s*:\\s*([^;]+)`).exec(block);
+    return match?.[1].trim() ?? '';
+}
+
+function luminance(hex: string): number {
+    const channels = hex
+        .slice(1)
+        .match(/.{2}/g)
+        ?.map((value) => Number.parseInt(value, 16) / 255) ?? [];
+    const linear = channels.map((channel) =>
+        channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+    );
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function contrast(foreground: string, background: string): number {
+    const lighter = Math.max(luminance(foreground), luminance(background));
+    const darker = Math.min(luminance(foreground), luminance(background));
+    return (lighter + 0.05) / (darker + 0.05);
+}
+
+describe('theme palettes', () => {
+    it('defines the complete semantic color contract for every theme', () => {
+        for (const theme of THEME_DEFINITIONS) {
+            const block = paletteBlock(theme.id);
+            for (const token of requiredTokens) {
+                expect(tokenValue(block, token), `${theme.id} is missing ${token}`).not.toBe('');
+            }
+        }
+    });
+
+    it('keeps primary text WCAG AA readable against the app canvas', () => {
+        for (const theme of THEME_DEFINITIONS) {
+            const block = paletteBlock(theme.id);
+            const canvas = tokenValue(block, '--color-canvas');
+            const text = tokenValue(block, '--color-text');
+
+            expect(canvas, `${theme.id} canvas must use an auditable six-digit hex color`).toMatch(/^#[\da-f]{6}$/i);
+            expect(text, `${theme.id} text must use an auditable six-digit hex color`).toMatch(/^#[\da-f]{6}$/i);
+            expect(contrast(text, canvas), `${theme.id} primary text contrast`).toBeGreaterThanOrEqual(4.5);
+        }
+    });
+
+    it('keeps compact text and action labels WCAG AA readable', () => {
+        for (const theme of THEME_DEFINITIONS) {
+            const block = paletteBlock(theme.id);
+            const pairs = [
+                ['--color-text-muted', '--color-canvas'],
+                ['--color-text', '--color-surface-0'],
+                ['--color-text', '--color-surface-1'],
+                ['--color-text', '--color-surface-2'],
+                ['--color-text-muted', '--color-surface-0'],
+                ['--color-text-muted', '--color-surface-1'],
+                ['--color-text-muted', '--color-surface-2'],
+                ['--color-on-accent', '--color-accent'],
+                ['--color-on-danger', '--color-danger'],
+            ] as const;
+
+            for (const [foregroundToken, backgroundToken] of pairs) {
+                const foreground = tokenValue(block, foregroundToken);
+                const background = tokenValue(block, backgroundToken);
+                expect(
+                    contrast(foreground, background),
+                    `${theme.id} ${foregroundToken} on ${backgroundToken}`,
+                ).toBeGreaterThanOrEqual(4.5);
+            }
+        }
+    });
+
+    it('keeps selector previews synchronized with the applied palette', () => {
+        for (const theme of THEME_DEFINITIONS) {
+            const block = paletteBlock(theme.id);
+            expect(theme.preview).toEqual([
+                tokenValue(block, '--color-canvas'),
+                tokenValue(block, '--color-surface-2'),
+                tokenValue(block, '--color-accent'),
+                tokenValue(block, '--color-text'),
+            ]);
+        }
+    });
+
+    it('preserves the existing Tokyo Night foundation', () => {
+        const tokyoNight = paletteBlock('tokyo-night');
+
+        expect(tokenValue(tokyoNight, '--color-canvas')).toBe('#1a1b26');
+        expect(tokenValue(tokyoNight, '--color-surface-0')).toBe('#16161e');
+        expect(tokenValue(tokyoNight, '--color-accent')).toBe('#7aa2f7');
+    });
+});

--- a/frontend/src/ui/theme/theme-style-contract.test.ts
+++ b/frontend/src/ui/theme/theme-style-contract.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const globalCss = readFileSync(new URL('../../style.css', import.meta.url), 'utf8');
+const appPaletteReference =
+    /var\(--(?:color-|text-main|text-muted|bg-|border\b|accent\b|danger\b|overlay-|focus-ring\b|scrim\b|shadow-)/g;
+
+function sectionBetween(startMarker: string, endMarker: string): string {
+    const start = globalCss.indexOf(startMarker);
+    const end = globalCss.indexOf(endMarker, start + startMarker.length);
+    if (start < 0 || end < 0) throw new Error(`missing CSS section: ${startMarker}`);
+    return globalCss.slice(start, end);
+}
+
+describe('global theme style contract', () => {
+    it('keeps palette colors out of the lower-specificity bare root', () => {
+        const root = /:root\s*\{([\s\S]*?)\n\}/.exec(globalCss)?.[1];
+        expect(root).toBeDefined();
+        expect(root).not.toMatch(/^\s+--(?:color-|overlay-|glass-|shadow-|focus-ring|scrim)\s*:/m);
+        expect(root).toContain('--radius-xs');
+        expect(root).toContain('--bg-dark: var(--color-canvas)');
+    });
+
+    it('keeps fixed-dark viewer chrome independent from app palette aliases', () => {
+        const viewer = sectionBetween(
+            '/* ----- File viewers: audio / PDF / text ----- */',
+            '/* Profile (avatar) dropdown in the top-right header. */',
+        );
+        const appPaletteReferences = viewer.match(appPaletteReference);
+
+        expect(appPaletteReferences ?? []).toEqual([]);
+        expect(viewer).toContain('var(--viewer-text)');
+        expect(viewer).toContain('var(--viewer-border)');
+        expect(viewer).toContain('var(--viewer-surface-0)');
+        expect(viewer).toContain('var(--viewer-focus-ring)');
+    });
+
+    it('keeps fixed-dark preview and video controls independent from app palettes', () => {
+        const preview = sectionBetween(
+            '/* ----- Lightbox info panel (the "ⓘ" card) ----- */',
+            '/* ----- Video player ----- */',
+        );
+        const video = sectionBetween('/* ----- Video player ----- */', '/* ----- Upload menu (Files / Folder) ----- */');
+
+        expect(preview.match(appPaletteReference) ?? []).toEqual([]);
+        expect(video.match(appPaletteReference) ?? []).toEqual([]);
+        expect(preview).toContain('var(--viewer-accent)');
+        expect(video).toContain('--video-accent: var(--viewer-accent)');
+        expect(video).toContain('background: var(--viewer-scrim)');
+    });
+});

--- a/frontend/src/ui/theme/theme-style-contract.test.ts
+++ b/frontend/src/ui/theme/theme-style-contract.test.ts
@@ -13,10 +13,14 @@ function sectionBetween(startMarker: string, endMarker: string): string {
 }
 
 function ruleFor(selector: string): string {
-    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const rule = new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\n\\}`).exec(globalCss)?.[1];
-    if (!rule) throw new Error(`missing CSS rule: ${selector}`);
-    return rule;
+    const start = globalCss.indexOf(`${selector} {`);
+    if (start < 0) throw new Error(`missing CSS rule: ${selector}`);
+
+    const bodyStart = globalCss.indexOf('{', start);
+    const bodyEnd = globalCss.indexOf('\n}', bodyStart);
+    if (bodyStart < 0 || bodyEnd < 0) throw new Error(`unterminated CSS rule: ${selector}`);
+
+    return globalCss.slice(bodyStart + 1, bodyEnd);
 }
 
 describe('global theme style contract', () => {
@@ -33,7 +37,9 @@ describe('global theme style contract', () => {
             '/* ----- File viewers: audio / PDF / text ----- */',
             '/* Profile (avatar) dropdown in the top-right header. */',
         );
-        const appPaletteReferences = viewer.match(appPaletteReference);
+        const textPreview = ruleFor('.file-viewer-shell.is-text');
+        const fixedViewer = viewer.replace(textPreview, '');
+        const appPaletteReferences = fixedViewer.match(appPaletteReference);
 
         expect(appPaletteReferences ?? []).toEqual([]);
         expect(viewer).toContain('var(--viewer-text)');
@@ -46,7 +52,8 @@ describe('global theme style contract', () => {
         const textPreview = ruleFor('.file-viewer-shell.is-text');
 
         expect(textPreview).toContain('--viewer-text: var(--color-text)');
-        expect(textPreview).toContain('--viewer-text-muted: var(--color-text-muted)');
+        expect(textPreview).toContain('--viewer-text-muted: var(--color-text-soft)');
+        expect(textPreview).toContain('--viewer-text-subtle: var(--color-text-muted)');
         expect(textPreview).toContain('--viewer-surface-0: var(--color-canvas)');
         expect(textPreview).toContain('--viewer-surface-2: var(--color-surface-1)');
         expect(textPreview).toContain('--viewer-border: var(--color-border)');

--- a/frontend/src/ui/theme/theme-style-contract.test.ts
+++ b/frontend/src/ui/theme/theme-style-contract.test.ts
@@ -12,6 +12,13 @@ function sectionBetween(startMarker: string, endMarker: string): string {
     return globalCss.slice(start, end);
 }
 
+function ruleFor(selector: string): string {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const rule = new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\n\\}`).exec(globalCss)?.[1];
+    if (!rule) throw new Error(`missing CSS rule: ${selector}`);
+    return rule;
+}
+
 describe('global theme style contract', () => {
     it('keeps palette colors out of the lower-specificity bare root', () => {
         const root = /:root\s*\{([\s\S]*?)\n\}/.exec(globalCss)?.[1];
@@ -33,6 +40,20 @@ describe('global theme style contract', () => {
         expect(viewer).toContain('var(--viewer-border)');
         expect(viewer).toContain('var(--viewer-surface-0)');
         expect(viewer).toContain('var(--viewer-focus-ring)');
+    });
+
+    it('maps text-preview chrome back onto the active app palette', () => {
+        const textPreview = ruleFor('.file-viewer-shell.is-text');
+
+        expect(textPreview).toContain('--viewer-text: var(--color-text)');
+        expect(textPreview).toContain('--viewer-text-muted: var(--color-text-muted)');
+        expect(textPreview).toContain('--viewer-surface-0: var(--color-canvas)');
+        expect(textPreview).toContain('--viewer-surface-2: var(--color-surface-1)');
+        expect(textPreview).toContain('--viewer-border: var(--color-border)');
+        expect(textPreview).toContain('--viewer-accent: var(--color-accent)');
+        expect(textPreview).toContain('--viewer-syntax-key: var(--color-accent)');
+        expect(textPreview).toContain('--viewer-syntax-string: var(--color-warning)');
+        expect(textPreview).toContain('--viewer-syntax-value: var(--color-success)');
     });
 
     it('keeps fixed-dark preview and video controls independent from app palettes', () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,16 @@ export default defineConfig({
         },
     },
     test: {
+        coverage: {
+            provider: 'v8',
+            include: ['src/ui/theme/**'],
+            thresholds: {
+                branches: 80,
+                functions: 80,
+                lines: 80,
+                statements: 80,
+            },
+        },
         projects: [
             // Fast server-render smoke tests (the default): assert markup from
             // svelte/server without a DOM.

--- a/main.go
+++ b/main.go
@@ -26,7 +26,10 @@ func main() {
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
-		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
+		// Match the no-preference Tokyo Night canvas during native window
+		// creation. The frontend synchronises this backdrop to the resolved
+		// light/dark palette as soon as the Wails runtime is ready.
+		BackgroundColour: &options.RGBA{R: 26, G: 27, B: 38, A: 255},
 		OnStartup:        app.startup,
 		OnShutdown:       app.shutdown,
 		// Native file drop: dropped folders and files arrive as absolute paths,


### PR DESCRIPTION
## Summary

- adds an adaptive multi-theme appearance system with explicit **Light** and **Dark** modes
- ships ten curated editor-inspired themes and moves application chrome onto semantic design tokens
- adds an accessible appearance picker to both the profile menu and authentication flow
- animates palette changes with View Transitions, a CSS fallback, and full reduced-motion support
- supports rapid, back-to-back palette scrubbing without closing or blocking the Appearance dialog
- makes text, Markdown, JSON, YAML, CSV, and other structured-text previews follow the selected palette while media and PDF viewers retain fixed-dark chrome
- applies the saved theme before first paint and synchronizes native Wails window chrome where the platform allows it

## Issues
- Closes #72

## Theme collection

**Light**

- TDrive Light
- Catppuccin Latte
- Solarized Light
- Gruvbox Light

**Dark**

- Tokyo Night
- Catppuccin Mocha
- Dracula
- Solarized Dark
- Gruvbox Dark
- Nord

## UX and accessibility

- Light/Dark mode cards use radio semantics with visible selected state and keyboard focus
- palette cards use roving keyboard focus and `aria-checked` radio semantics
- profile and auth entry points focus the selected appearance control when opened
- Escape handling and focus restoration are covered in the profile-menu and auth flows
- immutable event paths and tightly scoped transition-hit recovery keep rapid palette previews inside their open popover
- recovered transition clicks preserve focus on the selected radio card so arrow-key navigation can continue naturally
- theme changes respect `prefers-reduced-motion` and remain immediate when motion should be disabled
- palette and syntax colors are contrast-tested across semantic foreground/background pairings
- media and PDF viewers keep a separate fixed-dark contrast contract; text-based previews remap that contract to the active app palette

## Cross-platform behavior

- preferences are validated, versioned, and stored locally with a deterministic dark fallback
- legacy saved `System` preferences are normalized to Dark while preserving the user's selected dark palette
- startup uses a pre-paint bootstrap to prevent theme flash
- Wails receives the active native background color on every supported OS
- Windows title-bar appearance follows the explicit Light/Dark mode through the existing Wails runtime API
- unsupported native APIs fail safely without affecting the web UI

## Verification

- [x] `npm test -- --run` — 56 files / 268 tests
- [x] `npm run test:coverage -- --run` — 92.28% statements, 89.09% branches, 95.87% functions, 92.45% lines
- [x] `npm run typecheck`
- [x] `npm run lint` — passes with existing `no-explicit-any` warnings
- [x] `npm run build` — passes; existing ineffective dynamic import warning remains
- [x] `npm audit` — 0 vulnerabilities
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] `wails build -platform darwin/arm64` — existing libmpv macOS deployment-target linker warning remains
- [x] GitHub CI — frontend/tests plus Wails builds on darwin/arm64, linux/amd64, and windows/amd64
- [x] Headless Chromium — five raw palette clicks with no delay keep Appearance open, select and focus the fifth card, and produce no transition errors; light text-preview surfaces resolve to the selected light palette
- [x] Manual native visual smoke test on macOS, Windows, and Linux before marking ready for review
