### PR TITLE
fix: make large imports resilient

### DIFF
--- a/app.go
+++ b/app.go
@@ -314,8 +314,8 @@ func (a *App) PlanImport(paths []string, encrypt bool, extractArchives bool) fil
 
 // ImportPaths recreates the folder structure of the selected paths under
 // parentID and uploads their files. Archives are extracted when extractArchives
-// is set, otherwise uploaded as-is. Progress flows through the import_* and the
-// per-file upload_* events.
+// is set, otherwise uploaded as-is. Progress flows through aggregate import_*
+// events.
 func (a *App) ImportPaths(paths []string, parentID string, encrypt bool, extractArchives bool) error {
 	svc, err := a.requireFileService()
 	if err != nil {

--- a/backend/core/engine.go
+++ b/backend/core/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync/atomic"
 
 	"TDrive/backend"
@@ -310,19 +311,28 @@ func (e *Engine) ActorID(ctx context.Context) (int64, error) {
 // local projection. If local projection fails after the send, the op remains in
 // Telegram and the next sync can replay it.
 func (e *Engine) EmitAndProject(channelID int64, op projection.Op) (int64, error) {
+	return e.EmitAndProjectContext(e.ctx, channelID, op)
+}
+
+// EmitAndProjectContext is the request-scoped form used by imports and other
+// cancellable operations. Idempotent Telegram retries reuse one random_id, so
+// a lost response cannot create duplicate control messages.
+func (e *Engine) EmitAndProjectContext(ctx context.Context, channelID int64, op projection.Op) (int64, error) {
 	if e == nil || e.tg == nil {
 		return 0, fmt.Errorf("tg client not ready")
 	}
-	actorID, err := e.ActorID(e.ctx)
-	if err != nil {
+	if ctx == nil {
+		return 0, fmt.Errorf("control write requires a context")
+	}
+	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	peer, err := e.ChannelPeer(e.ctx, channelID)
+	actorID, err := e.ActorID(ctx)
 	if err != nil {
 		return 0, err
 	}
 	header := projection.Format(op)
-	msgID, err := e.tg.SendControl(e.ctx, peer, header, true)
+	msgID, err := e.sendControlContext(ctx, channelID, header)
 	if err != nil {
 		return 0, err
 	}
@@ -344,17 +354,23 @@ type projectedOp struct {
 // the UI-facing cache must be: if a later send fails, the already-sent ops will
 // converge through the next sync instead of locally half-applying a subtree.
 func (e *Engine) EmitAndProjectBatch(channelID int64, ops []projection.Op) error {
+	return e.EmitAndProjectBatchContext(e.ctx, channelID, ops)
+}
+
+func (e *Engine) EmitAndProjectBatchContext(ctx context.Context, channelID int64, ops []projection.Op) error {
 	if len(ops) == 0 {
 		return nil
 	}
 	if e == nil || e.tg == nil {
 		return fmt.Errorf("tg client not ready")
 	}
-	actorID, err := e.ActorID(e.ctx)
-	if err != nil {
+	if ctx == nil {
+		return fmt.Errorf("control write requires a context")
+	}
+	if err := ctx.Err(); err != nil {
 		return err
 	}
-	peer, err := e.ChannelPeer(e.ctx, channelID)
+	actorID, err := e.ActorID(ctx)
 	if err != nil {
 		return err
 	}
@@ -362,7 +378,7 @@ func (e *Engine) EmitAndProjectBatch(channelID int64, ops []projection.Op) error
 	sent := make([]projectedOp, 0, len(ops))
 	for _, op := range ops {
 		header := projection.Format(op)
-		msgID, err := e.tg.SendControl(e.ctx, peer, header, true)
+		msgID, err := e.sendControlContext(ctx, channelID, header)
 		if err != nil {
 			return err
 		}
@@ -387,6 +403,73 @@ func (e *Engine) EmitAndProjectBatch(channelID int64, ops []projection.Op) error
 		return fmt.Errorf("projection: commit batch tx: %w", err)
 	}
 	return nil
+}
+
+func (e *Engine) sendControlContext(ctx context.Context, channelID int64, header string) (int64, error) {
+	peer, cached, err := e.controlPeer(ctx, channelID)
+	if err != nil {
+		return 0, err
+	}
+	randomID, err := tgclient.StableRandomID(projection.NewUploadUUID(), "control")
+	if err != nil {
+		return 0, err
+	}
+
+	msgID, err := e.sendControlWithRetry(ctx, peer, header, randomID)
+	if err == nil || !cached || !isStalePeerError(err) {
+		return msgID, err
+	}
+
+	// Access hashes can rotate. Refresh once and retry with the same random_id;
+	// Telegram can therefore deduplicate an accepted send whose response was
+	// lost while the local cache was stale.
+	fresh, resolveErr := e.ChannelPeer(ctx, channelID)
+	if resolveErr != nil {
+		return 0, err
+	}
+	if backend.DB != nil {
+		if updateErr := projection.UpdateAccessHash(backend.DB, channelID, fresh.AccessHash); updateErr != nil {
+			e.warnf("warn: could not refresh channel access hash %d: %v\n", channelID, updateErr)
+		}
+	}
+	return e.sendControlWithRetry(ctx, fresh, header, randomID)
+}
+
+func (e *Engine) sendControlWithRetry(ctx context.Context, peer tgclient.InputPeer, header string, randomID int64) (int64, error) {
+	if _, ok := e.tg.(tgclient.IdempotentSender); !ok {
+		// A legacy client cannot safely retry an unknown send outcome.
+		return e.tg.SendControl(ctx, peer, header, true)
+	}
+
+	var msgID int64
+	policy := tgclient.DefaultWriteFloodWaitRetryPolicy()
+	err := policy.Do(ctx, func() error {
+		var sendErr error
+		msgID, sendErr = tgclient.SendControlIdempotent(ctx, e.tg, peer, header, true, randomID)
+		return sendErr
+	})
+	return msgID, err
+}
+
+func (e *Engine) controlPeer(ctx context.Context, channelID int64) (tgclient.InputPeer, bool, error) {
+	if backend.DB != nil {
+		if channel, err := projection.GetChannel(backend.DB, channelID); err == nil && channel.AccessHash != 0 {
+			return tgclient.InputPeer{ChannelID: channelID, AccessHash: channel.AccessHash}, true, nil
+		}
+	}
+	peer, err := e.ChannelPeer(ctx, channelID)
+	return peer, false, err
+}
+
+func isStalePeerError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToUpper(err.Error())
+	return strings.Contains(message, "CHANNEL_INVALID") ||
+		strings.Contains(message, "CHANNEL_PRIVATE") ||
+		strings.Contains(message, "PEER_ID_INVALID") ||
+		strings.Contains(message, "ACCESS_HASH")
 }
 
 func (e *Engine) AuthService() *authsvc.Service {
@@ -502,8 +585,15 @@ func (e *Engine) newFolderService() *folderservice.Service {
 			_, err := e.EmitAndProject(channelID, op)
 			return err
 		},
+		EmitOpContext: func(ctx context.Context, channelID int64, op projection.Op) error {
+			_, err := e.EmitAndProjectContext(ctx, channelID, op)
+			return err
+		},
 		EmitOps: func(channelID int64, ops []projection.Op) error {
 			return e.EmitAndProjectBatch(channelID, ops)
+		},
+		EmitOpsContext: func(ctx context.Context, channelID int64, ops []projection.Op) error {
+			return e.EmitAndProjectBatchContext(ctx, channelID, ops)
 		},
 		ActorID: func(ctx context.Context) (int64, error) {
 			return e.ActorID(ctx)
@@ -529,6 +619,9 @@ func (e *Engine) newFileService() *fileservice.Service {
 		EmitOp: func(channelID int64, op projection.Op) (int64, error) {
 			return e.EmitAndProject(channelID, op)
 		},
+		EmitOpContext: func(ctx context.Context, channelID int64, op projection.Op) (int64, error) {
+			return e.EmitAndProjectContext(ctx, channelID, op)
+		},
 		ActorID: func(ctx context.Context) (int64, error) {
 			return e.ActorID(ctx)
 		},
@@ -545,8 +638,8 @@ func (e *Engine) newFileService() *fileservice.Service {
 		WriteCiphertextTemp: func(plain io.Reader, plaintextSize int64, masterKey []byte) (*os.File, error) {
 			return e.EncryptionService().WriteCiphertextTemp(plain, plaintextSize, masterKey)
 		},
-		CreateFolder: func(channelID int64, name, parentID string) (string, error) {
-			f, err := e.FolderService().Create(channelID, name, parentID)
+		CreateFolder: func(ctx context.Context, channelID int64, name, parentID string) (string, error) {
+			f, err := e.FolderService().CreateContext(ctx, channelID, name, parentID)
 			return f.ID, err
 		},
 		Events: e.events,

--- a/backend/core/engine.go
+++ b/backend/core/engine.go
@@ -338,7 +338,7 @@ func (e *Engine) EmitAndProjectContext(ctx context.Context, channelID int64, op 
 	}
 	if _, err := projection.ProjectFromOp(backend.DB, channelID, msgID, op, actorID, header); err != nil {
 		e.warnf("warn: projection failed after send msg=%d op=%s: %v\n", msgID, op.Type, err)
-		return msgID, err
+		return msgID, fmt.Errorf("%w: msg=%d op=%s: %w", projection.ErrControlProjection, msgID, op.Type, err)
 	}
 	return msgID, nil
 }
@@ -387,7 +387,7 @@ func (e *Engine) EmitAndProjectBatchContext(ctx context.Context, channelID int64
 
 	tx, err := backend.DB.Begin()
 	if err != nil {
-		return fmt.Errorf("projection: begin batch tx: %w", err)
+		return fmt.Errorf("%w: begin batch tx: %w", projection.ErrControlProjection, err)
 	}
 	defer func() {
 		if err != nil {
@@ -396,11 +396,11 @@ func (e *Engine) EmitAndProjectBatchContext(ctx context.Context, channelID int64
 	}()
 	for _, item := range sent {
 		if _, err = projection.ProjectFromOpTx(tx, channelID, item.msgID, item.op, actorID, item.header); err != nil {
-			return fmt.Errorf("projection: project batch msg=%d op=%s: %w", item.msgID, item.op.Type, err)
+			return fmt.Errorf("%w: batch msg=%d op=%s: %w", projection.ErrControlProjection, item.msgID, item.op.Type, err)
 		}
 	}
 	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("projection: commit batch tx: %w", err)
+		return fmt.Errorf("%w: commit batch tx: %w", projection.ErrControlProjection, err)
 	}
 	return nil
 }

--- a/backend/core/engine_write_test.go
+++ b/backend/core/engine_write_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"TDrive/backend"
@@ -123,6 +126,111 @@ func TestNewFileServicePropagatesImportContextToFolderCreation(t *testing.T) {
 	}
 	if emittedContext != nil {
 		t.Fatal("canceled folder creation reached the emitter")
+	}
+}
+
+func TestRunImportStopsAfterControlProjectionFailure(t *testing.T) {
+	db := openEngineWriteTestDB(t)
+	previousDB := backend.DB
+	backend.DB = db
+	t.Cleanup(func() { backend.DB = previousDB })
+
+	if _, err := db.Exec(`
+		CREATE TRIGGER fail_import_folder_projection
+		BEFORE INSERT ON folders
+		BEGIN
+			SELECT RAISE(ABORT, 'injected folder projection failure');
+		END;
+	`); err != nil {
+		t.Fatalf("create projection trigger: %v", err)
+	}
+
+	peer := tgclient.InputPeer{ChannelID: engineWriteTestChannelID, AccessHash: 91}
+	fake := tgclient.NewFake(7)
+	fake.SeedChannel(peer, "Test drive")
+	engine := &Engine{
+		ctx:   context.Background(),
+		tg:    fake,
+		warnf: func(string, ...any) {},
+	}
+	engine.selfUserID.Store(7)
+
+	selectionRoot := t.TempDir()
+	folder := filepath.Join(selectionRoot, "Broken folder")
+	if err := os.Mkdir(folder, 0o755); err != nil {
+		t.Fatalf("create import folder: %v", err)
+	}
+	laterFile := filepath.Join(selectionRoot, "later.txt")
+	if err := os.WriteFile(laterFile, []byte("must not upload"), 0o600); err != nil {
+		t.Fatalf("create later file: %v", err)
+	}
+
+	err := engine.newFileService().RunImport(
+		context.Background(),
+		engineWriteTestChannelID,
+		[]string{folder, laterFile},
+		projection.RootParent,
+		false,
+		false,
+	)
+	if !errors.Is(err, projection.ErrControlProjection) {
+		t.Fatalf("RunImport error = %v, want ErrControlProjection", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "injected folder projection failure") {
+		t.Fatalf("RunImport error = %v, want injected root cause", err)
+	}
+	if controls := fake.SentControls(); len(controls) != 1 {
+		t.Fatalf("sent controls = %d, want the accepted mkdir only", len(controls))
+	}
+	if files := fake.SentFiles(); len(files) != 0 {
+		t.Fatalf("sent files after projection failure = %d, want 0", len(files))
+	}
+}
+
+func TestEmitAndProjectBatchMarksPostSendProjectionFailure(t *testing.T) {
+	db := openEngineWriteTestDB(t)
+	previousDB := backend.DB
+	backend.DB = db
+	t.Cleanup(func() { backend.DB = previousDB })
+
+	if _, err := db.Exec(`
+		CREATE TRIGGER fail_control_batch_projection
+		BEFORE INSERT ON folders
+		BEGIN
+			SELECT RAISE(ABORT, 'injected batch projection failure');
+		END;
+	`); err != nil {
+		t.Fatalf("create projection trigger: %v", err)
+	}
+
+	peer := tgclient.InputPeer{ChannelID: engineWriteTestChannelID, AccessHash: 91}
+	fake := tgclient.NewFake(7)
+	fake.SeedChannel(peer, "Test drive")
+	engine := &Engine{
+		ctx:   context.Background(),
+		tg:    fake,
+		warnf: func(string, ...any) {},
+	}
+	engine.selfUserID.Store(7)
+	ops := []projection.Op{
+		{Type: projection.OpMkdir, Obj: projection.FolderIDPrefix + "batch-a", Name: "A"},
+		{Type: projection.OpMkdir, Obj: projection.FolderIDPrefix + "batch-b", Name: "B"},
+	}
+
+	err := engine.EmitAndProjectBatchContext(context.Background(), engineWriteTestChannelID, ops)
+	if !errors.Is(err, projection.ErrControlProjection) {
+		t.Fatalf("EmitAndProjectBatchContext error = %v, want ErrControlProjection", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "injected batch projection failure") {
+		t.Fatalf("EmitAndProjectBatchContext error = %v, want injected root cause", err)
+	}
+	if controls := fake.SentControls(); len(controls) != len(ops) {
+		t.Fatalf("sent controls = %d, want %d accepted controls", len(controls), len(ops))
+	}
+	for _, op := range ops {
+		if projection.FolderExists(db, engineWriteTestChannelID, op.Obj) {
+			t.Fatalf("folder %q projected despite batch rollback", op.Obj)
+		}
 	}
 }
 

--- a/backend/core/engine_write_test.go
+++ b/backend/core/engine_write_test.go
@@ -1,0 +1,140 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"TDrive/backend"
+	"TDrive/backend/projection"
+	folderservice "TDrive/backend/services/folder"
+	"TDrive/backend/tgclient"
+
+	_ "modernc.org/sqlite"
+)
+
+const engineWriteTestChannelID int64 = 818181
+
+type engineWriteContextKey struct{}
+
+type retryingControlClient struct {
+	*tgclient.Fake
+	randomIDs []int64
+	contexts  []context.Context
+}
+
+func (c *retryingControlClient) SendControlWithRandomID(
+	ctx context.Context,
+	peer tgclient.InputPeer,
+	text string,
+	silent bool,
+	randomID int64,
+) (int64, error) {
+	c.randomIDs = append(c.randomIDs, randomID)
+	c.contexts = append(c.contexts, ctx)
+	if len(c.randomIDs) == 1 {
+		return 0, tgclient.NewFloodWaitError(0)
+	}
+	return c.Fake.SendControlWithRandomID(ctx, peer, text, silent, randomID)
+}
+
+func TestEmitAndProjectContextRetriesControlWithStableRandomID(t *testing.T) {
+	db := openEngineWriteTestDB(t)
+	previousDB := backend.DB
+	backend.DB = db
+	t.Cleanup(func() { backend.DB = previousDB })
+
+	peer := tgclient.InputPeer{ChannelID: engineWriteTestChannelID, AccessHash: 91}
+	fake := tgclient.NewFake(7)
+	fake.SeedChannel(peer, "Test drive")
+	client := &retryingControlClient{Fake: fake}
+	engine := &Engine{
+		ctx:   context.Background(),
+		tg:    client,
+		warnf: func(string, ...any) {},
+	}
+	engine.selfUserID.Store(7)
+
+	ctx := context.WithValue(context.Background(), engineWriteContextKey{}, "request context")
+	op := projection.Op{
+		Type:   projection.OpMkdir,
+		Obj:    projection.FolderIDPrefix + "context-write",
+		Parent: projection.RootParent,
+		Name:   "Context write",
+	}
+	msgID, err := engine.EmitAndProjectContext(ctx, engineWriteTestChannelID, op)
+	if err != nil {
+		t.Fatalf("EmitAndProjectContext: %v", err)
+	}
+	if msgID <= 0 {
+		t.Fatalf("message id = %d, want positive", msgID)
+	}
+	if len(client.randomIDs) != 2 {
+		t.Fatalf("control attempts = %d, want 2", len(client.randomIDs))
+	}
+	if client.randomIDs[0] <= 0 || client.randomIDs[0] != client.randomIDs[1] {
+		t.Fatalf("control random ids = %v, want one stable positive id", client.randomIDs)
+	}
+	for attempt, got := range client.contexts {
+		if got.Value(engineWriteContextKey{}) != "request context" {
+			t.Fatalf("attempt %d lost the request context", attempt+1)
+		}
+	}
+	if !projection.FolderExists(db, engineWriteTestChannelID, op.Obj) {
+		t.Fatal("successful retried control was not projected")
+	}
+}
+
+func TestNewFileServicePropagatesImportContextToFolderCreation(t *testing.T) {
+	db := openEngineWriteTestDB(t)
+	var emittedContext context.Context
+	folderService := &folderservice.Service{
+		DB: db,
+		EmitOpContext: func(ctx context.Context, _ int64, _ projection.Op) error {
+			emittedContext = ctx
+			return nil
+		},
+	}
+	engine := &Engine{
+		ctx:     context.Background(),
+		folders: folderService,
+	}
+	fileService := engine.newFileService()
+
+	ctx := context.WithValue(context.Background(), engineWriteContextKey{}, "folder import")
+	folderID, err := fileService.CreateFolder(ctx, engineWriteTestChannelID, "Imported", projection.RootParent)
+	if err != nil {
+		t.Fatalf("CreateFolder: %v", err)
+	}
+	if !projection.IsFolderID(folderID) {
+		t.Fatalf("folder id = %q, want a folder id", folderID)
+	}
+	if emittedContext == nil || emittedContext.Value(engineWriteContextKey{}) != "folder import" {
+		t.Fatal("file-service folder creation lost the import context")
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	emittedContext = nil
+	_, err = fileService.CreateFolder(canceled, engineWriteTestChannelID, "Canceled", projection.RootParent)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled CreateFolder error = %v, want context canceled", err)
+	}
+	if emittedContext != nil {
+		t.Fatal("canceled folder creation reached the emitter")
+	}
+}
+
+func openEngineWriteTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := projection.MigratePersonalChannel(db, engineWriteTestChannelID); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	return db
+}

--- a/backend/projection/errors.go
+++ b/backend/projection/errors.go
@@ -1,0 +1,8 @@
+package projection
+
+import "errors"
+
+// ErrControlProjection marks a control message that Telegram accepted but the
+// local projection could not apply. Callers must stop dependent writes until a
+// sync replays the accepted message into the local cache.
+var ErrControlProjection = errors.New("control message accepted but local projection failed")

--- a/backend/services/file/archive.go
+++ b/backend/services/file/archive.go
@@ -75,16 +75,12 @@ func sanitizeArchivePath(name string) (rel string, ok bool) {
 // Directory entries are returned with IsDir true. Symlinks, hardlinks, devices,
 // and zip-slip entries are skipped.
 func ScanArchive(p string) ([]ArchiveEntry, error) {
-	switch classifyArchive(p) {
-	case archiveZip:
-		return scanZip(p)
-	case archiveTar:
-		return scanTar(p, false)
-	case archiveTarGz:
-		return scanTar(p, true)
-	default:
-		return nil, fmt.Errorf("unsupported archive type: %s", p)
-	}
+	var entries []ArchiveEntry
+	err := forEachArchiveEntry(p, func(entry ArchiveEntry) error {
+		entries = append(entries, entry)
+		return nil
+	})
+	return entries, err
 }
 
 // StreamArchiveFiles calls fn for each safe regular-file entry in archive order,
@@ -108,14 +104,13 @@ func StreamArchiveFiles(p string, fn func(e ArchiveEntry, r io.Reader) error) er
 	}
 }
 
-func scanZip(p string) ([]ArchiveEntry, error) {
+func forEachZipEntry(p string, fn func(ArchiveEntry) error) error {
 	zr, err := zip.OpenReader(p)
 	if err != nil {
-		return nil, fmt.Errorf("open zip: %w", err)
+		return fmt.Errorf("open zip: %w", err)
 	}
 	defer zr.Close()
 
-	entries := make([]ArchiveEntry, 0, len(zr.File))
 	for _, f := range zr.File {
 		fi := f.FileInfo()
 		if fi.Mode()&os.ModeSymlink != 0 {
@@ -126,15 +121,19 @@ func scanZip(p string) ([]ArchiveEntry, error) {
 			continue
 		}
 		if fi.IsDir() {
-			entries = append(entries, ArchiveEntry{RelPath: rel, IsDir: true})
+			if err := fn(ArchiveEntry{RelPath: rel, IsDir: true}); err != nil {
+				return err
+			}
 			continue
 		}
 		if f.UncompressedSize64 > math.MaxInt64 {
 			continue // implausible declared size; treat as malformed and skip
 		}
-		entries = append(entries, ArchiveEntry{RelPath: rel, Size: int64(f.UncompressedSize64)})
+		if err := fn(ArchiveEntry{RelPath: rel, Size: int64(f.UncompressedSize64)}); err != nil {
+			return err
+		}
 	}
-	return entries, nil
+	return nil
 }
 
 func streamZip(p string, fn func(e ArchiveEntry, r io.Reader) error) error {
@@ -169,9 +168,8 @@ func streamZip(p string, fn func(e ArchiveEntry, r io.Reader) error) error {
 	return nil
 }
 
-func scanTar(p string, gzipped bool) ([]ArchiveEntry, error) {
-	var entries []ArchiveEntry
-	err := withTarReader(p, gzipped, func(tr *tar.Reader) error {
+func forEachTarEntry(p string, gzipped bool, fn func(ArchiveEntry) error) error {
+	return withTarReader(p, gzipped, func(tr *tar.Reader) error {
 		for {
 			hdr, err := tr.Next()
 			if err == io.EOF {
@@ -186,18 +184,31 @@ func scanTar(p string, gzipped bool) ([]ArchiveEntry, error) {
 			}
 			switch {
 			case isTarDir(hdr):
-				entries = append(entries, ArchiveEntry{RelPath: rel, IsDir: true})
+				if err := fn(ArchiveEntry{RelPath: rel, IsDir: true}); err != nil {
+					return err
+				}
 			case isTarRegular(hdr):
-				entries = append(entries, ArchiveEntry{RelPath: rel, Size: hdr.Size})
+				if err := fn(ArchiveEntry{RelPath: rel, Size: hdr.Size}); err != nil {
+					return err
+				}
 			default:
 				// symlink, hardlink, device, fifo: skip
 			}
 		}
 	})
-	if err != nil {
-		return nil, err
+}
+
+func forEachArchiveEntry(p string, fn func(ArchiveEntry) error) error {
+	switch classifyArchive(p) {
+	case archiveZip:
+		return forEachZipEntry(p, fn)
+	case archiveTar:
+		return forEachTarEntry(p, false, fn)
+	case archiveTarGz:
+		return forEachTarEntry(p, true, fn)
+	default:
+		return fmt.Errorf("unsupported archive type: %s", p)
 	}
-	return entries, nil
 }
 
 func streamTar(p string, gzipped bool, fn func(e ArchiveEntry, r io.Reader) error) error {

--- a/backend/services/file/import.go
+++ b/backend/services/file/import.go
@@ -226,10 +226,6 @@ func (s *Service) planArchive(ctx context.Context, p string, encrypt bool, plan 
 	entries, ignored, err := scanArchiveForImport(ctx, p)
 	plan.Ignored += ignored
 	if err != nil {
-		if errors.Is(err, errImportItemLimit) {
-			plan.LimitExceeded = true
-			return err
-		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
@@ -307,9 +303,6 @@ func scanArchiveForImportLimit(ctx context.Context, archivePath string, maxScann
 		}
 		if entry.IsDir {
 			return nil
-		}
-		if len(entries) >= maxScanned {
-			return errArchiveScanLimit
 		}
 		entries = append(entries, entry)
 		return nil
@@ -546,7 +539,7 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 				if err := s.addFileTask(p, info.Size(), parent, encrypt, tasks); err != nil {
 					fatalErr = err
 				}
-				continue
+				break // reach the shared fatal guard before scheduling another selected path
 			}
 			if err := s.importTree(ctx, channelID, dir, archiveFolderName(p), parent, encrypt, tasks); err != nil {
 				if isFatalImportError(err) {

--- a/backend/services/file/import.go
+++ b/backend/services/file/import.go
@@ -151,7 +151,7 @@ func (s *Service) planImport(ctx context.Context, paths []string, encrypt, extra
 			if IsArchive(p) {
 				plan.Archives++
 			}
-			planErr = s.planFile(info.Size(), encrypt, &plan)
+			_, planErr = s.planFile(info.Size(), encrypt, &plan)
 		}
 		if errors.Is(planErr, errImportItemLimit) {
 			break
@@ -186,14 +186,14 @@ func (p *ImportPlan) addFolder() error {
 	return p.checkItemLimit()
 }
 
-func (s *Service) planFile(size int64, encrypt bool, plan *ImportPlan) error {
+func (s *Service) planFile(size int64, encrypt bool, plan *ImportPlan) (bool, error) {
 	if uploadByteSize(size, encrypt) > s.largeFileMaxBytes() {
 		plan.Oversize++
-		return nil
+		return false, nil
 	}
 	plan.Files++
 	plan.Bytes += size
-	return plan.checkItemLimit()
+	return true, plan.checkItemLimit()
 }
 
 func (s *Service) planFolder(ctx context.Context, root string, encrypt bool, plan *ImportPlan) error {
@@ -213,7 +213,8 @@ func (s *Service) planFolder(ctx context.Context, root string, encrypt bool, pla
 			plan.addError(d.Name(), err)
 			return false, nil
 		}
-		return false, s.planFile(info.Size(), encrypt, plan)
+		_, planErr := s.planFile(info.Size(), encrypt, plan)
+		return false, planErr
 	}, func(p string, err error) error {
 		plan.addError(filepath.Base(p), err)
 		return nil
@@ -235,7 +236,8 @@ func (s *Service) planArchive(ctx context.Context, p string, encrypt bool, plan 
 		// Corrupt or unreadable: RunImport falls back to uploading it as a file.
 		plan.addError(filepath.Base(p), fmt.Errorf("cannot read archive (%v), will upload as a file", err))
 		if info, statErr := os.Stat(p); statErr == nil {
-			return s.planFile(info.Size(), encrypt, plan)
+			_, planErr := s.planFile(info.Size(), encrypt, plan)
+			return planErr
 		}
 		return nil
 	}
@@ -252,8 +254,12 @@ func (s *Service) planArchive(ctx context.Context, p string, encrypt bool, plan 
 		if rel == "" {
 			continue
 		}
-		if err := s.planFile(e.Size, encrypt, plan); err != nil {
+		uploadable, err := s.planFile(e.Size, encrypt, plan)
+		if err != nil {
 			return err
+		}
+		if !uploadable {
+			continue
 		}
 		for d := path.Dir(rel); d != "."; d = path.Dir(d) {
 			if _, exists := dirs[d]; exists {
@@ -403,6 +409,7 @@ func isFatalImportError(err error) bool {
 		errors.Is(err, context.Canceled) ||
 		errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, errImportItemLimit) ||
+		errors.Is(err, projection.ErrControlProjection) ||
 		errors.Is(err, errUploadProjection) ||
 		errors.Is(err, tgclient.ErrFloodWait) ||
 		errors.Is(err, tgclient.ErrSendOutcomeUnknown)
@@ -524,7 +531,8 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 			s.emitEvent("import_progress", map[string]any{"label": "Extracting " + filepath.Base(p)})
 			root, err := ensureTmp()
 			if err != nil {
-				return fmt.Errorf("create temp dir: %w", err)
+				fatalErr = fmt.Errorf("create temp dir: %w", err)
+				break
 			}
 			dir, stats, err := s.extractArchiveToTemp(ctx, p, root, encrypt)
 			tasks.oversize += stats.oversize
@@ -566,7 +574,7 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 		}
 	}
 	uploaded, observerFailed, uploadReasons := observer.Summary()
-	failed := max(plan.Files-uploaded, observerFailed)
+	failed := max(0, tasks.files-uploaded, observerFailed)
 	errorsOut := append([]string(nil), tasks.errors...)
 	for _, reason := range uploadReasons {
 		if len(errorsOut) >= maxImportErrorDetails {
@@ -574,14 +582,26 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 		}
 		errorsOut = append(errorsOut, reason)
 	}
+	status := "done"
+	fatalMessage := ""
+	if fatalErr != nil {
+		status = "failed"
+		fatalMessage = fatalErr.Error()
+		if errors.Is(fatalErr, context.Canceled) {
+			status = "canceled"
+		}
+	}
 	s.emitEvent("import_complete", map[string]any{
 		"uploaded":   uploaded,
 		"failed":     failed,
+		"scheduled":  tasks.files,
 		"folders":    tasks.folders,
 		"oversize":   tasks.oversize,
 		"ignored":    tasks.ignored,
 		"errorCount": tasks.errorCount,
 		"errors":     errorsOut,
+		"status":     status,
+		"error":      fatalMessage,
 	})
 	if fatalErr != nil {
 		return fatalErr
@@ -639,6 +659,9 @@ func (s *Service) importTree(ctx context.Context, channelID int64, root, topName
 			}
 			id, err := s.CreateFolder(ctx, channelID, d.Name(), parentID)
 			if err != nil {
+				if isFatalImportError(err) {
+					return false, err
+				}
 				tasks.addError(rel, err)
 				return true, nil
 			}

--- a/backend/services/file/import.go
+++ b/backend/services/file/import.go
@@ -29,13 +29,15 @@ const (
 	archiveExtractedBytesLimitFloor      = 512 * 1024 * 1024
 	archiveExtractedBytesLimitMultiplier = 8
 	maxImportItems                       = 10_000
-	maxImportArchiveScanEntries          = 100_000
-	importUploadBatchSize                = 128
-	maxImportErrorDetails                = 20
+	// Leave room for ignored and oversize members without permitting metadata
+	// alone to pin the app on an adversarial or generated archive.
+	maxImportArchiveScanEntries = maxImportItems * 4
+	importUploadBatchSize       = 128
+	maxImportErrorDetails       = 20
 )
 
 var (
-	errImportItemLimit   = errors.New("import exceeds the remote item limit")
+	errImportItemLimit  = errors.New("import exceeds the remote item limit")
 	errArchiveScanLimit = errors.New("archive has too many entries to inspect safely")
 )
 
@@ -154,6 +156,12 @@ func (s *Service) planImport(ctx context.Context, paths []string, encrypt, extra
 		if errors.Is(planErr, errImportItemLimit) {
 			break
 		}
+		if planErr != nil {
+			plan.addError(filepath.Base(p), planErr)
+			if ctx.Err() != nil {
+				break
+			}
+		}
 	}
 	return plan
 }
@@ -210,10 +218,7 @@ func (s *Service) planFolder(ctx context.Context, root string, encrypt bool, pla
 		plan.addError(filepath.Base(p), err)
 		return nil
 	})
-	if errors.Is(err, errImportItemLimit) {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (s *Service) planArchive(ctx context.Context, p string, encrypt bool, plan *ImportPlan) error {
@@ -222,6 +227,9 @@ func (s *Service) planArchive(ctx context.Context, p string, encrypt bool, plan 
 	if err != nil {
 		if errors.Is(err, errImportItemLimit) {
 			plan.LimitExceeded = true
+			return err
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return err
 		}
 		// Corrupt or unreadable: RunImport falls back to uploading it as a file.
@@ -261,8 +269,8 @@ func (s *Service) planArchive(ctx context.Context, p string, encrypt bool, plan 
 }
 
 // scanArchiveForImport streams archive metadata into a bounded, policy-filtered
-// slice. Tar scans stop at the admission limit; zip still requires Go's central
-// directory index, but TDrive no longer duplicates an unbounded list in memory.
+// slice. Tar scans stop at the inspection budget; zip still requires Go's
+// central-directory index, but TDrive no longer duplicates an unbounded list.
 func scanArchiveForImport(ctx context.Context, archivePath string) ([]ArchiveEntry, int, error) {
 	return scanArchiveForImportLimit(ctx, archivePath, maxImportArchiveScanEntries)
 }
@@ -294,8 +302,8 @@ func scanArchiveForImportLimit(ctx context.Context, archivePath string, maxScann
 		if entry.IsDir {
 			return nil
 		}
-		if len(entries) >= maxImportItems {
-			return errImportItemLimit
+		if len(entries) >= maxScanned {
+			return errArchiveScanLimit
 		}
 		entries = append(entries, entry)
 		return nil
@@ -391,7 +399,8 @@ func (t *importTasks) flush() error {
 }
 
 func isFatalImportError(err error) bool {
-	return errors.Is(err, context.Canceled) ||
+	return tgclient.IsTransientTransport(err) ||
+		errors.Is(err, context.Canceled) ||
 		errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, errImportItemLimit) ||
 		errors.Is(err, errUploadProjection) ||

--- a/backend/services/file/import.go
+++ b/backend/services/file/import.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"TDrive/backend/projection"
+	"TDrive/backend/tgclient"
 )
 
 // Folder and archive import. PlanImport walks a selection to produce counts for
@@ -26,41 +28,39 @@ const (
 	archiveExtractedFileLimit            = 10000
 	archiveExtractedBytesLimitFloor      = 512 * 1024 * 1024
 	archiveExtractedBytesLimitMultiplier = 8
+	maxImportItems                       = 10_000
+	maxImportArchiveScanEntries          = 100_000
+	importUploadBatchSize                = 128
+	maxImportErrorDetails                = 20
+)
+
+var (
+	errImportItemLimit   = errors.New("import exceeds the remote item limit")
+	errArchiveScanLimit = errors.New("archive has too many entries to inspect safely")
 )
 
 // ImportPlan is the summary shown in the import dialog before confirming.
 type ImportPlan struct {
-	Files    int      `json:"files"`    // files that would upload (excludes oversize)
-	Folders  int      `json:"folders"`  // folders that would be created
-	Bytes    int64    `json:"bytes"`    // total plaintext bytes of the uploadable files
-	Oversize int      `json:"oversize"` // files skipped for exceeding the per-file limit
-	Archives int      `json:"archives"` // archive items in the selection
-	MaxBytes int64    `json:"maxBytes"` // active per-file limit, for messaging
-	Errors   []string `json:"errors"`   // items that could not be scanned
+	Files    int   `json:"files"`    // files that would upload (excludes oversize)
+	Folders  int   `json:"folders"`  // folders that would be created
+	Bytes    int64 `json:"bytes"`    // total plaintext bytes of the uploadable files
+	Oversize int   `json:"oversize"` // files skipped for exceeding the per-file limit
+	Archives int   `json:"archives"` // archive items in the selection
+	Ignored  int   `json:"ignored"`  // generated/cache roots pruned from the selection
+	MaxBytes int64 `json:"maxBytes"` // active per-file limit, for messaging
+	MaxItems int   `json:"maxItems"` // maximum files + folders in one import
+	// LimitExceeded is set after counting one item beyond MaxItems. Planning
+	// stops there so an accidental huge tree cannot consume unbounded memory.
+	LimitExceeded bool     `json:"limitExceeded"`
+	ErrorCount    int      `json:"errorCount"`
+	Errors        []string `json:"errors"` // items that could not be scanned
 }
 
 type archiveExtractStats struct {
 	files    int
 	bytes    int64
 	oversize int
-}
-
-// isJunkName reports OS bookkeeping files that should never be uploaded.
-func isJunkName(name string) bool {
-	switch name {
-	case ".DS_Store", "Thumbs.db", "desktop.ini", ".localized", "__MACOSX":
-		return true
-	}
-	return strings.HasPrefix(name, "._") // macOS AppleDouble sidecars
-}
-
-func isJunkArchivePath(rel string) bool {
-	for _, part := range strings.Split(path.Clean(rel), "/") {
-		if isJunkName(part) || strings.EqualFold(part, "__MACOSX") {
-			return true
-		}
-	}
-	return false
+	ignored  int
 }
 
 func archiveDuplicateRoot(entries []ArchiveEntry, topName string) string {
@@ -71,7 +71,7 @@ func archiveDuplicateRoot(entries []ArchiveEntry, topName string) string {
 	seenUploadable := false
 	root := ""
 	for _, e := range entries {
-		if e.IsDir || isJunkArchivePath(e.RelPath) {
+		if e.IsDir || isIgnoredArchivePath(e.RelPath, e.IsDir) {
 			continue
 		}
 		first, rest, hasSlash := strings.Cut(e.RelPath, "/")
@@ -120,134 +120,301 @@ func archiveFolderName(p string) string {
 // dialog. encrypt and extractArchives must match what RunImport will be called
 // with so the totals line up. It never mutates anything.
 func (s *Service) PlanImport(paths []string, encrypt, extractArchives bool) ImportPlan {
-	plan := ImportPlan{MaxBytes: s.largeFileMaxBytes()}
+	return s.planImport(context.Background(), paths, encrypt, extractArchives)
+}
+
+func (s *Service) planImport(ctx context.Context, paths []string, encrypt, extractArchives bool) ImportPlan {
+	plan := ImportPlan{MaxBytes: s.largeFileMaxBytes(), MaxItems: maxImportItems}
 	for _, p := range paths {
+		if err := ctx.Err(); err != nil {
+			plan.addError("import canceled", err)
+			break
+		}
 		info, err := os.Stat(p)
 		if err != nil {
-			plan.Errors = append(plan.Errors, fmt.Sprintf("%s: %v", filepath.Base(p), err))
+			plan.addError(filepath.Base(p), err)
 			continue
 		}
+		var planErr error
 		switch {
 		case info.IsDir():
-			plan.Folders++ // the top folder itself
-			s.planFolder(p, encrypt, &plan)
+			planErr = plan.addFolder() // explicit top-level choices are preserved
+			if planErr == nil {
+				planErr = s.planFolder(ctx, p, encrypt, &plan)
+			}
 		case IsArchive(p) && extractArchives:
 			plan.Archives++
-			s.planArchive(p, encrypt, &plan)
+			planErr = s.planArchive(ctx, p, encrypt, &plan)
 		default:
 			if IsArchive(p) {
 				plan.Archives++
 			}
-			s.planFile(info.Size(), encrypt, &plan)
+			planErr = s.planFile(info.Size(), encrypt, &plan)
+		}
+		if errors.Is(planErr, errImportItemLimit) {
+			break
 		}
 	}
 	return plan
 }
 
-func (s *Service) planFile(size int64, encrypt bool, plan *ImportPlan) {
+func (p *ImportPlan) addError(name string, err error) {
+	p.ErrorCount++
+	if len(p.Errors) < maxImportErrorDetails {
+		p.Errors = append(p.Errors, fmt.Sprintf("%s: %v", name, err))
+	}
+}
+
+func (p *ImportPlan) checkItemLimit() error {
+	if p.Files+p.Folders <= p.MaxItems {
+		return nil
+	}
+	p.LimitExceeded = true
+	return errImportItemLimit
+}
+
+func (p *ImportPlan) addFolder() error {
+	p.Folders++
+	return p.checkItemLimit()
+}
+
+func (s *Service) planFile(size int64, encrypt bool, plan *ImportPlan) error {
 	if uploadByteSize(size, encrypt) > s.largeFileMaxBytes() {
 		plan.Oversize++
-		return
+		return nil
 	}
 	plan.Files++
 	plan.Bytes += size
+	return plan.checkItemLimit()
 }
 
-func (s *Service) planFolder(root string, encrypt bool, plan *ImportPlan) {
-	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
-		if err != nil {
-			plan.Errors = append(plan.Errors, fmt.Sprintf("%s: %v", filepath.Base(p), err))
-			if d != nil && d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if p == root {
-			return nil // counted by the caller
-		}
+func (s *Service) planFolder(ctx context.Context, root string, encrypt bool, plan *ImportPlan) error {
+	err := walkImportDescendants(ctx, root, func(_ string, _ string, d os.DirEntry) (bool, error) {
 		if d.Type()&os.ModeSymlink != 0 {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
+			return true, nil
 		}
-		if isJunkName(d.Name()) {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
+		if isIgnoredImportName(d.Name(), d.IsDir()) {
+			plan.Ignored++
+			return d.IsDir(), nil
 		}
 		if d.IsDir() {
-			plan.Folders++
-			return nil
+			return false, plan.addFolder()
 		}
 		info, err := d.Info()
 		if err != nil {
-			plan.Errors = append(plan.Errors, fmt.Sprintf("%s: %v", d.Name(), err))
-			return nil
+			plan.addError(d.Name(), err)
+			return false, nil
 		}
-		s.planFile(info.Size(), encrypt, plan)
+		return false, s.planFile(info.Size(), encrypt, plan)
+	}, func(p string, err error) error {
+		plan.addError(filepath.Base(p), err)
 		return nil
 	})
+	if errors.Is(err, errImportItemLimit) {
+		return err
+	}
+	return nil
 }
 
-func (s *Service) planArchive(p string, encrypt bool, plan *ImportPlan) {
-	entries, err := ScanArchive(p)
+func (s *Service) planArchive(ctx context.Context, p string, encrypt bool, plan *ImportPlan) error {
+	entries, ignored, err := scanArchiveForImport(ctx, p)
+	plan.Ignored += ignored
 	if err != nil {
-		// Corrupt or unreadable: RunImport falls back to uploading it as a file.
-		plan.Errors = append(plan.Errors, fmt.Sprintf("%s: cannot read archive (%v), will upload as a file", filepath.Base(p), err))
-		if info, statErr := os.Stat(p); statErr == nil {
-			s.planFile(info.Size(), encrypt, plan)
+		if errors.Is(err, errImportItemLimit) {
+			plan.LimitExceeded = true
+			return err
 		}
-		return
+		// Corrupt or unreadable: RunImport falls back to uploading it as a file.
+		plan.addError(filepath.Base(p), fmt.Errorf("cannot read archive (%v), will upload as a file", err))
+		if info, statErr := os.Stat(p); statErr == nil {
+			return s.planFile(info.Size(), encrypt, plan)
+		}
+		return nil
 	}
-	plan.Folders++ // the archive-named folder
+	if err := plan.addFolder(); err != nil { // the archive-named folder
+		return err
+	}
 	stripRoot := archiveDuplicateRoot(entries, archiveFolderName(p))
 	// Count folders the way import actually creates them: from the parent dirs
 	// of real files. Empty directory entries are not recreated (extraction
 	// streams files only), so they are intentionally not counted here.
 	dirs := map[string]struct{}{}
 	for _, e := range entries {
-		if e.IsDir || isJunkArchivePath(e.RelPath) {
-			continue
-		}
 		rel := stripArchiveRoot(e.RelPath, stripRoot)
-		if rel == "" || isJunkArchivePath(rel) {
+		if rel == "" {
 			continue
 		}
-		s.planFile(e.Size, encrypt, plan)
+		if err := s.planFile(e.Size, encrypt, plan); err != nil {
+			return err
+		}
 		for d := path.Dir(rel); d != "."; d = path.Dir(d) {
+			if _, exists := dirs[d]; exists {
+				continue
+			}
 			dirs[d] = struct{}{}
+			if err := plan.addFolder(); err != nil {
+				return err
+			}
 		}
 	}
-	plan.Folders += len(dirs)
+	return nil
 }
 
-// importTasks accumulates the file uploads and folder/skip counts produced while
-// walking a selection.
+// scanArchiveForImport streams archive metadata into a bounded, policy-filtered
+// slice. Tar scans stop at the admission limit; zip still requires Go's central
+// directory index, but TDrive no longer duplicates an unbounded list in memory.
+func scanArchiveForImport(ctx context.Context, archivePath string) ([]ArchiveEntry, int, error) {
+	return scanArchiveForImportLimit(ctx, archivePath, maxImportArchiveScanEntries)
+}
+
+func scanArchiveForImportLimit(ctx context.Context, archivePath string, maxScanned int) ([]ArchiveEntry, int, error) {
+	if ctx == nil {
+		return nil, 0, fmt.Errorf("archive scan requires a context")
+	}
+	if maxScanned <= 0 {
+		return nil, 0, fmt.Errorf("archive scan limit must be positive")
+	}
+	entries := make([]ArchiveEntry, 0, min(maxImportItems, 256))
+	ignoredRoots := make(map[string]struct{})
+	seen := 0
+	err := forEachArchiveEntry(archivePath, func(entry ArchiveEntry) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		seen++
+		if seen > maxScanned {
+			return errArchiveScanLimit
+		}
+		if root := ignoredArchiveRoot(entry.RelPath, entry.IsDir); root != "" {
+			if len(ignoredRoots) < maxImportItems {
+				ignoredRoots[root] = struct{}{}
+			}
+			return nil
+		}
+		if entry.IsDir {
+			return nil
+		}
+		if len(entries) >= maxImportItems {
+			return errImportItemLimit
+		}
+		entries = append(entries, entry)
+		return nil
+	})
+	return entries, len(ignoredRoots), err
+}
+
+type importBatch struct {
+	paths   []string
+	parents []string
+}
+
+func newImportBatch() *importBatch {
+	return &importBatch{
+		paths:   make([]string, 0, importUploadBatchSize),
+		parents: make([]string, 0, importUploadBatchSize),
+	}
+}
+
+func (b *importBatch) add(srcPath, parentID string) bool {
+	b.paths = append(b.paths, srcPath)
+	b.parents = append(b.parents, parentID)
+	return len(b.paths) == importUploadBatchSize
+}
+
+func (b *importBatch) len() int {
+	return len(b.paths)
+}
+
+func (b *importBatch) reset() {
+	clear(b.paths)
+	clear(b.parents)
+	b.paths = b.paths[:0]
+	b.parents = b.parents[:0]
+}
+
+type importBatchUploader func(paths, parents []string, idOffset int) error
+
+// importTasks retains only one bounded upload window plus bounded diagnostics.
+// The synchronous uploader provides natural backpressure to the filesystem
+// walk; it never schedules the next window while this one is active.
 type importTasks struct {
-	paths    []string
-	parents  []string
-	folders  int
-	oversize int
-	errors   []string
+	batch        *importBatch
+	upload       importBatchUploader
+	nextUploadID int
+	files        int
+	remoteItems  int
+	folders      int
+	oversize     int
+	ignored      int
+	errorCount   int
+	errors       []string
+	warnf        WarnFunc
 }
 
-func (t *importTasks) add(srcPath, parentID string) {
-	t.paths = append(t.paths, srcPath)
-	t.parents = append(t.parents, parentID)
+func (t *importTasks) reserveRemoteItem() error {
+	if t.remoteItems >= maxImportItems {
+		return errImportItemLimit
+	}
+	t.remoteItems++
+	return nil
+}
+
+func (t *importTasks) add(srcPath, parentID string) error {
+	if err := t.reserveRemoteItem(); err != nil {
+		return err
+	}
+	t.files++
+	if t.batch.add(srcPath, parentID) {
+		return t.flush()
+	}
+	return nil
+}
+
+func (t *importTasks) flush() error {
+	if t.batch.len() == 0 {
+		return nil
+	}
+	batchSize := t.batch.len()
+	err := t.upload(t.batch.paths, t.batch.parents, t.nextUploadID)
+	t.nextUploadID += batchSize
+	t.batch.reset()
+	if err != nil && t.warnf != nil {
+		t.warnf("import: upload window failed: %v\n", err)
+	}
+	if isFatalImportError(err) {
+		return err
+	}
+	if err != nil {
+		t.addError("upload window", err)
+	}
+	return nil
+}
+
+func isFatalImportError(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, errImportItemLimit) ||
+		errors.Is(err, errUploadProjection) ||
+		errors.Is(err, tgclient.ErrFloodWait) ||
+		errors.Is(err, tgclient.ErrSendOutcomeUnknown)
 }
 
 func (t *importTasks) addError(name string, err error) {
-	t.errors = append(t.errors, fmt.Sprintf("%s: %v", name, err))
+	t.errorCount++
+	if len(t.errors) < maxImportErrorDetails {
+		t.errors = append(t.errors, fmt.Sprintf("%s: %v", name, err))
+	}
 }
 
 // RunImport recreates the folder structure of the selected paths under parentID
 // and uploads their files. Top-level folder names that collide with an existing
 // folder are suffixed (Name (2)); archives chosen for extraction are unpacked to
 // a temp dir and imported like folders. Progress flows through import_start, the
-// per-file upload_* events, and import_complete.
+// aggregate import events, and import_complete.
 func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string, parentID string, encrypt, extractArchives bool) error {
+	if ctx == nil {
+		return fmt.Errorf("import: context is required")
+	}
 	if err := s.ready(); err != nil {
 		return err
 	}
@@ -274,6 +441,17 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 			return fmt.Errorf("encryption upload not ready")
 		}
 	}
+	plan := s.planImport(ctx, paths, encrypt, extractArchives)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if plan.LimitExceeded {
+		return fmt.Errorf("%w: keep the selection under %d files and folders", errImportItemLimit, plan.MaxItems)
+	}
+	peer, err := s.Peers.ResolvePeer(ctx, channelID)
+	if err != nil {
+		return err
+	}
 
 	// The extraction temp dir is created lazily on the first archive we actually
 	// extract, so a folder-only import never touches /tmp.
@@ -297,10 +475,25 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 	// Announce the import immediately so the bell shows activity through the
 	// prepare, extract, and folder-creation phases, before any uploads begin.
 	s.emitEvent("import_start")
-
-	tasks := &importTasks{}
+	s.emitEvent("import_uploading", map[string]any{"files": plan.Files, "folders": plan.Folders})
+	observer := newImportUploadObserver(s, plan.Files)
+	observer.EmitInitial()
+	tasks := &importTasks{
+		batch: newImportBatch(),
+		warnf: s.warnf,
+	}
+	tasks.upload = func(batchPaths, batchParents []string, idOffset int) error {
+		_, err := s.upload(ctx, channelID, batchPaths, batchParents, encrypt, uploadOptions{
+			observer: observer,
+			peer:     &peer,
+			idOffset: idOffset,
+		})
+		return err
+	}
+	var fatalErr error
 	for _, p := range paths {
-		if ctx.Err() != nil {
+		if err := ctx.Err(); err != nil {
+			fatalErr = err
 			break
 		}
 		info, err := os.Stat(p)
@@ -312,6 +505,10 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 		case info.IsDir():
 			s.emitEvent("import_progress", map[string]any{"label": "Adding " + filepath.Base(p)})
 			if err := s.importTree(ctx, channelID, p, filepath.Base(p), parent, encrypt, tasks); err != nil {
+				if isFatalImportError(err) {
+					fatalErr = err
+					break
+				}
 				tasks.addError(filepath.Base(p), err)
 			}
 		case IsArchive(p) && extractArchives:
@@ -320,69 +517,91 @@ func (s *Service) RunImport(ctx context.Context, channelID int64, paths []string
 			if err != nil {
 				return fmt.Errorf("create temp dir: %w", err)
 			}
-			dir, stats, err := s.extractArchiveToTemp(p, root, encrypt)
+			dir, stats, err := s.extractArchiveToTemp(ctx, p, root, encrypt)
 			tasks.oversize += stats.oversize
+			tasks.ignored += stats.ignored
 			if err != nil {
+				if isFatalImportError(err) {
+					fatalErr = err
+					break
+				}
 				tasks.addError(filepath.Base(p), fmt.Errorf("extract failed, uploading as a file: %w", err))
-				s.addFileTask(p, info.Size(), parent, encrypt, tasks)
+				if err := s.addFileTask(p, info.Size(), parent, encrypt, tasks); err != nil {
+					fatalErr = err
+				}
 				continue
 			}
 			if err := s.importTree(ctx, channelID, dir, archiveFolderName(p), parent, encrypt, tasks); err != nil {
+				if isFatalImportError(err) {
+					fatalErr = err
+					break
+				}
 				tasks.addError(filepath.Base(p), err)
 			}
 		default:
-			s.addFileTask(p, info.Size(), parent, encrypt, tasks)
+			if err := s.addFileTask(p, info.Size(), parent, encrypt, tasks); err != nil {
+				fatalErr = err
+			}
+		}
+		if fatalErr != nil {
+			break
 		}
 	}
-
-	// Switch the bell to the upload phase now that the folders exist and the
-	// file list is known, so the progress denominator is the real upload count.
-	s.emitEvent("import_uploading", map[string]any{"files": len(tasks.paths), "folders": tasks.folders})
-
-	uploaded := 0
-	var uploadErr error
-	if len(tasks.paths) > 0 {
-		metas, err := s.Upload(ctx, channelID, tasks.paths, tasks.parents, encrypt)
-		uploaded = len(metas)
-		uploadErr = err
+	if fatalErr == nil {
+		if err := tasks.flush(); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				fatalErr = ctxErr
+			} else {
+				fatalErr = err
+			}
+		}
 	}
-
+	uploaded, observerFailed, uploadReasons := observer.Summary()
+	failed := max(plan.Files-uploaded, observerFailed)
+	errorsOut := append([]string(nil), tasks.errors...)
+	for _, reason := range uploadReasons {
+		if len(errorsOut) >= maxImportErrorDetails {
+			break
+		}
+		errorsOut = append(errorsOut, reason)
+	}
 	s.emitEvent("import_complete", map[string]any{
-		"uploaded": uploaded,
-		"failed":   len(tasks.paths) - uploaded,
-		"folders":  tasks.folders,
-		"oversize": tasks.oversize,
-		"errors":   tasks.errors,
+		"uploaded":   uploaded,
+		"failed":     failed,
+		"folders":    tasks.folders,
+		"oversize":   tasks.oversize,
+		"ignored":    tasks.ignored,
+		"errorCount": tasks.errorCount,
+		"errors":     errorsOut,
 	})
-	// Per-file upload failures are already reported through import_complete (and
-	// the upload_error events). Returning them here too made the frontend
-	// overwrite that accurate summary with a generic "Import failed", so log and
-	// swallow; only genuine pre-import errors above reject the call.
-	if uploadErr != nil {
-		s.warnf("import: some uploads failed: %v\n", uploadErr)
+	if fatalErr != nil {
+		return fatalErr
 	}
 	return nil
 }
 
 // addFileTask queues a single file for upload, skipping (and counting) it if it
 // exceeds the per-file limit.
-func (s *Service) addFileTask(srcPath string, size int64, parentID string, encrypt bool, tasks *importTasks) {
+func (s *Service) addFileTask(srcPath string, size int64, parentID string, encrypt bool, tasks *importTasks) error {
 	if uploadByteSize(size, encrypt) > s.largeFileMaxBytes() {
 		tasks.oversize++
-		return
+		return nil
 	}
-	tasks.add(srcPath, parentID)
+	return tasks.add(srcPath, parentID)
 }
 
 // importTree creates a top folder (collision-suffixed) under parentID, mirrors
 // the directory structure beneath root, and queues every file for upload. The
-// walk is lexical, so a directory is always created before its children.
+// depth-first walk always creates a directory before visiting its children.
 func (s *Service) importTree(ctx context.Context, channelID int64, root, topName, parentID string, encrypt bool, tasks *importTasks) error {
 	freeName, err := projection.NextFreeFolderName(s.DB, channelID, parentID, topName)
 	if err != nil {
 		return err
 	}
-	topID, err := s.CreateFolder(channelID, freeName, parentID)
+	if err := tasks.reserveRemoteItem(); err != nil {
+		return err
+	}
+	topID, err := s.CreateFolder(ctx, channelID, freeName, parentID)
 	if err != nil {
 		return err
 	}
@@ -391,64 +610,42 @@ func (s *Service) importTree(ctx context.Context, channelID int64, root, topName
 	// Maps a cleaned forward-slash relative directory to its created folder ID.
 	dirIDs := map[string]string{".": topID}
 
-	return filepath.WalkDir(root, func(p string, d os.DirEntry, walkErr error) error {
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-		if walkErr != nil {
-			tasks.addError(filepath.Base(p), walkErr)
-			if d != nil && d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if p == root {
-			return nil
-		}
+	return walkImportDescendants(ctx, root, func(p, rel string, d os.DirEntry) (bool, error) {
 		if d.Type()&os.ModeSymlink != 0 {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
+			return true, nil
 		}
-		if isJunkName(d.Name()) {
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
+		if isIgnoredImportName(d.Name(), d.IsDir()) {
+			tasks.ignored++
+			return d.IsDir(), nil
 		}
-		rel, err := filepath.Rel(root, p)
-		if err != nil {
-			tasks.addError(filepath.Base(p), err)
-			return nil
-		}
-		rel = filepath.ToSlash(rel)
 		parentID := dirIDs[path.Dir(rel)]
 		if parentID == "" {
 			// A parent we failed to create earlier; skip this dangling entry.
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
+			return d.IsDir(), nil
 		}
 
 		if d.IsDir() {
-			id, err := s.CreateFolder(channelID, d.Name(), parentID)
+			if err := tasks.reserveRemoteItem(); err != nil {
+				return false, err
+			}
+			id, err := s.CreateFolder(ctx, channelID, d.Name(), parentID)
 			if err != nil {
 				tasks.addError(rel, err)
-				return filepath.SkipDir
+				return true, nil
 			}
 			dirIDs[rel] = id
 			tasks.folders++
-			return nil
+			return false, nil
 		}
 
 		info, err := d.Info()
 		if err != nil {
 			tasks.addError(rel, err)
-			return nil
+			return false, nil
 		}
-		s.addFileTask(p, info.Size(), parentID, encrypt, tasks)
+		return false, s.addFileTask(p, info.Size(), parentID, encrypt, tasks)
+	}, func(p string, err error) error {
+		tasks.addError(filepath.Base(p), err)
 		return nil
 	})
 }
@@ -457,12 +654,15 @@ func (s *Service) importTree(ctx context.Context, channelID int64, root, topName
 // temp directory under tmpRoot, preserving relative structure, and returns the
 // directory. StreamArchiveFiles already drops unsafe (zip-slip) and symlink
 // entries; the prefix check below is defense in depth.
-func (s *Service) extractArchiveToTemp(archivePath, tmpRoot string, encrypt bool) (string, archiveExtractStats, error) {
+func (s *Service) extractArchiveToTemp(ctx context.Context, archivePath, tmpRoot string, encrypt bool) (string, archiveExtractStats, error) {
+	if err := ctx.Err(); err != nil {
+		return "", archiveExtractStats{}, err
+	}
 	dir, err := os.MkdirTemp(tmpRoot, "arc-")
 	if err != nil {
 		return "", archiveExtractStats{}, err
 	}
-	entries, err := ScanArchive(archivePath)
+	entries, ignored, err := scanArchiveForImport(ctx, archivePath)
 	if err != nil {
 		_ = os.RemoveAll(dir)
 		return "", archiveExtractStats{}, err
@@ -479,13 +679,16 @@ func (s *Service) extractArchiveToTemp(archivePath, tmpRoot string, encrypt bool
 		readLimit++
 	}
 	totalLimit := s.maxArchiveExtractBytes()
-	stats := archiveExtractStats{}
+	stats := archiveExtractStats{ignored: ignored}
 	err = StreamArchiveFiles(archivePath, func(e ArchiveEntry, r io.Reader) error {
-		if isJunkArchivePath(e.RelPath) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if root := ignoredArchiveRoot(e.RelPath, e.IsDir); root != "" {
 			return nil
 		}
 		rel := stripArchiveRoot(e.RelPath, stripRoot)
-		if rel == "" || isJunkArchivePath(rel) {
+		if rel == "" || isIgnoredArchivePath(rel, e.IsDir) {
 			return nil
 		}
 		if e.Size < 0 {
@@ -519,7 +722,7 @@ func (s *Service) extractArchiveToTemp(archivePath, tmpRoot string, encrypt bool
 			remainingReadLimit++
 		}
 		entryReadLimit := minInt64(readLimit, remainingReadLimit)
-		written, copyErr := io.Copy(f, io.LimitReader(r, entryReadLimit))
+		written, copyErr := io.Copy(f, io.LimitReader(&contextReader{ctx: ctx, source: r}, entryReadLimit))
 		closeErr := f.Close()
 		if copyErr != nil {
 			_ = os.Remove(actualDest)

--- a/backend/services/file/import_batch_test.go
+++ b/backend/services/file/import_batch_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -148,6 +149,26 @@ func (r *importTestEventRecorder) names() []string {
 	return names
 }
 
+func (r *importTestEventRecorder) lastPayload(name string) (map[string]any, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for index := len(r.records) - 1; index >= 0; index-- {
+		record := r.records[index]
+		if record.name != name || len(record.args) != 1 {
+			continue
+		}
+		payload, ok := record.args[0].(map[string]any)
+		return payload, ok
+	}
+	return nil, false
+}
+
+type importPeerResolverFunc func(context.Context, int64) (tgclient.InputPeer, error)
+
+func (resolve importPeerResolverFunc) ResolvePeer(ctx context.Context, channelID int64) (tgclient.InputPeer, error) {
+	return resolve(ctx, channelID)
+}
+
 func TestRunImportEmitsAggregateEventsOnly(t *testing.T) {
 	svc, db, _, _ := newTestService(t)
 	svc.CreateFolder = contextTestFolderCreator(db)
@@ -268,5 +289,134 @@ func TestRunImportStopsSchedulingAfterFatalUploadWindow(t *testing.T) {
 	}
 	if sent := len(fakeTG.SentFiles()); sent != importUploadBatchSize-1 {
 		t.Fatalf("sent files after fatal upload window = %d, want first window minus failed send %d", sent, importUploadBatchSize-1)
+	}
+}
+
+func TestRunImportCompletionReportsFatalFolderOnlyFailure(t *testing.T) {
+	svc, _, fakeTG, _ := newTestService(t)
+	events := &importTestEventRecorder{}
+	svc.Events = events
+	fatalErr := fmt.Errorf("folder projection failed: %w", tgclient.ErrSendOutcomeUnknown)
+	svc.CreateFolder = func(context.Context, int64, string, string) (string, error) {
+		return "", fatalErr
+	}
+
+	folder := filepath.Join(t.TempDir(), "Empty folder")
+	if err := os.Mkdir(folder, 0o755); err != nil {
+		t.Fatalf("create empty folder: %v", err)
+	}
+
+	err := svc.RunImport(context.Background(), personalChannelID, []string{folder}, "", false, false)
+	if !errors.Is(err, tgclient.ErrSendOutcomeUnknown) {
+		t.Fatalf("RunImport error = %v, want ErrSendOutcomeUnknown", err)
+	}
+	if files := fakeTG.SentFiles(); len(files) != 0 {
+		t.Fatalf("sent files = %d, want 0 for folder-only failure", len(files))
+	}
+	payload, ok := events.lastPayload("import_complete")
+	if !ok {
+		t.Fatal("import_complete payload missing")
+	}
+	if got := payload["status"]; got != "failed" {
+		t.Fatalf("completion status = %v, want failed", got)
+	}
+	if got := payload["error"]; got == nil || !strings.Contains(fmt.Sprint(got), "folder projection failed") {
+		t.Fatalf("completion error = %v, want folder projection failure", got)
+	}
+	if got := payload["uploaded"]; got != 0 {
+		t.Fatalf("completion uploaded = %v, want 0", got)
+	}
+	if got := payload["failed"]; got != 0 {
+		t.Fatalf("completion failed files = %v, want 0", got)
+	}
+}
+
+func TestRunImportStopsAfterNestedControlProjectionFailure(t *testing.T) {
+	svc, _, fakeTG, _ := newTestService(t)
+	createCalls := 0
+	svc.CreateFolder = func(context.Context, int64, string, string) (string, error) {
+		createCalls++
+		if createCalls == 1 {
+			return projection.FolderIDPrefix + "top", nil
+		}
+		return "", fmt.Errorf("nested folder projection failed: %w", projection.ErrControlProjection)
+	}
+
+	selectionRoot := t.TempDir()
+	folder := filepath.Join(selectionRoot, "Project")
+	if err := os.MkdirAll(filepath.Join(folder, "nested"), 0o755); err != nil {
+		t.Fatalf("create nested folder: %v", err)
+	}
+	laterFile := filepath.Join(selectionRoot, "later.txt")
+	if err := os.WriteFile(laterFile, []byte("must not upload"), 0o600); err != nil {
+		t.Fatalf("create later file: %v", err)
+	}
+
+	err := svc.RunImport(
+		context.Background(),
+		personalChannelID,
+		[]string{folder, laterFile},
+		"",
+		false,
+		false,
+	)
+	if !errors.Is(err, projection.ErrControlProjection) {
+		t.Fatalf("RunImport error = %v, want ErrControlProjection", err)
+	}
+	if createCalls != 2 {
+		t.Fatalf("folder creation calls = %d, want top-level and failing nested folder", createCalls)
+	}
+	if files := fakeTG.SentFiles(); len(files) != 0 {
+		t.Fatalf("sent files after nested projection failure = %d, want 0", len(files))
+	}
+}
+
+func TestRunImportArchiveFallbackUsesScheduledUploadCount(t *testing.T) {
+	svc, db, fakeTG, _ := newTestService(t)
+	svc.CreateFolder = contextTestFolderCreator(db)
+	events := &importTestEventRecorder{}
+	svc.Events = events
+	archivePath := buildZip(t, map[string]string{
+		"one.txt":   "one",
+		"two.txt":   "two",
+		"three.txt": "three",
+	}, nil, nil)
+	if plan := svc.PlanImport([]string{archivePath}, false, true); plan.Files != 3 {
+		t.Fatalf("preflight files = %d, want 3 archive members", plan.Files)
+	}
+
+	baseResolver := svc.Peers
+	svc.Peers = importPeerResolverFunc(func(ctx context.Context, channelID int64) (tgclient.InputPeer, error) {
+		peer, err := baseResolver.ResolvePeer(ctx, channelID)
+		if err != nil {
+			return tgclient.InputPeer{}, err
+		}
+		if err := os.WriteFile(archivePath, []byte("corrupt after preflight"), 0o600); err != nil {
+			return tgclient.InputPeer{}, err
+		}
+		return peer, nil
+	})
+
+	if err := svc.RunImport(context.Background(), personalChannelID, []string{archivePath}, "", false, true); err != nil {
+		t.Fatalf("RunImport fallback: %v", err)
+	}
+	if files := fakeTG.SentFiles(); len(files) != 1 {
+		t.Fatalf("sent files = %d, want one raw archive fallback", len(files))
+	}
+	payload, ok := events.lastPayload("import_complete")
+	if !ok {
+		t.Fatal("import_complete payload missing")
+	}
+	if got := payload["uploaded"]; got != 1 {
+		t.Fatalf("completion uploaded = %v, want 1", got)
+	}
+	if got := payload["failed"]; got != 0 {
+		t.Fatalf("completion failed = %v, want 0 for successful raw fallback", got)
+	}
+	if got := payload["status"]; got != "done" {
+		t.Fatalf("completion status = %v, want done", got)
+	}
+	if got := payload["errorCount"]; got != 1 {
+		t.Fatalf("completion errorCount = %v, want one extraction warning", got)
 	}
 }

--- a/backend/services/file/import_batch_test.go
+++ b/backend/services/file/import_batch_test.go
@@ -1,0 +1,272 @@
+package file
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"TDrive/backend/projection"
+	"TDrive/backend/tgclient"
+)
+
+func TestImportBatchIsBoundedAndPreservesPairs(t *testing.T) {
+	total := 2*importUploadBatchSize + 1
+	wantPaths := make([]string, total)
+	wantParents := make([]string, total)
+	gotPaths := make([]string, 0, total)
+	gotParents := make([]string, 0, total)
+	batch := newImportBatch()
+
+	consume := func() {
+		if batch.len() > importUploadBatchSize {
+			t.Fatalf("batch length = %d, exceeds bound %d", batch.len(), importUploadBatchSize)
+		}
+		if cap(batch.paths) > importUploadBatchSize || cap(batch.parents) > importUploadBatchSize {
+			t.Fatalf("batch capacity = (%d, %d), exceeds bound %d", cap(batch.paths), cap(batch.parents), importUploadBatchSize)
+		}
+		gotPaths = append(gotPaths, batch.paths...)
+		gotParents = append(gotParents, batch.parents...)
+		batch.reset()
+		if batch.len() != 0 {
+			t.Fatalf("batch length after reset = %d, want 0", batch.len())
+		}
+	}
+
+	for i := 0; i < total; i++ {
+		wantPaths[i] = fmt.Sprintf("path-%03d", i)
+		wantParents[i] = fmt.Sprintf("parent-%03d", i)
+		if full := batch.add(wantPaths[i], wantParents[i]); full {
+			consume()
+		}
+		if batch.len() > importUploadBatchSize {
+			t.Fatalf("batch length after add = %d, exceeds bound %d", batch.len(), importUploadBatchSize)
+		}
+	}
+	if batch.len() > 0 {
+		consume()
+	}
+
+	if len(gotPaths) != total || len(gotParents) != total {
+		t.Fatalf("consumed pairs = (%d, %d), want (%d, %d)", len(gotPaths), len(gotParents), total, total)
+	}
+	for i := 0; i < total; i++ {
+		if gotPaths[i] != wantPaths[i] || gotParents[i] != wantParents[i] {
+			t.Fatalf("pair %d = (%q, %q), want (%q, %q)", i, gotPaths[i], gotParents[i], wantPaths[i], wantParents[i])
+		}
+	}
+}
+
+func contextTestFolderCreator(db *sql.DB) CreateFolderFunc {
+	var mu sync.Mutex
+	var folderNumber, messageID int64 = 0, 70000
+	return func(ctx context.Context, channelID int64, name, parentID string) (string, error) {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		folderNumber++
+		messageID++
+		id := fmt.Sprintf("%sctximp%d", projection.FolderIDPrefix, folderNumber)
+		op := projection.Op{Type: projection.OpMkdir, Obj: id, Parent: parentID, Name: name}
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return "", err
+		}
+		if err := projection.ApplyOp(tx, channelID, messageID, op, 7); err != nil {
+			_ = tx.Rollback()
+			return "", err
+		}
+		if err := tx.Commit(); err != nil {
+			return "", err
+		}
+		return id, nil
+	}
+}
+
+func TestRunImportPassesContextAndStopsOnCancellation(t *testing.T) {
+	type contextKey struct{}
+	const marker = "import-context"
+
+	svc, _, fakeTG, _ := newTestService(t)
+	root := filepath.Join(t.TempDir(), "Project")
+	mkfile(t, filepath.Join(root, "file.txt"), "must not upload")
+	base := context.WithValue(context.Background(), contextKey{}, marker)
+	ctx, cancel := context.WithCancel(base)
+	defer cancel()
+	called := false
+	svc.CreateFolder = func(folderCtx context.Context, _ int64, _, _ string) (string, error) {
+		called = true
+		if got := folderCtx.Value(contextKey{}); got != marker {
+			t.Fatalf("folder context marker = %v, want %q", got, marker)
+		}
+		cancel()
+		return projection.FolderIDPrefix + "cancelled", nil
+	}
+
+	err := svc.RunImport(ctx, personalChannelID, []string{root}, "", false, false)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunImport error = %v, want context.Canceled", err)
+	}
+	if !called {
+		t.Fatal("CreateFolder was not called")
+	}
+	if sent := fakeTG.SentFiles(); len(sent) != 0 {
+		t.Fatalf("sent files after cancellation = %d, want 0", len(sent))
+	}
+}
+
+type importEventRecord struct {
+	name string
+	args []any
+}
+
+type importTestEventRecorder struct {
+	mu      sync.Mutex
+	records []importEventRecord
+}
+
+func (r *importTestEventRecorder) Emit(name string, args ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, importEventRecord{name: name, args: append([]any(nil), args...)})
+}
+
+func (r *importTestEventRecorder) names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	names := make([]string, len(r.records))
+	for i, record := range r.records {
+		names[i] = record.name
+	}
+	return names
+}
+
+func TestRunImportEmitsAggregateEventsOnly(t *testing.T) {
+	svc, db, _, _ := newTestService(t)
+	svc.CreateFolder = contextTestFolderCreator(db)
+	events := &importTestEventRecorder{}
+	svc.Events = events
+	root := filepath.Join(t.TempDir(), "Project")
+	mkfile(t, filepath.Join(root, "a.txt"), "a")
+	mkfile(t, filepath.Join(root, "b.txt"), "b")
+
+	if err := svc.RunImport(context.Background(), personalChannelID, []string{root}, "", false, false); err != nil {
+		t.Fatalf("RunImport: %v", err)
+	}
+
+	names := events.names()
+	if len(names) == 0 || names[0] != "import_start" {
+		t.Fatalf("event names = %v, want import_start first", names)
+	}
+	if names[len(names)-1] != "import_complete" {
+		t.Fatalf("event names = %v, want import_complete last", names)
+	}
+	for _, want := range []string{"import_uploading", "import_upload_progress"} {
+		found := false
+		for _, name := range names {
+			if name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("event names = %v, missing %s", names, want)
+		}
+	}
+	for _, name := range names {
+		if strings.HasPrefix(name, "upload_") {
+			t.Errorf("event names = %v, import leaked per-file event %q", names, name)
+		}
+	}
+}
+
+func TestImportProgressEventsStayBoundedAtHighCardinality(t *testing.T) {
+	const total = 10_000
+	events := &importTestEventRecorder{}
+	svc := &Service{Events: events}
+	observer := newImportUploadObserver(svc, total)
+	observer.EmitInitial()
+	for id := 0; id < total; id++ {
+		observer.Completed(id, "")
+	}
+
+	events.mu.Lock()
+	records := append([]importEventRecord(nil), events.records...)
+	events.mu.Unlock()
+	if len(records) > 101 {
+		t.Fatalf("aggregate progress events = %d, want at most 101", len(records))
+	}
+	lastProgress := -1.0
+	for index, record := range records {
+		if record.name != "import_upload_progress" || len(record.args) != 1 {
+			t.Fatalf("record %d = %+v, want one aggregate progress payload", index, record)
+		}
+		payload, ok := record.args[0].(map[string]any)
+		if !ok {
+			t.Fatalf("record %d payload = %T, want map", index, record.args[0])
+		}
+		progress, ok := payload["progress"].(float64)
+		if !ok || progress < lastProgress || progress < 0 || progress > 100 {
+			t.Fatalf("record %d progress = %v after %.2f", index, payload["progress"], lastProgress)
+		}
+		lastProgress = progress
+	}
+	if lastProgress != 100 {
+		t.Fatalf("final progress = %.2f, want 100", lastProgress)
+	}
+}
+
+func TestRunImportStopsSchedulingAfterProjectionFailure(t *testing.T) {
+	svc, db, fakeTG, _ := newTestService(t)
+	svc.CreateFolder = contextTestFolderCreator(db)
+	root := filepath.Join(t.TempDir(), "Project")
+	for index := 0; index < importUploadBatchSize+1; index++ {
+		mkfile(t, filepath.Join(root, fmt.Sprintf("file-%03d.txt", index)), "x")
+	}
+	if _, err := db.Exec(`
+		CREATE TRIGGER fail_import_file_projection
+		BEFORE INSERT ON files
+		BEGIN
+			SELECT RAISE(ABORT, 'injected import projection failure');
+		END;
+	`); err != nil {
+		t.Fatalf("create projection trigger: %v", err)
+	}
+
+	err := svc.RunImport(context.Background(), personalChannelID, []string{root}, "", false, false)
+	if err == nil || !strings.Contains(err.Error(), "injected import projection failure") {
+		t.Fatalf("RunImport error = %v, want injected projection failure", err)
+	}
+	if sent := len(fakeTG.SentFiles()); sent != importUploadBatchSize {
+		t.Fatalf("sent files after projection failure = %d, want first bounded window %d", sent, importUploadBatchSize)
+	}
+}
+
+func TestRunImportStopsSchedulingAfterFatalUploadWindow(t *testing.T) {
+	svc, db, fakeTG, _ := newTestService(t)
+	svc.CreateFolder = contextTestFolderCreator(db)
+	svc.MaxConcurrentUploads = 1
+	svc.FloodWaitRetry = tgclient.FloodWaitRetryPolicy{
+		Sleep: func(context.Context, time.Duration) error { return nil },
+	}
+	fakeTG.InjectFloodWaits(1)
+	root := filepath.Join(t.TempDir(), "Project")
+	for index := 0; index < importUploadBatchSize+1; index++ {
+		mkfile(t, filepath.Join(root, fmt.Sprintf("file-%03d.txt", index)), "x")
+	}
+
+	err := svc.RunImport(context.Background(), personalChannelID, []string{root}, "", false, false)
+	if !errors.Is(err, tgclient.ErrFloodWait) {
+		t.Fatalf("RunImport error = %v, want FLOOD_WAIT", err)
+	}
+	if sent := len(fakeTG.SentFiles()); sent != importUploadBatchSize-1 {
+		t.Fatalf("sent files after fatal upload window = %d, want first window minus failed send %d", sent, importUploadBatchSize-1)
+	}
+}

--- a/backend/services/file/import_batch_test.go
+++ b/backend/services/file/import_batch_test.go
@@ -420,3 +420,67 @@ func TestRunImportArchiveFallbackUsesScheduledUploadCount(t *testing.T) {
 		t.Fatalf("completion errorCount = %v, want one extraction warning", got)
 	}
 }
+
+func TestRunImportArchiveFallbackStopsSchedulingAfterFatalUploadWindow(t *testing.T) {
+	svc, _, fakeTG, _ := newTestService(t)
+	events := &importTestEventRecorder{}
+	svc.Events = events
+	svc.MaxConcurrentUploads = 1
+	svc.FloodWaitRetry = tgclient.FloodWaitRetryPolicy{
+		Sleep: func(context.Context, time.Duration) error { return nil },
+	}
+	fakeTG.InjectFloodWaits(1)
+
+	selectionRoot := t.TempDir()
+	paths := make([]string, 0, importUploadBatchSize+1)
+	for index := 0; index < importUploadBatchSize-1; index++ {
+		filePath := filepath.Join(selectionRoot, fmt.Sprintf("file-%03d.txt", index))
+		mkfile(t, filePath, "x")
+		paths = append(paths, filePath)
+	}
+	archivePath := buildZip(t, map[string]string{"inside.txt": "inside"}, nil, nil)
+	paths = append(paths, archivePath)
+	laterFolder := filepath.Join(selectionRoot, "must-not-be-created")
+	if err := os.Mkdir(laterFolder, 0o755); err != nil {
+		t.Fatalf("create later folder: %v", err)
+	}
+	paths = append(paths, laterFolder)
+
+	createCalls := 0
+	svc.CreateFolder = func(context.Context, int64, string, string) (string, error) {
+		createCalls++
+		return "", fmt.Errorf("later folder creation: %w", projection.ErrControlProjection)
+	}
+	baseResolver := svc.Peers
+	svc.Peers = importPeerResolverFunc(func(ctx context.Context, channelID int64) (tgclient.InputPeer, error) {
+		peer, err := baseResolver.ResolvePeer(ctx, channelID)
+		if err != nil {
+			return tgclient.InputPeer{}, err
+		}
+		if err := os.WriteFile(archivePath, []byte("corrupt after preflight"), 0o600); err != nil {
+			return tgclient.InputPeer{}, err
+		}
+		return peer, nil
+	})
+
+	err := svc.RunImport(context.Background(), personalChannelID, paths, "", false, true)
+	if !errors.Is(err, tgclient.ErrFloodWait) {
+		t.Fatalf("RunImport error = %v, want FLOOD_WAIT", err)
+	}
+	if createCalls != 0 {
+		t.Fatalf("folder creation calls after fatal archive fallback = %d, want 0", createCalls)
+	}
+	payload, ok := events.lastPayload("import_complete")
+	if !ok {
+		t.Fatal("import_complete payload missing")
+	}
+	if got := payload["scheduled"]; got != importUploadBatchSize {
+		t.Fatalf("completion scheduled = %v, want one bounded window %d", got, importUploadBatchSize)
+	}
+	if got := payload["status"]; got != "failed" {
+		t.Fatalf("completion status = %v, want failed", got)
+	}
+	if got := fmt.Sprint(payload["error"]); !strings.Contains(got, "flood wait") {
+		t.Fatalf("completion error = %q, want original FLOOD_WAIT", got)
+	}
+}

--- a/backend/services/file/import_policy.go
+++ b/backend/services/file/import_policy.go
@@ -1,0 +1,54 @@
+package file
+
+import (
+	"path"
+	"strings"
+)
+
+func isIgnoredImportName(name string, directory bool) bool {
+	lower := strings.ToLower(name)
+	if lower == "" {
+		return false
+	}
+	switch lower {
+	case ".ds_store", "thumbs.db", "desktop.ini", ".localized":
+		return true
+	}
+	if strings.HasPrefix(lower, "._") { // macOS AppleDouble sidecars
+		return true
+	}
+	if directory {
+		// Keep this deliberately conservative. Ambiguous output folders such as
+		// build, dist, target, and vendor may be the content being archived.
+		switch lower {
+		case ".cache", ".git", ".hg", ".mypy_cache", ".nox", ".pytest_cache",
+			".ruff_cache", ".svn", ".tox", ".venv", "__macosx", "__pycache__", "node_modules":
+			return true
+		}
+	}
+	return strings.HasSuffix(lower, ".pyc") ||
+		strings.HasSuffix(lower, ".pyo") ||
+		strings.HasSuffix(lower, ".tsbuildinfo")
+}
+
+// ignoredArchiveRoot returns the first excluded path prefix. Callers use the
+// prefix as a set key so one pruned cache tree counts as one ignored entry,
+// even when an archive lists every descendant separately.
+func ignoredArchiveRoot(relativePath string, entryIsDir bool) string {
+	cleaned := path.Clean(relativePath)
+	if cleaned == "." || cleaned == "" {
+		return ""
+	}
+	parts := strings.Split(cleaned, "/")
+	for index, part := range parts {
+		directory := index < len(parts)-1 || entryIsDir
+		if isIgnoredImportName(part, directory) {
+			return strings.Join(parts[:index+1], "/")
+		}
+	}
+	return ""
+}
+
+func isIgnoredArchivePath(relativePath string, entryIsDir bool) bool {
+	return ignoredArchiveRoot(relativePath, entryIsDir) != ""
+}

--- a/backend/services/file/import_policy_test.go
+++ b/backend/services/file/import_policy_test.go
@@ -236,3 +236,9 @@ func TestArchiveImportScanBoundsIgnoredMetadataToo(t *testing.T) {
 		t.Fatalf("retained ignored entries = %d, want 0", len(entries))
 	}
 }
+
+func TestArchiveScanLimitRemainsRecoverableForRawUploadFallback(t *testing.T) {
+	if isFatalImportError(errArchiveScanLimit) {
+		t.Fatal("archive inspection limit must fall back to uploading the original archive")
+	}
+}

--- a/backend/services/file/import_policy_test.go
+++ b/backend/services/file/import_policy_test.go
@@ -1,0 +1,238 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const expectedMaxImportItems = 10_000
+
+var ignoredImportDirectories = []string{
+	".git",
+	".hg",
+	".svn",
+	"node_modules",
+	"__pycache__",
+	".pytest_cache",
+	".mypy_cache",
+	".ruff_cache",
+	".tox",
+	".nox",
+	".venv",
+	".cache",
+}
+
+var preservedImportDirectories = []string{
+	".github",
+	"build",
+	"dist",
+	"target",
+	"vendor",
+}
+
+var ignoredImportFiles = []string{
+	"compiled.pyc",
+	"optimized.pyo",
+	"project.tsbuildinfo",
+}
+
+func makeImportPolicyTree(t *testing.T) string {
+	t.Helper()
+
+	root := filepath.Join(t.TempDir(), "Project")
+	for _, name := range ignoredImportDirectories {
+		mkfile(t, filepath.Join(root, name, "nested", "ignored.txt"), "ignored")
+	}
+	for _, name := range ignoredImportFiles {
+		mkfile(t, filepath.Join(root, name), "ignored")
+	}
+	for _, name := range preservedImportDirectories {
+		mkfile(t, filepath.Join(root, name, "kept.txt"), "kept")
+	}
+	mkfile(t, filepath.Join(root, "cache.json"), "kept")
+	mkfile(t, filepath.Join(root, "source.go"), "kept")
+	return root
+}
+
+func makeImportPolicyArchive(t *testing.T) string {
+	t.Helper()
+
+	entries := make(map[string]string, len(ignoredImportDirectories)+len(ignoredImportFiles)+len(preservedImportDirectories)+2)
+	for _, name := range ignoredImportDirectories {
+		entries[name+"/nested/ignored.txt"] = "ignored"
+	}
+	for _, name := range ignoredImportFiles {
+		entries[name] = "ignored"
+	}
+	for _, name := range preservedImportDirectories {
+		entries[name+"/kept.txt"] = "kept"
+	}
+	entries["cache.json"] = "kept"
+	entries["source.go"] = "kept"
+	return buildZip(t, entries, nil, nil)
+}
+
+func assertImportPolicyPlan(t *testing.T, plan ImportPlan) {
+	t.Helper()
+
+	wantFiles := len(preservedImportDirectories) + 2
+	if plan.Files != wantFiles {
+		t.Errorf("plan.Files = %d, want %d preserved files", plan.Files, wantFiles)
+	}
+	wantFolders := len(preservedImportDirectories) + 1
+	if plan.Folders != wantFolders {
+		t.Errorf("plan.Folders = %d, want %d preserved folders", plan.Folders, wantFolders)
+	}
+	wantIgnored := len(ignoredImportDirectories) + len(ignoredImportFiles)
+	if plan.Ignored != wantIgnored {
+		t.Errorf("plan.Ignored = %d, want %d ignored roots", plan.Ignored, wantIgnored)
+	}
+}
+
+func TestPlanImportUsesConservativeIgnorePolicyForFolders(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	assertImportPolicyPlan(t, svc.PlanImport([]string{makeImportPolicyTree(t)}, false, false))
+}
+
+func TestPlanImportUsesConservativeIgnorePolicyForArchives(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	assertImportPolicyPlan(t, svc.PlanImport([]string{makeImportPolicyArchive(t)}, false, true))
+}
+
+func TestPlanImportIgnorePolicyIsCaseInsensitive(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	root := filepath.Join(t.TempDir(), "Project")
+	mkfile(t, filepath.Join(root, ".GIT", "ignored.txt"), "ignored")
+	mkfile(t, filepath.Join(root, "BYTECODE.PYC"), "ignored")
+	mkfile(t, filepath.Join(root, "cache.JSON"), "kept")
+
+	plan := svc.PlanImport([]string{root}, false, false)
+	if plan.Files != 1 || plan.Folders != 1 || plan.Ignored != 2 {
+		t.Fatalf("case-insensitive policy plan = %+v, want only cache.JSON preserved", plan)
+	}
+}
+
+func TestImportIgnorePolicyDoesNotTrimLegitimateNames(t *testing.T) {
+	if isIgnoredImportName(" .git", true) {
+		t.Fatal("leading-space directory was mistaken for .git")
+	}
+	if isIgnoredImportName("node_modules ", true) {
+		t.Fatal("trailing-space directory was mistaken for node_modules")
+	}
+}
+
+func TestRunImportUsesThePlannedIgnorePolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    func(*testing.T) string
+		extract bool
+	}{
+		{name: "folder", path: makeImportPolicyTree},
+		{name: "archive", path: makeImportPolicyArchive, extract: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			svc, db, fakeTG, _ := newTestService(t)
+			svc.CreateFolder = contextTestFolderCreator(db)
+			selectedPath := test.path(t)
+			plan := svc.PlanImport([]string{selectedPath}, false, test.extract)
+
+			if err := svc.RunImport(context.Background(), personalChannelID, []string{selectedPath}, "", false, test.extract); err != nil {
+				t.Fatalf("RunImport: %v", err)
+			}
+			if got := len(fakeTG.SentFiles()); got != plan.Files {
+				t.Fatalf("sent files = %d, want planned %d", got, plan.Files)
+			}
+			if got := countLiveFiles(t, db, personalChannelID); got != plan.Files {
+				t.Fatalf("projected files = %d, want planned %d", got, plan.Files)
+			}
+		})
+	}
+}
+
+func TestPlanImportDoesNotIgnoreAnExplicitSelection(t *testing.T) {
+	svc, db, fakeTG, _ := newTestService(t)
+	svc.CreateFolder = contextTestFolderCreator(db)
+	topFile := filepath.Join(t.TempDir(), "manual.pyc")
+	mkfile(t, topFile, "chosen explicitly")
+
+	filePlan := svc.PlanImport([]string{topFile}, false, false)
+	if filePlan.Files != 1 || filePlan.Ignored != 0 {
+		t.Fatalf("explicit file plan = %+v, want one importable file", filePlan)
+	}
+
+	topFolder := filepath.Join(t.TempDir(), "__pycache__")
+	mkfile(t, filepath.Join(topFolder, "keep.txt"), "chosen explicitly")
+	mkfile(t, filepath.Join(topFolder, ".git", "ignored.txt"), "ignored descendant")
+	folderPlan := svc.PlanImport([]string{topFolder}, false, false)
+	if folderPlan.Files != 1 || folderPlan.Folders != 1 || folderPlan.Ignored != 1 {
+		t.Fatalf("explicit folder plan = %+v, want root and keep.txt only", folderPlan)
+	}
+
+	if err := svc.RunImport(context.Background(), personalChannelID, []string{topFile, topFolder}, "", false, false); err != nil {
+		t.Fatalf("RunImport explicit selections: %v", err)
+	}
+	if got := len(fakeTG.SentFiles()); got != 2 {
+		t.Fatalf("explicitly selected files sent = %d, want 2", got)
+	}
+}
+
+func TestPlanImportReportsRemoteObjectLimit(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	root := filepath.Join(t.TempDir(), "LargeProject")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The selected root itself is one remote folder, so maxImportItems files put
+	// the plan exactly one object beyond the safe admission limit.
+	for i := 0; i < expectedMaxImportItems; i++ {
+		name := filepath.Join(root, fmt.Sprintf("file-%05d.txt", i))
+		if err := os.WriteFile(name, nil, 0o644); err != nil {
+			t.Fatalf("create item %d: %v", i, err)
+		}
+	}
+
+	plan := svc.PlanImport([]string{root}, false, false)
+	if plan.MaxItems != expectedMaxImportItems {
+		t.Fatalf("plan.MaxItems = %d, want %d", plan.MaxItems, expectedMaxImportItems)
+	}
+	if !plan.LimitExceeded {
+		t.Fatalf("plan.LimitExceeded = false for %d remote objects", plan.Files+plan.Folders)
+	}
+	if got := plan.Files + plan.Folders; got <= plan.MaxItems {
+		t.Fatalf("planned remote objects = %d, want more than limit %d", got, plan.MaxItems)
+	}
+
+	createCalled := false
+	svc.CreateFolder = func(context.Context, int64, string, string) (string, error) {
+		createCalled = true
+		return "", errors.New("unexpected remote mutation")
+	}
+	if err := svc.RunImport(context.Background(), personalChannelID, []string{root}, "", false, false); err == nil {
+		t.Fatal("RunImport accepted a selection over the remote-object limit")
+	}
+	if createCalled {
+		t.Fatal("RunImport created a remote folder before enforcing the item limit")
+	}
+}
+
+func TestArchiveImportScanBoundsIgnoredMetadataToo(t *testing.T) {
+	archive := buildZip(t, map[string]string{
+		"node_modules/a.js": "a",
+		"node_modules/b.js": "b",
+		"node_modules/c.js": "c",
+		"node_modules/d.js": "d",
+	}, nil, nil)
+
+	entries, _, err := scanArchiveForImportLimit(context.Background(), archive, 3)
+	if !errors.Is(err, errArchiveScanLimit) {
+		t.Fatalf("scan error = %v, want archive metadata limit", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("retained ignored entries = %d, want 0", len(entries))
+	}
+}

--- a/backend/services/file/import_test.go
+++ b/backend/services/file/import_test.go
@@ -19,7 +19,10 @@ import (
 // NextFreeFolderName sees created folders) and hands back a unique id.
 func testFolderCreator(db *sql.DB) CreateFolderFunc {
 	var n, msgID int64 = 0, 50000
-	return func(channelID int64, name, parentID string) (string, error) {
+	return func(ctx context.Context, channelID int64, name, parentID string) (string, error) {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		n++
 		id := fmt.Sprintf("%simp%d", projection.FolderIDPrefix, n)
 		op := projection.Op{Type: projection.OpMkdir, Obj: id, Parent: parentID, Name: name}
@@ -272,7 +275,7 @@ func TestRunImportNameCollisionSuffixes(t *testing.T) {
 	svc.CreateFolder = create
 
 	// A folder named "Photos" already exists at the root.
-	if _, err := create(personalChannelID, "Photos", ""); err != nil {
+	if _, err := create(context.Background(), personalChannelID, "Photos", ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/backend/services/file/import_test.go
+++ b/backend/services/file/import_test.go
@@ -155,6 +155,32 @@ func TestPlanImportFlagsOversize(t *testing.T) {
 	}
 }
 
+func TestPlanArchiveDoesNotReserveDirectoriesForOversizeMembers(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	svc.MaxUploadBytes = 1
+	archivePath := buildZip(t, map[string]string{
+		"nested/huge.bin": strings.Repeat("x", MaxParts+1),
+	}, nil, nil)
+	plan := ImportPlan{
+		MaxBytes: svc.largeFileMaxBytes(),
+		MaxItems: 1, // only the archive-named folder should be admitted
+	}
+
+	err := svc.planArchive(context.Background(), archivePath, false, &plan)
+	if err != nil {
+		t.Fatalf("planArchive: %v", err)
+	}
+	if plan.LimitExceeded {
+		t.Fatal("oversized member directories falsely exceeded the item limit")
+	}
+	if plan.Files != 0 || plan.Oversize != 1 {
+		t.Fatalf("plan files/oversize = %d/%d, want 0/1", plan.Files, plan.Oversize)
+	}
+	if plan.Folders != 1 {
+		t.Fatalf("plan folders = %d, want only the archive-named folder", plan.Folders)
+	}
+}
+
 func TestPlanImportCorruptArchiveDoesNotCountExtractFolder(t *testing.T) {
 	svc, _, _, _ := newTestService(t)
 	p := filepath.Join(t.TempDir(), "bad.zip")

--- a/backend/services/file/import_walk.go
+++ b/backend/services/file/import_walk.go
@@ -1,0 +1,104 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const importWalkReadBatchSize = 256
+
+type importWalkFrame struct {
+	dir      *os.File
+	fullPath string
+	relPath  string
+	entries  []os.DirEntry
+	next     int
+	readErr  error
+}
+
+// walkImportDescendants performs a depth-first walk without WalkDir's
+// read-and-sort-entire-directory behavior. At most one small ReadDir window is
+// retained per active directory, which keeps very wide project folders from
+// causing a memory spike before the import limit can stop the scan.
+func walkImportDescendants(
+	ctx context.Context,
+	root string,
+	visit func(fullPath, relPath string, entry os.DirEntry) (skipDir bool, err error),
+	onReadError func(path string, err error) error,
+) (err error) {
+	if ctx == nil {
+		return errors.New("import walk requires a context")
+	}
+	rootDir, err := os.Open(root)
+	if err != nil {
+		return err
+	}
+	stack := []*importWalkFrame{{dir: rootDir, fullPath: root}}
+	defer func() {
+		for _, frame := range stack {
+			_ = frame.dir.Close()
+		}
+	}()
+
+	for len(stack) > 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		frame := stack[len(stack)-1]
+
+		if frame.next >= len(frame.entries) {
+			if frame.readErr != nil {
+				readErr := frame.readErr
+				_ = frame.dir.Close()
+				stack = stack[:len(stack)-1]
+				if !errors.Is(readErr, io.EOF) && onReadError != nil {
+					if err := onReadError(frame.fullPath, readErr); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			frame.entries, frame.readErr = frame.dir.ReadDir(importWalkReadBatchSize)
+			frame.next = 0
+			if len(frame.entries) == 0 {
+				continue
+			}
+		}
+
+		entry := frame.entries[frame.next]
+		frame.next++
+		fullPath := filepath.Join(frame.fullPath, entry.Name())
+		relPath := entry.Name()
+		if frame.relPath != "" {
+			relPath = filepath.Join(frame.relPath, entry.Name())
+		}
+
+		skipDir, err := visit(fullPath, filepath.ToSlash(relPath), entry)
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() || skipDir {
+			continue
+		}
+
+		child, err := os.Open(fullPath)
+		if err != nil {
+			if onReadError != nil {
+				if err := onReadError(fullPath, err); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		stack = append(stack, &importWalkFrame{
+			dir:      child,
+			fullPath: fullPath,
+			relPath:  relPath,
+		})
+	}
+	return nil
+}

--- a/backend/services/file/service.go
+++ b/backend/services/file/service.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -48,7 +49,7 @@ type WarnFunc func(format string, args ...any)
 // CreateFolderFunc creates a folder and returns its new ID. It is injected so
 // import can build folder trees without the file service depending on the
 // folder service directly.
-type CreateFolderFunc func(channelID int64, name, parentID string) (folderID string, err error)
+type CreateFolderFunc func(ctx context.Context, channelID int64, name, parentID string) (folderID string, err error)
 
 type EventSink interface {
 	Emit(name string, args ...any)
@@ -140,6 +141,7 @@ var (
 	// treating an unknown outcome as a retryable transport failure when a
 	// legacy client cannot preserve Telegram's random_id across attempts.
 	errVisibleSendOutcomeUnknownNoRetry  = errors.New("visible upload outcome unknown without idempotency")
+	errUploadProjection                  = errors.New("visible upload projection failed")
 	errPreviewNotFound                   = errors.New("File not found")
 	errPreviewNotSupported               = errors.New("Not a supported image")
 	errPreviewTooLarge                   = errors.New("File too large")
@@ -159,9 +161,31 @@ var previewMimeTypes = map[string]string{
 }
 
 func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []string, parentIDs []string, encrypt bool) ([]Metadata, error) {
+	return s.upload(ctx, channelID, filePaths, parentIDs, encrypt, uploadOptions{
+		observer: detailedUploadObserver{service: s},
+	})
+}
+
+type uploadOptions struct {
+	observer uploadObserver
+	peer     *tgclient.InputPeer
+	idOffset int
+}
+
+type uploadedResult struct {
+	UploadID  int
+	Meta      Metadata
+	RawHeader string
+	Op        projection.Op
+}
+
+func (s *Service) upload(ctx context.Context, channelID int64, filePaths []string, parentIDs []string, encrypt bool, options uploadOptions) ([]Metadata, error) {
 	slog.Debug("file: upload batch starting", "channel_id", channelID, "files", len(filePaths), "encrypt", encrypt)
 	if len(filePaths) != len(parentIDs) {
 		return nil, fmt.Errorf("filepaths and parentIDs length mismatch")
+	}
+	if len(filePaths) > maxImportItems {
+		return nil, fmt.Errorf("%w: keep the batch under %d files", errImportItemLimit, maxImportItems)
 	}
 	if err := s.ready(); err != nil {
 		return nil, err
@@ -178,16 +202,21 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 	if s.ActorID == nil {
 		return nil, fmt.Errorf("actor resolver not ready")
 	}
+	observer := options.observer
+	if observer == nil {
+		observer = detailedUploadObserver{service: s}
+	}
 	actorID, err := s.ActorID(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	type uploadedResult struct {
-		UploadID  int
-		Meta      Metadata
-		RawHeader string
-		Op        projection.Op
+	peer := options.peer
+	if peer == nil {
+		resolved, err := s.Peers.ResolvePeer(ctx, channelID)
+		if err != nil {
+			return nil, err
+		}
+		peer = &resolved
 	}
 
 	var wg sync.WaitGroup
@@ -200,7 +229,7 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 	for i := 0; i < len(filePaths); i++ {
 		path := filePaths[i]
 		pid := parentIDs[i]
-		uploadID := i
+		uploadID := options.idOffset + i
 		release, slotErr := s.acquireUploadSlot(ctx)
 		if slotErr != nil {
 			mu.Lock()
@@ -209,7 +238,7 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 				firstErr = slotErr
 			}
 			mu.Unlock()
-			s.emitEvent("upload_error", uploadID, filepath.Base(path), slotErr.Error())
+			observer.Failed(uploadID, filepath.Base(path), slotErr)
 			continue
 		}
 		wg.Add(1)
@@ -225,11 +254,11 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 						firstErr = fmt.Errorf("upload panic: %v", r)
 					}
 					mu.Unlock()
-					s.emitEvent("upload_error", uploadID, filepath.Base(path), fmt.Sprintf("upload panic: %v", r))
+					observer.Failed(uploadID, filepath.Base(path), fmt.Errorf("upload panic: %v", r))
 				}
 			}()
 
-			meta, op, header, err := s.uploadSingle(ctx, uploadID, path, pid, channelID, encrypt)
+			meta, op, header, err := s.uploadSingleWithObserver(ctx, uploadID, path, pid, channelID, encrypt, *peer, observer)
 			if err != nil {
 				if meta.MsgID != 0 {
 					mu.Lock()
@@ -250,7 +279,7 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 				}
 				mu.Unlock()
 				s.warnf("warn: upload failed for %q: %v\n", filepath.Base(path), err)
-				s.emitEvent("upload_error", uploadID, filepath.Base(path), err.Error())
+				observer.Failed(uploadID, filepath.Base(path), err)
 				return
 			}
 
@@ -266,40 +295,17 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 	}
 
 	wg.Wait()
+	sort.Slice(uploaded, func(i, j int) bool {
+		return uploaded[i].Meta.MsgID < uploaded[j].Meta.MsgID
+	})
 
 	uploadedFiles := make([]Metadata, 0, len(uploaded))
 	for _, item := range uploaded {
 		uploadedFiles = append(uploadedFiles, item.Meta)
 	}
 
-	emitLocalIndexError := func(reason string) {
-		for _, item := range uploaded {
-			s.emitEvent("upload_error", item.UploadID, item.Meta.Name, reason)
-		}
-	}
-
-	for _, item := range uploaded {
-		// Multipart uploads project their own parts + manifest inside
-		// uploadMultipart and return an empty op, so there's nothing to project
-		// here for them.
-		if item.Op.Type == "" {
-			continue
-		}
-		if _, err := projection.ProjectFromOp(
-			s.DB,
-			channelID,
-			int64(item.Meta.MsgID),
-			item.Op,
-			actorID,
-			item.RawHeader,
-		); err != nil {
-			emitLocalIndexError("local index write failed")
-			return uploadedFiles, err
-		}
-	}
-
-	for _, item := range uploaded {
-		s.emitEvent("upload_complete", item.UploadID, item.Meta.Name)
+	if err := s.projectUploaded(channelID, actorID, uploaded, observer); err != nil {
+		return uploadedFiles, err
 	}
 
 	if failed > 0 {
@@ -313,13 +319,75 @@ func (s *Service) Upload(ctx context.Context, channelID int64, filePaths []strin
 	return uploadedFiles, nil
 }
 
+const uploadProjectionBatchSize = 128
+
+func (s *Service) projectUploaded(channelID, actorID int64, uploaded []uploadedResult, observer uploadObserver) error {
+	pending := make([]uploadedResult, 0, len(uploaded))
+	for _, item := range uploaded {
+		// Multipart uploads project their parts and manifest before returning.
+		if item.Op.Type == "" {
+			observer.Completed(item.UploadID, item.Meta.Name)
+			continue
+		}
+		pending = append(pending, item)
+	}
+
+	for start := 0; start < len(pending); start += uploadProjectionBatchSize {
+		end := min(start+uploadProjectionBatchSize, len(pending))
+		// Telegram has already accepted these messages. Finish the local receipt
+		// projection even if the caller canceled meanwhile; otherwise the files
+		// disappear until the next history sync repairs the cache.
+		tx, err := s.DB.Begin()
+		if err == nil {
+			for _, item := range pending[start:end] {
+				_, err = projection.ProjectFromOpTx(tx, channelID, int64(item.Meta.MsgID), item.Op, actorID, item.RawHeader)
+				if err != nil {
+					break
+				}
+			}
+		}
+		if err == nil {
+			err = tx.Commit()
+		} else if tx != nil {
+			_ = tx.Rollback()
+		}
+		if err != nil {
+			wrapped := fmt.Errorf("local index write failed: %w", err)
+			for _, item := range pending[start:] {
+				observer.Failed(item.UploadID, item.Meta.Name, wrapped)
+			}
+			return fmt.Errorf("%w: %v", errUploadProjection, err)
+		}
+		for _, item := range pending[start:end] {
+			observer.Completed(item.UploadID, item.Meta.Name)
+		}
+	}
+	return nil
+}
+
 func (s *Service) uploadSingle(ctx context.Context, uploadID int, filePath string, parentID string, channelID int64, wantEncrypted bool) (Metadata, projection.Op, string, error) {
+	peer, err := s.Peers.ResolvePeer(ctx, channelID)
+	if err != nil {
+		return Metadata{}, projection.Op{}, "", err
+	}
+	return s.uploadSingleWithObserver(
+		ctx,
+		uploadID,
+		filePath,
+		parentID,
+		channelID,
+		wantEncrypted,
+		peer,
+		detailedUploadObserver{service: s},
+	)
+}
+
+func (s *Service) uploadSingleWithObserver(ctx context.Context, uploadID int, filePath string, parentID string, channelID int64, wantEncrypted bool, peer tgclient.InputPeer, observer uploadObserver) (Metadata, projection.Op, string, error) {
 	if channelID == 0 {
 		return Metadata{}, projection.Op{}, "", fmt.Errorf("drive channel id not found")
 	}
 
 	filename := filepath.Base(filePath)
-	s.emitEvent("upload_start", uploadID, filename, int64(0), parentID)
 
 	plainFile, err := os.Open(filePath)
 	if err != nil {
@@ -333,8 +401,12 @@ func (s *Service) uploadSingle(ctx context.Context, uploadID int, filePath strin
 		return Metadata{}, projection.Op{}, "", err
 	}
 	plaintextSize := info.Size()
+	// Announce the operation once the local source is known, before validating
+	// remote metadata. That keeps failed uploads visible to callers while
+	// avoiding the duplicate start event that used to be emitted at two layers.
+	observer.Started(uploadID, filename, uploadByteSize(plaintextSize, wantEncrypted), parentID)
 	slog.Debug("file: uploading", "channel_id", channelID, "name", filename, "size", plaintextSize, "encrypt", wantEncrypted, "parent_id", parentID)
-	meta, op, header, err := s.uploadVisibleSource(ctx, uploadID, plainFile, filename, plaintextSize, parentID, channelID, wantEncrypted)
+	meta, op, header, err := s.uploadVisibleSource(ctx, uploadID, plainFile, filename, plaintextSize, parentID, channelID, wantEncrypted, peer, observer)
 	if err != nil {
 		slog.Error("file: upload failed", "channel_id", channelID, "name", filename, "size", plaintextSize, "error", err)
 	} else {
@@ -346,7 +418,7 @@ func (s *Service) uploadSingle(ctx context.Context, uploadID int, filePath strin
 // uploadVisibleSource is the compatibility path used by the existing GUI/CLI
 // uploader. Keeping the source boundary seekable lets staged-file callers use
 // the same single/multipart planning without coupling the core to local paths.
-func (s *Service) uploadVisibleSource(ctx context.Context, uploadID int, source io.ReadSeeker, filename string, plaintextSize int64, parentID string, channelID int64, wantEncrypted bool) (Metadata, projection.Op, string, error) {
+func (s *Service) uploadVisibleSource(ctx context.Context, uploadID int, source io.ReadSeeker, filename string, plaintextSize int64, parentID string, channelID int64, wantEncrypted bool, peer tgclient.InputPeer, observer uploadObserver) (Metadata, projection.Op, string, error) {
 	if err := validateSeekableSize(source, plaintextSize); err != nil {
 		return Metadata{}, projection.Op{}, "", err
 	}
@@ -369,17 +441,12 @@ func (s *Service) uploadVisibleSource(ctx context.Context, uploadID int, source 
 		return Metadata{}, projection.Op{}, "", err
 	}
 
-	peer, err := s.Peers.ResolvePeer(ctx, channelID)
-	if err != nil {
-		return Metadata{}, projection.Op{}, "", err
-	}
-
 	if multipart {
 		// uploadMultipart sends the parts, projects them, and emits the manifest
 		// (the commit point) itself. Success returns an empty op; if Telegram
 		// commits but the local manifest projection fails, it returns that exact
 		// op/header so Upload can retry the local-only step.
-		return s.uploadMultipart(ctx, uploadID, source, filename, plaintextSize, parent, channelID, wantEncrypted, masterKey, peer, storedSize)
+		return s.uploadMultipart(ctx, uploadID, source, filename, plaintextSize, parent, channelID, wantEncrypted, masterKey, peer, storedSize, observer)
 	}
 
 	encrypted := wantEncrypted
@@ -419,7 +486,6 @@ func (s *Service) uploadVisibleSource(ctx context.Context, uploadID int, source 
 	caption := header + "\nTDrive: " + filename
 
 	s.warnf("Starting upload: %s\n", filename)
-	s.emitEvent("upload_start", uploadID, filename, uploadSize, parent)
 
 	var (
 		lastProgress = time.Now()
@@ -438,7 +504,7 @@ func (s *Service) uploadVisibleSource(ctx context.Context, uploadID int, source 
 				percent = 100
 			}
 		}
-		s.emitEvent("upload_progress", uploadID, percent)
+		observer.Progress(uploadID, percent)
 		lastProgress = time.Now()
 	}
 	var result tgclient.SendFileResult
@@ -474,7 +540,7 @@ func (s *Service) uploadVisibleSource(ctx context.Context, uploadID int, source 
 		return Metadata{}, projection.Op{}, "", fmt.Errorf("upload success, but could not find msgID")
 	}
 
-	s.emitEvent("upload_progress", uploadID, 100.0)
+	observer.Progress(uploadID, 100.0)
 	return Metadata{
 		Name:          filename,
 		Size:          uploadSize,
@@ -533,7 +599,7 @@ func (plan uploadPartPlan) window(storedSize int64, partIndex int) (offset int64
 // projected before an idempotent manifest commits the logical file. Encrypted
 // data is staged one part at a time, which makes retries rewind-safe without
 // materializing a complete multi-gigabyte ciphertext file.
-func (s *Service) uploadMultipart(ctx context.Context, uploadID int, plainFile io.ReadSeeker, filename string, plaintextSize int64, parent string, channelID int64, encrypt bool, masterKey []byte, peer tgclient.InputPeer, storedSize int64) (Metadata, projection.Op, string, error) {
+func (s *Service) uploadMultipart(ctx context.Context, uploadID int, plainFile io.ReadSeeker, filename string, plaintextSize int64, parent string, channelID int64, encrypt bool, masterKey []byte, peer tgclient.InputPeer, storedSize int64, observer uploadObserver) (Metadata, projection.Op, string, error) {
 	if s.ActorID == nil {
 		return Metadata{}, projection.Op{}, "", fmt.Errorf("actor resolver not ready")
 	}
@@ -553,7 +619,6 @@ func (s *Service) uploadMultipart(ctx context.Context, uploadID int, plainFile i
 
 	uploadUUID := projection.NewUploadUUID()
 	s.warnf("Starting multipart upload: %s (%d parts)\n", filename, numParts)
-	s.emitEvent("upload_start", uploadID, filename, storedSize, parent)
 
 	var encryptedStream io.Reader
 	var finishEncryption func() error
@@ -653,7 +718,7 @@ func (s *Service) uploadMultipart(ctx context.Context, uploadID int, plainFile i
 					percent = 100
 				}
 			}
-			s.emitEvent("upload_progress", uploadID, percent)
+			observer.Progress(uploadID, percent)
 			lastProgress = time.Now()
 		}
 		var result tgclient.SendFileResult
@@ -763,7 +828,7 @@ func (s *Service) uploadMultipart(ctx context.Context, uploadID int, plainFile i
 		return Metadata{}, projection.Op{}, "", err
 	}
 
-	s.emitEvent("upload_progress", uploadID, 100.0)
+	observer.Progress(uploadID, 100.0)
 	return committedMeta(manifestMsgID), projection.Op{}, "", nil
 }
 

--- a/backend/services/file/service.go
+++ b/backend/services/file/service.go
@@ -356,7 +356,7 @@ func (s *Service) projectUploaded(channelID, actorID int64, uploaded []uploadedR
 			for _, item := range pending[start:] {
 				observer.Failed(item.UploadID, item.Meta.Name, wrapped)
 			}
-			return fmt.Errorf("%w: %v", errUploadProjection, err)
+			return fmt.Errorf("%w: %w", errUploadProjection, err)
 		}
 		for _, item := range pending[start:end] {
 			observer.Completed(item.UploadID, item.Meta.Name)

--- a/backend/services/file/service_test.go
+++ b/backend/services/file/service_test.go
@@ -36,6 +36,25 @@ func (r testPeerResolver) ResolvePeer(ctx context.Context, channelID int64) (tgc
 	return r.peer, nil
 }
 
+type countingTestPeerResolver struct {
+	mu    sync.Mutex
+	peer  tgclient.InputPeer
+	calls int
+}
+
+func (r *countingTestPeerResolver) ResolvePeer(context.Context, int64) (tgclient.InputPeer, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	return r.peer, nil
+}
+
+func (r *countingTestPeerResolver) Calls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
 type eventRecorder struct {
 	mu     sync.Mutex
 	events []string
@@ -56,6 +75,18 @@ func (r *eventRecorder) Has(name string) bool {
 		}
 	}
 	return false
+}
+
+func (r *eventRecorder) Count(name string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, event := range r.events {
+		if event == name {
+			count++
+		}
+	}
+	return count
 }
 
 func newTestService(t *testing.T) (*Service, *sql.DB, *tgclient.Fake, *int64) {
@@ -357,6 +388,61 @@ func TestUploadRejectsMissingParentBeforeSend(t *testing.T) {
 	}
 	if !events.Has("upload_start") || !events.Has("upload_error") {
 		t.Fatalf("events = %+v, want visible failed upload lifecycle", events.events)
+	}
+}
+
+func TestUploadResolvesPeerOnceForTheWholeBatch(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	resolver := &countingTestPeerResolver{peer: tgclient.InputPeer{ChannelID: personalChannelID, AccessHash: 99}}
+	svc.Peers = resolver
+	paths := []string{
+		writeTempNamedFile(t, "one.txt", []byte("one")),
+		writeTempNamedFile(t, "two.txt", []byte("two")),
+		writeTempNamedFile(t, "three.txt", []byte("three")),
+	}
+
+	if _, err := svc.Upload(context.Background(), personalChannelID, paths, []string{"", "", ""}, false); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if got := resolver.Calls(); got != 1 {
+		t.Fatalf("peer resolutions = %d, want 1 for the batch", got)
+	}
+}
+
+func TestUploadEmitsExactlyOneStartForMultipartFiles(t *testing.T) {
+	svc, _, _, _ := newTestService(t)
+	svc.MaxUploadBytes = 3
+	events := &eventRecorder{}
+	svc.Events = events
+	path := writeTempNamedFile(t, "multipart.txt", []byte("four"))
+
+	if _, err := svc.Upload(context.Background(), personalChannelID, []string{path}, []string{""}, false); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if got := events.Count("upload_start"); got != 1 {
+		t.Fatalf("upload_start events = %d, want exactly 1", got)
+	}
+}
+
+func TestUploadRejectsAnUnboundedDirectBatchBeforeWorkStarts(t *testing.T) {
+	svc, _, fakeTG, _ := newTestService(t)
+	actorCalled := false
+	svc.ActorID = func(context.Context) (int64, error) {
+		actorCalled = true
+		return 0, errors.New("unexpected actor lookup")
+	}
+	paths := make([]string, maxImportItems+1)
+	parents := make([]string, len(paths))
+
+	_, err := svc.Upload(context.Background(), personalChannelID, paths, parents, false)
+	if !errors.Is(err, errImportItemLimit) {
+		t.Fatalf("Upload error = %v, want import item limit", err)
+	}
+	if actorCalled {
+		t.Fatal("oversized direct batch reached actor lookup")
+	}
+	if sent := fakeTG.SentFiles(); len(sent) != 0 {
+		t.Fatalf("oversized direct batch sent %d files", len(sent))
 	}
 }
 

--- a/backend/services/file/upload_events.go
+++ b/backend/services/file/upload_events.go
@@ -1,0 +1,154 @@
+package file
+
+import (
+	"math"
+	"sync"
+)
+
+type uploadObserver interface {
+	Started(id int, name string, size int64, parentID string)
+	Progress(id int, percent float64)
+	Completed(id int, name string)
+	Failed(id int, name string, err error)
+}
+
+type detailedUploadObserver struct {
+	service *Service
+}
+
+func (o detailedUploadObserver) Started(id int, name string, size int64, parentID string) {
+	o.service.emitEvent("upload_start", id, name, size, parentID)
+}
+
+func (o detailedUploadObserver) Progress(id int, percent float64) {
+	o.service.emitEvent("upload_progress", id, percent)
+}
+
+func (o detailedUploadObserver) Completed(id int, name string) {
+	o.service.emitEvent("upload_complete", id, name)
+}
+
+func (o detailedUploadObserver) Failed(id int, name string, err error) {
+	o.service.emitEvent("upload_error", id, name, err.Error())
+}
+
+const maxImportUploadFailureReasons = 3
+
+// importUploadObserver folds a window's concurrent file updates into at most
+// one event per whole percentage point. Its active map is bounded by the import
+// upload window, so neither backend nor frontend state grows with the import.
+type importUploadObserver struct {
+	service *Service
+	total   int
+
+	mu             sync.Mutex
+	active         map[int]float64
+	activeProgress float64
+	done           int
+	failed         int
+	lastPercent    int
+	failureReasons []string
+}
+
+func newImportUploadObserver(service *Service, total int) *importUploadObserver {
+	return &importUploadObserver{
+		service:     service,
+		total:       max(total, 0),
+		active:      make(map[int]float64, importUploadBatchSize),
+		lastPercent: -1,
+	}
+}
+
+func (o *importUploadObserver) Started(int, string, int64, string) {}
+
+func (o *importUploadObserver) Progress(id int, percent float64) {
+	fraction := math.Max(0, math.Min(1, percent/100))
+	o.mu.Lock()
+	previous := o.active[id]
+	if fraction > previous {
+		o.active[id] = fraction
+		o.activeProgress += fraction - previous
+	}
+	// A file is not complete until its Telegram receipt is projected. Deferring
+	// its final 100% update lets the aggregate counter and percentage advance in
+	// the same bounded event.
+	payload, emit := o.progressPayloadLocked(false, fraction < 1)
+	o.mu.Unlock()
+	if emit {
+		o.service.emitEvent("import_upload_progress", payload)
+	}
+}
+
+func (o *importUploadObserver) Completed(id int, _ string) {
+	o.mu.Lock()
+	o.removeActiveLocked(id)
+	o.done++
+	payload, emit := o.progressPayloadLocked(false, true)
+	o.mu.Unlock()
+	if emit {
+		o.service.emitEvent("import_upload_progress", payload)
+	}
+}
+
+func (o *importUploadObserver) Failed(id int, name string, err error) {
+	o.mu.Lock()
+	o.removeActiveLocked(id)
+	o.failed++
+	if len(o.failureReasons) < maxImportUploadFailureReasons {
+		if name == "" {
+			o.failureReasons = append(o.failureReasons, err.Error())
+		} else {
+			o.failureReasons = append(o.failureReasons, name+": "+err.Error())
+		}
+	}
+	payload, emit := o.progressPayloadLocked(false, true)
+	o.mu.Unlock()
+	if emit {
+		o.service.emitEvent("import_upload_progress", payload)
+	}
+}
+
+func (o *importUploadObserver) EmitInitial() {
+	o.mu.Lock()
+	payload, emit := o.progressPayloadLocked(true, true)
+	o.mu.Unlock()
+	if emit {
+		o.service.emitEvent("import_upload_progress", payload)
+	}
+}
+
+func (o *importUploadObserver) Summary() (done, failed int, failureReasons []string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.done, o.failed, append([]string(nil), o.failureReasons...)
+}
+
+func (o *importUploadObserver) removeActiveLocked(id int) {
+	if fraction, ok := o.active[id]; ok {
+		o.activeProgress -= fraction
+		delete(o.active, id)
+	}
+}
+
+func (o *importUploadObserver) progressPayloadLocked(force, allowEmit bool) (map[string]any, bool) {
+	progress := 100.0
+	if o.total > 0 {
+		progress = (float64(o.done+o.failed) + o.activeProgress) / float64(o.total) * 100
+		progress = math.Max(0, math.Min(100, progress))
+	}
+	wholePercent := int(math.Floor(progress))
+	if wholePercent < o.lastPercent {
+		wholePercent = o.lastPercent
+		progress = float64(wholePercent)
+	}
+	if !force && (!allowEmit || wholePercent <= o.lastPercent) {
+		return nil, false
+	}
+	o.lastPercent = wholePercent
+	return map[string]any{
+		"total":    o.total,
+		"done":     o.done,
+		"failed":   o.failed,
+		"progress": progress,
+	}, true
+}

--- a/backend/tgclient/gotd.go
+++ b/backend/tgclient/gotd.go
@@ -26,6 +26,7 @@ import (
 type Gotd struct {
 	connect func() (*telegram.Client, error)
 	conn    *liveConn
+	writes  *writeCoordinator
 
 	mu     sync.Mutex
 	client *telegram.Client
@@ -40,6 +41,7 @@ func NewGotd(connect func() (*telegram.Client, error)) *Gotd {
 	g := &Gotd{
 		connect: connect,
 		cdn:     make(map[int]telegram.CloseInvoker),
+		writes:  newWriteCoordinator(time.Now, sleepContext),
 	}
 	g.conn = newLiveConn(g.scope)
 	return g
@@ -239,20 +241,22 @@ func (g *Gotd) SendControlWithRandomID(ctx context.Context, peer InputPeer, text
 		return 0, fmt.Errorf("tgclient: random id must be positive")
 	}
 	var msgID int64
-	err := g.run(ctx, func(ctx context.Context, api *tg.Client) error {
-		req := &tg.MessagesSendMessageRequest{
-			Peer:      toPeer(peer),
-			Message:   text,
-			RandomID:  sendRandomID,
-			Silent:    silent,
-			NoWebpage: true,
-		}
-		updates, err := api.MessagesSendMessage(ctx, req)
-		if err != nil {
-			return fmt.Errorf("%w: send message: %w", ErrSendOutcomeUnknown, err)
-		}
-		msgID, err = requiredSendMsgID(updates, sendRandomID, "send control")
-		return err
+	err := g.writes.Do(ctx, writeClassMessage, func() error {
+		return g.run(ctx, func(ctx context.Context, api *tg.Client) error {
+			req := &tg.MessagesSendMessageRequest{
+				Peer:      toPeer(peer),
+				Message:   text,
+				RandomID:  sendRandomID,
+				Silent:    silent,
+				NoWebpage: true,
+			}
+			updates, err := api.MessagesSendMessage(ctx, req)
+			if err != nil {
+				return fmt.Errorf("%w: send message: %w", ErrSendOutcomeUnknown, err)
+			}
+			msgID, err = requiredSendMsgID(updates, sendRandomID, "send control")
+			return err
+		})
 	})
 	return msgID, err
 }
@@ -272,8 +276,10 @@ func (g *Gotd) SendFileWithRandomID(ctx context.Context, peer InputPeer, r io.Re
 	partClient := &retryingUploadClient{
 		policy: DefaultWriteFloodWaitRetryPolicy(),
 		run: func(ctx context.Context, action func(uploader.Client) error) error {
-			return g.run(ctx, func(ctx context.Context, api *tg.Client) error {
-				return action(api)
+			return g.writes.Do(ctx, writeClassUploadPart, func() error {
+				return g.run(ctx, func(ctx context.Context, api *tg.Client) error {
+					return action(api)
+				})
 			})
 		},
 	}
@@ -298,29 +304,31 @@ func (g *Gotd) SendFileWithRandomID(ctx context.Context, peer InputPeer, r io.Re
 	}
 
 	var result SendFileResult
-	err = g.run(ctx, func(ctx context.Context, api *tg.Client) error {
-		req := &tg.MessagesSendMediaRequest{
-			Peer: toPeer(peer),
-			Media: &tg.InputMediaUploadedDocument{
-				File:      uploadResult,
-				MimeType:  "application/octet-stream",
-				ForceFile: true,
-				Attributes: []tg.DocumentAttributeClass{
-					&tg.DocumentAttributeFilename{FileName: name},
+	err = g.writes.Do(ctx, writeClassMessage, func() error {
+		return g.run(ctx, func(ctx context.Context, api *tg.Client) error {
+			req := &tg.MessagesSendMediaRequest{
+				Peer: toPeer(peer),
+				Media: &tg.InputMediaUploadedDocument{
+					File:      uploadResult,
+					MimeType:  "application/octet-stream",
+					ForceFile: true,
+					Attributes: []tg.DocumentAttributeClass{
+						&tg.DocumentAttributeFilename{FileName: name},
+					},
 				},
-			},
-			RandomID: sendRandomID,
-			Message:  caption,
-		}
-		updates, err := api.MessagesSendMedia(ctx, req)
-		if err != nil {
-			// Uploading the document precedes MessagesSendMedia. A transport error
-			// at this boundary can arrive after Telegram accepted the random_id,
-			// so callers must reconcile with the same id before cleanup.
-			return fmt.Errorf("%w: send media: %w", ErrSendOutcomeUnknown, err)
-		}
-		result.MsgID, err = requiredSendMsgID(updates, sendRandomID, "send file")
-		return err
+				RandomID: sendRandomID,
+				Message:  caption,
+			}
+			updates, err := api.MessagesSendMedia(ctx, req)
+			if err != nil {
+				// Uploading the document precedes MessagesSendMedia. A transport error
+				// at this boundary can arrive after Telegram accepted the random_id,
+				// so callers must reconcile with the same id before cleanup.
+				return fmt.Errorf("%w: send media: %w", ErrSendOutcomeUnknown, err)
+			}
+			result.MsgID, err = requiredSendMsgID(updates, sendRandomID, "send file")
+			return err
+		})
 	})
 	return result, err
 }
@@ -532,16 +540,18 @@ func (g *Gotd) DeleteMessages(ctx context.Context, peer InputPeer, msgIDs []int6
 		return nil
 	}
 	slog.Debug("tgclient: ChannelsDeleteMessages", "channel_id", peer.ChannelID, "count", len(msgIDs))
-	err := g.run(ctx, func(ctx context.Context, api *tg.Client) error {
-		ids := make([]int, 0, len(msgIDs))
-		for _, id := range msgIDs {
-			ids = append(ids, int(id))
-		}
-		_, err := api.ChannelsDeleteMessages(ctx, &tg.ChannelsDeleteMessagesRequest{
-			Channel: &tg.InputChannel{ChannelID: peer.ChannelID, AccessHash: peer.AccessHash},
-			ID:      ids,
+	err := g.writes.Do(ctx, writeClassMessage, func() error {
+		return g.run(ctx, func(ctx context.Context, api *tg.Client) error {
+			ids := make([]int, 0, len(msgIDs))
+			for _, id := range msgIDs {
+				ids = append(ids, int(id))
+			}
+			_, err := api.ChannelsDeleteMessages(ctx, &tg.ChannelsDeleteMessagesRequest{
+				Channel: &tg.InputChannel{ChannelID: peer.ChannelID, AccessHash: peer.AccessHash},
+				ID:      ids,
+			})
+			return err
 		})
-		return err
 	})
 	if err != nil {
 		slog.Error("tgclient: ChannelsDeleteMessages failed", "channel_id", peer.ChannelID, "count", len(msgIDs), "error", err)

--- a/backend/tgclient/write_coordinator.go
+++ b/backend/tgclient/write_coordinator.go
@@ -1,0 +1,113 @@
+package tgclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// writeClass separates logical message creation from upload-part traffic.
+// Telegram can accept file parts concurrently, while serializing message
+// creation prevents a large import from bursting thousands of channel writes.
+type writeClass uint8
+
+const (
+	writeClassMessage writeClass = iota + 1
+	writeClassUploadPart
+)
+
+// writeCoordinator owns process-wide backpressure for one Telegram client.
+// It does not invent a client-side rate: Telegram's longest observed
+// FLOOD_WAIT is the source of truth for the shared cooldown.
+type writeCoordinator struct {
+	now   func() time.Time
+	sleep func(context.Context, time.Duration) error
+
+	messageSlot chan struct{}
+
+	mu           sync.Mutex
+	blockedUntil time.Time
+}
+
+func newWriteCoordinator(now func() time.Time, sleep func(context.Context, time.Duration) error) *writeCoordinator {
+	if now == nil {
+		now = time.Now
+	}
+	if sleep == nil {
+		sleep = sleepContext
+	}
+	return &writeCoordinator{
+		now:         now,
+		sleep:       sleep,
+		messageSlot: make(chan struct{}, 1),
+	}
+}
+
+// Do waits for the shared Telegram cooldown, executes one write, then records
+// any server-directed FLOOD_WAIT for every subsequent write class. Message
+// writes are serialized; upload parts remain concurrent.
+func (c *writeCoordinator) Do(ctx context.Context, class writeClass, action func() error) error {
+	if ctx == nil {
+		return fmt.Errorf("tgclient: write coordinator requires a context")
+	}
+	if action == nil {
+		return fmt.Errorf("tgclient: write coordinator requires an action")
+	}
+	if class != writeClassMessage && class != writeClassUploadPart {
+		return fmt.Errorf("tgclient: unknown write class %d", class)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if class == writeClassMessage {
+		select {
+		case c.messageSlot <- struct{}{}:
+			defer func() { <-c.messageSlot }()
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	// Recheck after acquiring the message slot: a concurrent upload part or
+	// the preceding message may have extended the cooldown while this call was
+	// queued.
+	if err := c.waitForCooldown(ctx); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	err := action()
+	c.observe(err)
+	return err
+}
+
+func (c *writeCoordinator) waitForCooldown(ctx context.Context) error {
+	for {
+		c.mu.Lock()
+		wait := c.blockedUntil.Sub(c.now())
+		c.mu.Unlock()
+		if wait <= 0 {
+			return nil
+		}
+		if err := c.sleep(ctx, wait); err != nil {
+			return err
+		}
+	}
+}
+
+func (c *writeCoordinator) observe(err error) {
+	wait, ok := FloodWaitDuration(err)
+	if !ok || wait < 0 {
+		return
+	}
+	deadline := c.now().Add(wait)
+	c.mu.Lock()
+	if deadline.After(c.blockedUntil) {
+		c.blockedUntil = deadline
+	}
+	c.mu.Unlock()
+}

--- a/backend/tgclient/write_coordinator_test.go
+++ b/backend/tgclient/write_coordinator_test.go
@@ -1,0 +1,230 @@
+package tgclient
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+)
+
+type coordinatorTestClock struct {
+	mu           sync.Mutex
+	now          time.Time
+	sleepStarted chan time.Duration
+	sleepRelease chan struct{}
+}
+
+func newCoordinatorTestClock(now time.Time) *coordinatorTestClock {
+	return &coordinatorTestClock{
+		now:          now,
+		sleepStarted: make(chan time.Duration, 8),
+		sleepRelease: make(chan struct{}, 8),
+	}
+}
+
+func (c *coordinatorTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *coordinatorTestClock) Set(now time.Time) {
+	c.mu.Lock()
+	c.now = now
+	c.mu.Unlock()
+}
+
+func (c *coordinatorTestClock) Sleep(ctx context.Context, wait time.Duration) error {
+	select {
+	case c.sleepStarted <- wait:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-c.sleepRelease:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestWriteCoordinatorSharesLongestFloodWaitAcrossWriteClasses(t *testing.T) {
+	start := time.Unix(1_700_000_000, 0)
+	clock := newCoordinatorTestClock(start)
+	coordinator := newWriteCoordinator(clock.Now, clock.Sleep)
+
+	firstEntered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	firstResult := make(chan error, 1)
+	secondResult := make(chan error, 1)
+
+	go func() {
+		firstResult <- coordinator.Do(context.Background(), writeClassUploadPart, func() error {
+			close(firstEntered)
+			<-releaseFirst
+			return NewFloodWaitError(2 * time.Second)
+		})
+	}()
+	go func() {
+		secondResult <- coordinator.Do(context.Background(), writeClassUploadPart, func() error {
+			close(secondEntered)
+			<-releaseSecond
+			return NewFloodWaitError(5 * time.Second)
+		})
+	}()
+
+	// Upload parts share backpressure state but must remain independently
+	// runnable; serializing their RPCs would erase gotd's multipart parallelism.
+	<-firstEntered
+	<-secondEntered
+	close(releaseFirst)
+	if err := <-firstResult; !errors.Is(err, ErrFloodWait) {
+		t.Fatalf("first upload-part error = %v, want FLOOD_WAIT", err)
+	}
+	close(releaseSecond)
+	if err := <-secondResult; !errors.Is(err, ErrFloodWait) {
+		t.Fatalf("second upload-part error = %v, want FLOOD_WAIT", err)
+	}
+
+	messageAction := make(chan struct{}, 1)
+	uploadAction := make(chan struct{}, 1)
+	messageResult := make(chan error, 1)
+	uploadResult := make(chan error, 1)
+	go func() {
+		messageResult <- coordinator.Do(context.Background(), writeClassMessage, func() error {
+			messageAction <- struct{}{}
+			return nil
+		})
+	}()
+	go func() {
+		uploadResult <- coordinator.Do(context.Background(), writeClassUploadPart, func() error {
+			uploadAction <- struct{}{}
+			return nil
+		})
+	}()
+
+	for i := 0; i < 2; i++ {
+		if wait := <-clock.sleepStarted; wait != 5*time.Second {
+			t.Fatalf("shared cooldown wait = %s, want 5s", wait)
+		}
+	}
+	assertNoCoordinatorAction(t, messageAction, "message")
+	assertNoCoordinatorAction(t, uploadAction, "upload part")
+
+	clock.Set(start.Add(5 * time.Second))
+	clock.sleepRelease <- struct{}{}
+	clock.sleepRelease <- struct{}{}
+	<-messageAction
+	<-uploadAction
+	if err := <-messageResult; err != nil {
+		t.Fatalf("message after cooldown: %v", err)
+	}
+	if err := <-uploadResult; err != nil {
+		t.Fatalf("upload part after cooldown: %v", err)
+	}
+}
+
+func TestWriteCoordinatorSerializesMessagesAndRechecksCooldownAfterQueue(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Unix(1_700_000_000, 0)
+		clock := newCoordinatorTestClock(start)
+		coordinator := newWriteCoordinator(clock.Now, clock.Sleep)
+
+		firstEntered := make(chan struct{})
+		releaseFirst := make(chan struct{})
+		firstResult := make(chan error, 1)
+		go func() {
+			firstResult <- coordinator.Do(context.Background(), writeClassMessage, func() error {
+				close(firstEntered)
+				<-releaseFirst
+				return nil
+			})
+		}()
+		<-firstEntered
+
+		secondAction := make(chan struct{}, 1)
+		secondResult := make(chan error, 1)
+		go func() {
+			secondResult <- coordinator.Do(context.Background(), writeClassMessage, func() error {
+				secondAction <- struct{}{}
+				return nil
+			})
+		}()
+		synctest.Wait()
+		assertNoCoordinatorAction(t, secondAction, "second message")
+
+		// Upload parts are not held behind the logical-message capacity. The
+		// resulting FLOOD_WAIT arrives while message two is queued.
+		err := coordinator.Do(context.Background(), writeClassUploadPart, func() error {
+			return NewFloodWaitError(4 * time.Second)
+		})
+		if !errors.Is(err, ErrFloodWait) {
+			t.Fatalf("upload-part error = %v, want FLOOD_WAIT", err)
+		}
+
+		close(releaseFirst)
+		if err := <-firstResult; err != nil {
+			t.Fatalf("first message: %v", err)
+		}
+		if wait := <-clock.sleepStarted; wait != 4*time.Second {
+			t.Fatalf("queued message cooldown = %s, want 4s", wait)
+		}
+		assertNoCoordinatorAction(t, secondAction, "second message during cooldown")
+
+		clock.Set(start.Add(4 * time.Second))
+		clock.sleepRelease <- struct{}{}
+		<-secondAction
+		if err := <-secondResult; err != nil {
+			t.Fatalf("second message: %v", err)
+		}
+	})
+}
+
+func TestWriteCoordinatorCancellationPreventsAction(t *testing.T) {
+	clock := newCoordinatorTestClock(time.Unix(1_700_000_000, 0))
+	coordinator := newWriteCoordinator(clock.Now, clock.Sleep)
+	if err := coordinator.Do(context.Background(), writeClassUploadPart, func() error {
+		return NewFloodWaitError(time.Minute)
+	}); !errors.Is(err, ErrFloodWait) {
+		t.Fatalf("seed cooldown error = %v, want FLOOD_WAIT", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var called atomic.Bool
+	err := coordinator.Do(ctx, writeClassMessage, func() error {
+		called.Store(true)
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled call error = %v, want context canceled", err)
+	}
+	if called.Load() {
+		t.Fatal("action ran after cancellation")
+	}
+
+	err = coordinator.Do(nil, writeClassMessage, func() error {
+		called.Store(true)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("nil context was accepted")
+	}
+	if called.Load() {
+		t.Fatal("action ran with a nil context")
+	}
+}
+
+func assertNoCoordinatorAction(t *testing.T, action <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-action:
+		t.Fatalf("%s action ran before the shared cooldown elapsed", label)
+	default:
+	}
+}

--- a/frontend/src/modules/import-progress.test.ts
+++ b/frontend/src/modules/import-progress.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+    createImportProgress,
+    reduceImportProgress,
+    type ImportProgress,
+} from './import-progress';
+
+describe('import progress reducer', () => {
+    it('folds high-cardinality aggregate snapshots into constant-size immutable state', () => {
+        const initial = createImportProgress();
+        const first = reduceImportProgress(initial, {
+            total: 10_000,
+            done: 1,
+            failed: 0,
+            progress: 0.01,
+        });
+
+        expect(first).not.toBe(initial);
+        expect(initial).toEqual({ total: 0, done: 0, failed: 0, progress: 0 });
+
+        let current: ImportProgress = first;
+        for (let done = 2; done <= 10_000; done++) {
+            current = reduceImportProgress(current, {
+                total: 10_000,
+                done,
+                failed: 0,
+                progress: done / 100,
+            });
+        }
+
+        // The reducer receives backend aggregates, so its retained state cannot
+        // grow with the number of files (the previous implementation kept one
+        // Map entry per active upload and repeatedly iterated the whole Map).
+        expect(Object.keys(current).sort()).toEqual(['done', 'failed', 'progress', 'total']);
+        expect(current).toEqual({ total: 10_000, done: 10_000, failed: 0, progress: 100 });
+    });
+
+    it('clamps finite values and ignores non-finite regressions', () => {
+        const clamped = reduceImportProgress(createImportProgress(), {
+            total: 8,
+            done: 2,
+            failed: -4,
+            progress: -20,
+        });
+
+        expect(clamped).toEqual({ total: 8, done: 2, failed: 0, progress: 0 });
+
+        const unchanged = reduceImportProgress(clamped, {
+            total: Number.NaN,
+            done: Number.POSITIVE_INFINITY,
+            failed: Number.NEGATIVE_INFINITY,
+            progress: Number.NaN,
+        });
+        expect(unchanged).toEqual(clamped);
+
+        const upperBound = reduceImportProgress(clamped, {
+            total: 8,
+            done: 2,
+            failed: 0,
+            progress: 140,
+        });
+        expect(upperBound.progress).toBe(100);
+    });
+
+    it('does not move backward when a delayed snapshot arrives', () => {
+        const current = reduceImportProgress(createImportProgress(), {
+            total: 20,
+            done: 8,
+            failed: 2,
+            progress: 54,
+        });
+        const afterDelayed = reduceImportProgress(current, {
+            total: 18,
+            done: 5,
+            failed: 1,
+            progress: 31,
+        });
+
+        expect(afterDelayed).toEqual(current);
+    });
+
+    it('forces terminal progress to 100 when every item is accounted for', () => {
+        const complete = reduceImportProgress(createImportProgress(), {
+            total: 10,
+            done: 7,
+            failed: 3,
+            progress: 83,
+        });
+
+        expect(complete).toEqual({ total: 10, done: 7, failed: 3, progress: 100 });
+    });
+
+    it('creates an independent zero state for the next import', () => {
+        const previous = reduceImportProgress(createImportProgress(), {
+            total: 2,
+            done: 2,
+            failed: 0,
+            progress: 100,
+        });
+        const reset = createImportProgress();
+
+        expect(reset).not.toBe(previous);
+        expect(reset).toEqual({ total: 0, done: 0, failed: 0, progress: 0 });
+    });
+});

--- a/frontend/src/modules/import-progress.ts
+++ b/frontend/src/modules/import-progress.ts
@@ -1,0 +1,44 @@
+export interface ImportProgress {
+    total: number;
+    done: number;
+    failed: number;
+    progress: number;
+}
+
+export interface ImportProgressSnapshot {
+    total?: unknown;
+    done?: unknown;
+    failed?: unknown;
+    progress?: unknown;
+}
+
+export function createImportProgress(): ImportProgress {
+    return { total: 0, done: 0, failed: 0, progress: 0 };
+}
+
+function monotonicCount(value: unknown, previous: number): number {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return previous;
+    return Math.max(previous, Math.floor(Math.max(0, parsed)));
+}
+
+function monotonicPercent(value: unknown, previous: number): number {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return previous;
+    return Math.max(previous, Math.min(100, Math.max(0, parsed)));
+}
+
+// Import progress arrives as backend aggregates, so every update is O(1) and
+// the retained state stays constant regardless of the number of files.
+export function reduceImportProgress(
+    previous: ImportProgress,
+    snapshot: ImportProgressSnapshot,
+): ImportProgress {
+    const total = monotonicCount(snapshot.total, previous.total);
+    const done = monotonicCount(snapshot.done, previous.done);
+    const failed = monotonicCount(snapshot.failed, previous.failed);
+    let progress = monotonicPercent(snapshot.progress, previous.progress);
+
+    if (total > 0 && done + failed >= total) progress = 100;
+    return { total, done, failed, progress };
+}

--- a/frontend/src/modules/modals/import-options.ts
+++ b/frontend/src/modules/modals/import-options.ts
@@ -39,13 +39,21 @@ function finish(result: ImportChoice | null): void {
 async function refreshPlan(encrypt: boolean, extract: boolean): Promise<void> {
     if (!currentReplan) return;
     const seq = ++replanSeq;
+    if (currentPayload) {
+        currentPayload = { ...currentPayload, replanning: true };
+        importOptionsModal.setPayload(currentPayload);
+    }
     try {
         const next = await currentReplan(encrypt, extract);
         if (seq !== replanSeq || !currentPayload) return; // ignore out-of-order responses
-        currentPayload = { ...currentPayload, plan: next };
+        currentPayload = { ...currentPayload, plan: next, replanning: false };
         importOptionsModal.setPayload(currentPayload);
     } catch {
-        // Keep the last good summary if a re-plan fails.
+        // Keep the last good summary if a re-plan fails, but never leave the
+        // confirmation action stuck in its pending state.
+        if (seq !== replanSeq || !currentPayload) return;
+        currentPayload = { ...currentPayload, replanning: false };
+        importOptionsModal.setPayload(currentPayload);
     }
 }
 
@@ -87,6 +95,7 @@ export function openImportOptionsModal(opts: {
             plan: opts.plan,
             personal: opts.personal,
             hasArchives: opts.hasArchives,
+            replanning: false,
         };
         importOptionsModal.open(currentPayload);
     });

--- a/frontend/src/modules/transfers.dom.test.ts
+++ b/frontend/src/modules/transfers.dom.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { state } from '../state';
+
+const mocks = vi.hoisted(() => ({
+    markTransferDone: vi.fn(),
+    notify: vi.fn(),
+    openImportOptionsModal: vi.fn(),
+    pushTransferStart: vi.fn(),
+    updateTransferName: vi.fn(),
+    updateTransferProgress: vi.fn(),
+}));
+
+vi.mock('../../wailsjs/go/main/App', () => ({
+    DownloadFile: vi.fn(),
+    SelectFiles: vi.fn(),
+}));
+vi.mock('./notifications', () => ({ notify: mocks.notify }));
+vi.mock('./notif-bell', () => ({
+    markTransferDone: mocks.markTransferDone,
+    pushTransferStart: mocks.pushTransferStart,
+    updateTransferName: mocks.updateTransferName,
+    updateTransferProgress: mocks.updateTransferProgress,
+}));
+vi.mock('./encryption', () => ({ loadEncryptionStatus: vi.fn() }));
+vi.mock('./modals/import-options', () => ({
+    openImportOptionsModal: mocks.openImportOptionsModal,
+}));
+vi.mock('./modals/upload-options', () => ({ openUploadOptionsModal: vi.fn() }));
+vi.mock('./modals/encryption-setup', () => ({ openEncryptionSetupModal: vi.fn() }));
+vi.mock('./modals/encryption-password', () => ({ openEncryptionPasswordModal: vi.fn() }));
+vi.mock('../ui/chrome/UploadMenu.svelte', () => ({ default: {} }));
+vi.mock('../ui/mount', () => ({ mountSvelte: vi.fn() }));
+
+import { importFolderWithParentID, setupUploadProgress } from './transfers';
+
+type RuntimeHandler = (...args: unknown[]) => void;
+
+interface TestNotice {
+    level?: string;
+    body?: string;
+}
+
+const handlers = new Map<string, RuntimeHandler>();
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    handlers.clear();
+    state.activeChannel = { id: 1, title: 'Test drive', kind: 'shared' };
+    state.activeTransfer = null;
+    state.cancelingUpload = false;
+    state.importBatch = null;
+    state.uploadBatch = null;
+    state.uploadTransfers = new Map();
+
+    mocks.openImportOptionsModal.mockResolvedValue({ encrypt: false, extract: false });
+    const app = {
+        SelectFolder: vi.fn().mockResolvedValue('/tmp/empty-folder'),
+        PlanImport: vi.fn().mockResolvedValue({
+            files: 0,
+            folders: 1,
+            archives: 0,
+            limitExceeded: false,
+        }),
+        ImportPaths: vi.fn(async () => {
+            handlers.get('import_start')?.();
+            handlers.get('import_complete')?.({
+                status: 'failed',
+                error: 'folder projection failed after Telegram accepted the folder',
+                uploaded: 0,
+                failed: 0,
+                folders: 0,
+                oversize: 0,
+                ignored: 0,
+                errorCount: 0,
+                errors: [],
+            });
+            throw new Error('folder projection failed after Telegram accepted the folder');
+        }),
+    };
+    Object.defineProperty(window, 'go', {
+        configurable: true,
+        value: { main: { App: app } },
+    });
+    Object.defineProperty(window, 'refreshFiles', {
+        configurable: true,
+        value: vi.fn(),
+    });
+    Object.defineProperty(window, 'runtime', {
+        configurable: true,
+        value: {
+            EventsOn: vi.fn((name: string, handler: RuntimeHandler) => {
+                handlers.set(name, handler);
+            }),
+        },
+    });
+    setupUploadProgress();
+});
+
+afterEach(() => {
+    state.activeChannel = null;
+    state.activeTransfer = null;
+    state.cancelingUpload = false;
+    state.importBatch = null;
+    Reflect.deleteProperty(window, 'go');
+    Reflect.deleteProperty(window, 'runtime');
+    Reflect.deleteProperty(window, 'refreshFiles');
+});
+
+describe('aggregate import completion', () => {
+    it('reports a fatal completion once even when ImportPaths subsequently rejects', async () => {
+        await importFolderWithParentID('');
+
+        expect(mocks.markTransferDone).toHaveBeenCalledWith({
+            id: 'import',
+            direction: 'up',
+            status: 'failed',
+        });
+        expect(mocks.markTransferDone).toHaveBeenCalledTimes(1);
+        expect(mocks.markTransferDone).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'done' }));
+        expect(mocks.pushTransferStart).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'Import failed' }));
+
+        const errorNotifications = mocks.notify.mock.calls
+            .map(([notice]) => notice as TestNotice)
+            .filter((notice) => notice?.level === 'error');
+        expect(errorNotifications).toHaveLength(1);
+        expect(errorNotifications[0].body).toContain('folder projection failed');
+    });
+
+    it('keeps cancellation authoritative over a late fatal status', () => {
+        handlers.get('import_start')?.();
+        state.cancelingUpload = true;
+        handlers.get('import_complete')?.({
+            status: 'failed',
+            error: 'request canceled while a write was settling',
+            uploaded: 0,
+            failed: 0,
+            errorCount: 0,
+            errors: [],
+        });
+
+        expect(mocks.markTransferDone).toHaveBeenCalledWith({
+            id: 'import',
+            direction: 'up',
+            status: 'canceled',
+        });
+        expect(mocks.notify).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/modules/transfers.dom.test.ts
+++ b/frontend/src/modules/transfers.dom.test.ts
@@ -37,6 +37,7 @@ type RuntimeHandler = (...args: unknown[]) => void;
 
 interface TestNotice {
     level?: string;
+    title?: string;
     body?: string;
 }
 
@@ -118,11 +119,17 @@ describe('aggregate import completion', () => {
         expect(mocks.markTransferDone).toHaveBeenCalledTimes(1);
         expect(mocks.markTransferDone).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'done' }));
         expect(mocks.pushTransferStart).not.toHaveBeenCalledWith(expect.objectContaining({ name: 'Import failed' }));
+        expect(mocks.updateTransferName).toHaveBeenLastCalledWith({
+            id: 'import',
+            direction: 'up',
+            name: 'Import failed',
+        });
 
         const errorNotifications = mocks.notify.mock.calls
             .map(([notice]) => notice as TestNotice)
             .filter((notice) => notice?.level === 'error');
         expect(errorNotifications).toHaveLength(1);
+        expect(errorNotifications[0].title).toBe('Import failed');
         expect(errorNotifications[0].body).toContain('folder projection failed');
     });
 
@@ -144,5 +151,32 @@ describe('aggregate import completion', () => {
             status: 'canceled',
         });
         expect(mocks.notify).not.toHaveBeenCalled();
+    });
+
+    it('preserves partial-import wording for non-fatal file failures', () => {
+        handlers.get('import_start')?.();
+        handlers.get('import_complete')?.({
+            status: 'done',
+            uploaded: 999,
+            failed: 1,
+            errorCount: 0,
+            errors: [],
+        });
+
+        expect(mocks.updateTransferName).toHaveBeenLastCalledWith({
+            id: 'import',
+            direction: 'up',
+            name: 'Imported 999 files · 1 failed',
+        });
+        expect(mocks.markTransferDone).toHaveBeenCalledWith({
+            id: 'import',
+            direction: 'up',
+            status: 'failed',
+        });
+        expect(mocks.notify).toHaveBeenCalledWith(expect.objectContaining({
+            level: 'error',
+            title: 'Imported 999 files · 1 failed',
+            body: expect.stringContaining('1 failed'),
+        }));
     });
 });

--- a/frontend/src/modules/transfers.ts
+++ b/frontend/src/modules/transfers.ts
@@ -352,26 +352,34 @@ export function setupUploadProgress() {
         const failedUploads = Math.max(Number(info?.failed) || 0, state.importBatch?.failed || 0);
         const uploaded = Number(info?.uploaded) || 0;
         const oversize = Number(info?.oversize) || 0;
+        const backendStatus = String(info?.status ?? '').toLowerCase();
+        const fatalError = String(info?.error ?? '').trim();
         const reportedErrors = Number(info?.errorCount);
         const errorCount = Number.isFinite(reportedErrors)
             ? Math.max(0, Math.floor(reportedErrors))
             : (Array.isArray(info?.errors) ? info.errors.length : 0);
-        const canceled = state.cancelingUpload;
-        const status = canceled ? 'canceled' : (failedUploads > 0 ? 'failed' : 'done');
+        const canceled = state.cancelingUpload || backendStatus === 'canceled';
+        const status = canceled
+            ? 'canceled'
+            : (backendStatus === 'failed' || failedUploads > 0 ? 'failed' : 'done');
         if (!state.importBatch) {
             pushTransferStart({ id: IMPORT_TRANSFER_ID, direction: 'up', name: 'Import completed', total: uploaded + failedUploads });
         }
         updateTransferName({
             id: IMPORT_TRANSFER_ID,
             direction: 'up',
-            name: canceled ? 'Import canceled' : (uploaded === 1 ? 'Imported 1 file' : `Imported ${uploaded} files`),
+            name: canceled
+                ? 'Import canceled'
+                : (status === 'failed'
+                    ? 'Import failed'
+                    : (uploaded === 1 ? 'Imported 1 file' : `Imported ${uploaded} files`)),
         });
         markTransferDone({ id: IMPORT_TRANSFER_ID, direction: 'up', status });
         state.importBatch = null;
 
         if (typeof window.refreshFiles === 'function') window.refreshFiles();
 
-        if (!canceled && (failedUploads > 0 || oversize > 0 || errorCount > 0)) {
+        if (!canceled && (status === 'failed' || failedUploads > 0 || oversize > 0 || errorCount > 0)) {
             const bits: string[] = [];
             if (failedUploads > 0) bits.push(`${failedUploads} failed`);
             if (oversize > 0) bits.push(`${oversize} skipped (too large)`);
@@ -379,7 +387,12 @@ export function setupUploadProgress() {
             // Include the first few concrete reasons (per-file upload errors,
             // then backend scan errors) so the summary is actionable, not just
             // counts.
-            const reasons = [...importFailureReasons];
+            const reasons: string[] = [];
+            if (fatalError) reasons.push(fatalError);
+            for (const reason of importFailureReasons) {
+                if (reasons.length >= MAX_IMPORT_FAILURE_REASONS) break;
+                if (!reasons.includes(reason)) reasons.push(reason);
+            }
             if (Array.isArray(info?.errors)) {
                 for (const raw of info.errors) {
                     if (reasons.length >= MAX_IMPORT_FAILURE_REASONS) break;
@@ -388,9 +401,11 @@ export function setupUploadProgress() {
                 }
             }
             notify({
-                level: failedUploads > 0 ? 'error' : 'info',
-                title: `Imported ${uploaded === 1 ? '1 file' : `${uploaded} files`}`,
-                body: [...bits, ...reasons].join('  ·  '),
+                level: status === 'failed' ? 'error' : 'info',
+                title: status === 'failed'
+                    ? 'Import failed'
+                    : `Imported ${uploaded === 1 ? '1 file' : `${uploaded} files`}`,
+                body: [...bits, ...reasons].join('  ·  ') || 'The import stopped before it could finish.',
             });
         }
         importFailureReasons.length = 0;
@@ -521,7 +536,7 @@ async function runImportFlow(parentID: any, paths: any) {
             if (!state.cancelingUpload && !importCompleteReceived) {
                 notify({ level: 'error', title: 'Import failed', body: String(err) });
             }
-            if (!state.importBatch) {
+            if (!importCompleteReceived && !state.importBatch) {
                 pushTransferStart({ id: IMPORT_TRANSFER_ID, direction: 'up', name: 'Import failed', total: 0 });
             }
         } finally {
@@ -532,7 +547,7 @@ async function runImportFlow(parentID: any, paths: any) {
                 markTransferDone({ id: IMPORT_TRANSFER_ID, direction: 'up', status: importThrew ? 'failed' : 'done' });
                 state.importBatch = null;
             }
-            if (importThrew) {
+            if (importThrew && !importCompleteReceived) {
                 markTransferDone({ id: IMPORT_TRANSFER_ID, direction: 'up', status: 'failed' });
             }
         }

--- a/frontend/src/modules/transfers.ts
+++ b/frontend/src/modules/transfers.ts
@@ -168,6 +168,11 @@ function recordImportFailureReason(name: any, message: any) {
     if (!importFailureReasons.includes(entry)) importFailureReasons.push(entry);
 }
 
+function formatImportResultLabel(uploaded: number, failedUploads = 0) {
+    const imported = uploaded === 1 ? 'Imported 1 file' : `Imported ${uploaded} files`;
+    return failedUploads > 0 ? `${imported} · ${failedUploads} failed` : imported;
+}
+
 // refreshImportRow renders one constant-size aggregate supplied by the backend.
 function refreshImportRow() {
     const batch = state.importBatch;
@@ -359,9 +364,11 @@ export function setupUploadProgress() {
             ? Math.max(0, Math.floor(reportedErrors))
             : (Array.isArray(info?.errors) ? info.errors.length : 0);
         const canceled = state.cancelingUpload || backendStatus === 'canceled';
+        const fatal = backendStatus === 'failed';
         const status = canceled
             ? 'canceled'
-            : (backendStatus === 'failed' || failedUploads > 0 ? 'failed' : 'done');
+            : (fatal || failedUploads > 0 ? 'failed' : 'done');
+        const resultLabel = formatImportResultLabel(uploaded, failedUploads);
         if (!state.importBatch) {
             pushTransferStart({ id: IMPORT_TRANSFER_ID, direction: 'up', name: 'Import completed', total: uploaded + failedUploads });
         }
@@ -370,9 +377,9 @@ export function setupUploadProgress() {
             direction: 'up',
             name: canceled
                 ? 'Import canceled'
-                : (status === 'failed'
+                : (fatal
                     ? 'Import failed'
-                    : (uploaded === 1 ? 'Imported 1 file' : `Imported ${uploaded} files`)),
+                    : resultLabel),
         });
         markTransferDone({ id: IMPORT_TRANSFER_ID, direction: 'up', status });
         state.importBatch = null;
@@ -402,9 +409,9 @@ export function setupUploadProgress() {
             }
             notify({
                 level: status === 'failed' ? 'error' : 'info',
-                title: status === 'failed'
+                title: fatal
                     ? 'Import failed'
-                    : `Imported ${uploaded === 1 ? '1 file' : `${uploaded} files`}`,
+                    : resultLabel,
                 body: [...bits, ...reasons].join('  ·  ') || 'The import stopped before it could finish.',
             });
         }

--- a/frontend/src/modules/transfers.ts
+++ b/frontend/src/modules/transfers.ts
@@ -13,6 +13,7 @@ import { openUploadOptionsModal } from './modals/upload-options';
 import { openImportOptionsModal } from './modals/import-options';
 import { openEncryptionSetupModal } from './modals/encryption-setup';
 import { openEncryptionPasswordModal } from './modals/encryption-password';
+import { createImportProgress, reduceImportProgress } from './import-progress';
 import {
     pushTransferStart,
     updateTransferProgress,
@@ -151,15 +152,12 @@ const IMPORT_TRANSFER_ID = 'import';
 // or a drop during an active import) is rejected rather than corrupting the
 // shared batch/transfer state.
 let flowBusy = false;
-const importProgressById = new Map<number, number>();
-// Per-file upload ids seen during the current import, so stray per-file rows
-// can be swept if a completion event is dropped.
-const importFileIds = new Set<number>();
 // First few distinct per-file failure reasons, folded into the aggregate
 // import summary toast. Imports report one toast for the whole batch, so this
 // is the only place the backend's actual error text survives to the user.
 const MAX_IMPORT_FAILURE_REASONS = 3;
 const importFailureReasons: string[] = [];
+let importCompleteReceived = false;
 
 function recordImportFailureReason(name: any, message: any) {
     if (importFailureReasons.length >= MAX_IMPORT_FAILURE_REASONS) return;
@@ -170,16 +168,12 @@ function recordImportFailureReason(name: any, message: any) {
     if (!importFailureReasons.includes(entry)) importFailureReasons.push(entry);
 }
 
-// refreshImportRow advances the aggregate import row as files finish.
+// refreshImportRow renders one constant-size aggregate supplied by the backend.
 function refreshImportRow() {
     const batch = state.importBatch;
     if (!batch) return;
-    let partial = 0;
-    for (const value of importProgressById.values()) partial += value;
-    const finished = batch.done + batch.failed + partial;
     const total = batch.total || 0;
-    const pct = total > 0 ? Math.min(100, (finished / total) * 100) : 100;
-    updateTransferProgress({ id: IMPORT_TRANSFER_ID, direction: 'up', progress: pct });
+    updateTransferProgress({ id: IMPORT_TRANSFER_ID, direction: 'up', progress: batch.progress });
     if (total > 0) {
         updateTransferName({
             id: IMPORT_TRANSFER_ID,
@@ -189,28 +183,13 @@ function refreshImportRow() {
     }
 }
 
-// sweepImportFileRows finalizes any import per-file rows still marked active
-// (e.g. if a completion event was dropped). markTransferDone is idempotent, so
-// rows that already ended (done/failed) are left untouched.
-function sweepImportFileRows() {
-    for (const fid of importFileIds) {
-        markTransferDone({ id: fid, direction: 'up', status: 'done' });
-    }
-    importFileIds.clear();
-}
-
 export function setupUploadProgress() {
     if (!window.runtime?.EventsOn) return;
 
     window.runtime.EventsOn("upload_start", (id: any, name: any, size: any, parentId: any) => {
-        // During an import, also show a per-file row; the aggregate row owns the
-        // batch counters and the overall progress.
+        // New backends suppress detailed events during imports. Ignore any
+        // strays from an older backend so a large import still keeps one row.
         if (state.importBatch) {
-            const fid = Number(id);
-            if (Number.isFinite(fid)) {
-                importFileIds.add(fid);
-                pushTransferStart({ id: fid, direction: 'up', name: String(name ?? ""), total: Number(size) || 0 });
-            }
             return;
         }
 
@@ -247,9 +226,6 @@ export function setupUploadProgress() {
         const clamped = Math.max(0, Math.min(100, value));
 
         if (state.importBatch) {
-            importProgressById.set(uploadId, clamped / 100);
-            updateTransferProgress({ id: uploadId, direction: 'up', progress: clamped });
-            refreshImportRow();
             return;
         }
 
@@ -263,11 +239,6 @@ export function setupUploadProgress() {
         const uploadId = Number(id);
         if (!Number.isFinite(uploadId)) return;
         if (state.importBatch) {
-            importProgressById.delete(uploadId);
-            importFileIds.delete(uploadId);
-            state.importBatch.done += 1;
-            markTransferDone({ id: uploadId, direction: 'up', status: 'done' });
-            refreshImportRow();
             return;
         }
         const item = state.uploadTransfers.get(uploadId);
@@ -300,13 +271,7 @@ export function setupUploadProgress() {
         const uploadId = Number(id);
         if (!Number.isFinite(uploadId)) return;
         if (state.importBatch) {
-            importProgressById.delete(uploadId);
-            importFileIds.delete(uploadId);
-            state.importBatch.failed += 1;
             if (!state.cancelingUpload) recordImportFailureReason(name, message);
-            pushTransferStart({ id: uploadId, direction: 'up', name: String(name ?? "") || 'Upload failed', total: 0 });
-            markTransferDone({ id: uploadId, direction: 'up', status: state.cancelingUpload ? 'canceled' : 'failed' });
-            refreshImportRow();
             return;
         }
         const filename = String(name ?? "");
@@ -350,10 +315,9 @@ export function setupUploadProgress() {
     });
 
     window.runtime.EventsOn("import_start", () => {
-        importProgressById.clear();
-        importFileIds.clear();
+        importCompleteReceived = false;
         importFailureReasons.length = 0;
-        state.importBatch = { total: 0, done: 0, failed: 0 };
+        state.importBatch = createImportProgress();
         pushTransferStart({ id: IMPORT_TRANSFER_ID, direction: 'up', name: 'Preparing import…', total: 0 });
     });
 
@@ -368,8 +332,7 @@ export function setupUploadProgress() {
     window.runtime.EventsOn("import_uploading", (info: any) => {
         if (!state.importBatch) return;
         const files = Number(info?.files) || 0;
-        state.importBatch.total = files;
-        importProgressById.clear();
+        state.importBatch = reduceImportProgress(state.importBatch, { total: files });
         updateTransferName({
             id: IMPORT_TRANSFER_ID,
             direction: 'up',
@@ -378,11 +341,21 @@ export function setupUploadProgress() {
         refreshImportRow();
     });
 
+    window.runtime.EventsOn("import_upload_progress", (info: any) => {
+        if (!state.importBatch) return;
+        state.importBatch = reduceImportProgress(state.importBatch, info ?? {});
+        refreshImportRow();
+    });
+
     window.runtime.EventsOn("import_complete", (info: any) => {
+        importCompleteReceived = true;
         const failedUploads = Math.max(Number(info?.failed) || 0, state.importBatch?.failed || 0);
         const uploaded = Number(info?.uploaded) || 0;
         const oversize = Number(info?.oversize) || 0;
-        const errorCount = Array.isArray(info?.errors) ? info.errors.length : 0;
+        const reportedErrors = Number(info?.errorCount);
+        const errorCount = Number.isFinite(reportedErrors)
+            ? Math.max(0, Math.floor(reportedErrors))
+            : (Array.isArray(info?.errors) ? info.errors.length : 0);
         const canceled = state.cancelingUpload;
         const status = canceled ? 'canceled' : (failedUploads > 0 ? 'failed' : 'done');
         if (!state.importBatch) {
@@ -395,12 +368,10 @@ export function setupUploadProgress() {
         });
         markTransferDone({ id: IMPORT_TRANSFER_ID, direction: 'up', status });
         state.importBatch = null;
-        importProgressById.clear();
-        sweepImportFileRows();
 
         if (typeof window.refreshFiles === 'function') window.refreshFiles();
 
-        if (failedUploads > 0 || oversize > 0 || errorCount > 0) {
+        if (!canceled && (failedUploads > 0 || oversize > 0 || errorCount > 0)) {
             const bits: string[] = [];
             if (failedUploads > 0) bits.push(`${failedUploads} failed`);
             if (oversize > 0) bits.push(`${oversize} skipped (too large)`);
@@ -492,6 +463,16 @@ async function runImportFlow(parentID: any, paths: any) {
             return;
         }
 
+        if (plan.limitExceeded) {
+            const maxItems = Math.max(1, Math.floor(Number(plan.maxItems) || 10_000));
+            notify({
+                level: 'info',
+                title: 'Selection is too large',
+                body: `Keep it under ${maxItems.toLocaleString()} items by removing generated/cache folders or splitting it into smaller batches.`,
+            });
+            return;
+        }
+
         const complex = Number(plan.folders) > 0 || Number(plan.archives) > 0;
 
         if (!complex) {
@@ -530,13 +511,16 @@ async function runImportFlow(parentID: any, paths: any) {
         }
 
         state.activeTransfer = "upload";
+        importCompleteReceived = false;
         let importThrew = false;
         try {
             await importFn(paths, parentID || "", encrypt, extract);
         } catch (err) {
             importThrew = true;
             console.error("Import failed:", err);
-            notify({ level: 'error', title: 'Import failed', body: String(err) });
+            if (!state.cancelingUpload && !importCompleteReceived) {
+                notify({ level: 'error', title: 'Import failed', body: String(err) });
+            }
             if (!state.importBatch) {
                 pushTransferStart({ id: IMPORT_TRANSFER_ID, direction: 'up', name: 'Import failed', total: 0 });
             }
@@ -551,8 +535,6 @@ async function runImportFlow(parentID: any, paths: any) {
             if (importThrew) {
                 markTransferDone({ id: IMPORT_TRANSFER_ID, direction: 'up', status: 'failed' });
             }
-            importProgressById.clear();
-            sweepImportFileRows();
         }
     } finally {
         flowBusy = false;

--- a/frontend/src/state.ts
+++ b/frontend/src/state.ts
@@ -1,3 +1,5 @@
+import type { ImportProgress } from './modules/import-progress';
+
 // Centralized state for the TDrive frontend.
 //
 // Loosely-shaped, frequently-reshaped fields (drag payloads, modal targets,
@@ -41,9 +43,9 @@ export interface State {
     transferClearEl: HTMLElement | null;
     uploadTransfers: Map<string | number, any>;
     uploadBatch: { total: number; done: number; failed: number } | null;
-    // Aggregate progress for a folder/archive import. When set, per-file upload
-    // events feed this single bell row instead of spawning one row per file.
-    importBatch: { total: number; done: number; failed: number } | null;
+    // Constant-size aggregate progress for a folder/archive import. The backend
+    // coalesces per-file activity before it crosses the Wails bridge.
+    importBatch: ImportProgress | null;
     // True while a cancel is in flight, so abort events relabel rows as canceled
     // instead of failed.
     cancelingUpload: boolean;

--- a/frontend/src/ui/modals/ImportOptionsModal.svelte
+++ b/frontend/src/ui/modals/ImportOptionsModal.svelte
@@ -46,13 +46,22 @@
     const note = $derived.by(() => {
         const plan = $view.payload?.plan;
         if (!plan) return '';
-        const errors = Array.isArray(plan.errors) ? plan.errors.length : 0;
+        const reportedErrors = Number(plan.errorCount);
+        const errors = Number.isFinite(reportedErrors)
+            ? Math.max(0, Math.floor(reportedErrors))
+            : (Array.isArray(plan.errors) ? plan.errors.length : 0);
         const notes: string[] = [];
         if (plan.oversize > 0) {
             notes.push(`${plural(plan.oversize, 'file', 'files')} over ${humanBytes(plan.maxBytes)} will be skipped (Telegram's per-file limit).`);
         }
+        if (plan.ignored > 0) {
+            notes.push(`${plural(plan.ignored, 'generated/cache entry', 'generated/cache entries')} will be skipped.`);
+        }
         if (errors > 0) {
             notes.push(`${plural(errors, 'item', 'items')} could not be scanned and may be skipped or uploaded as-is.`);
+        }
+        if (plan.limitExceeded) {
+            notes.push(`Keep it under ${plan.maxItems.toLocaleString()} items by removing generated/cache folders or splitting it into smaller batches.`);
         }
         return notes.join(' ');
     });
@@ -108,9 +117,11 @@
             id="import-options-confirm"
             class="primary-btn"
             type="button"
+            disabled={$view.payload?.plan.limitExceeded || $view.payload?.replanning}
+            aria-busy={$view.payload?.replanning}
             onclick={() => onConfirm({ encrypt, extract })}
         >
-            Import
+            {$view.payload?.replanning ? 'Checking…' : 'Import'}
         </button>
     {/snippet}
 </ModalShell>

--- a/frontend/src/ui/modals/import-options-modal-store.ts
+++ b/frontend/src/ui/modals/import-options-modal-store.ts
@@ -6,7 +6,11 @@ export interface ImportOptionsPlan {
     bytes: number;
     oversize: number;
     archives: number;
+    ignored: number;
+    maxItems: number;
+    limitExceeded: boolean;
     maxBytes: number;
+    errorCount?: number;
     errors?: string[];
 }
 
@@ -14,6 +18,7 @@ export interface ImportOptionsPayload {
     plan: ImportOptionsPlan;
     personal: boolean;
     hasArchives: boolean;
+    replanning?: boolean;
 }
 
 export const importOptionsModal = createModalController<ImportOptionsPayload>();

--- a/frontend/src/ui/modals/modals.test.ts
+++ b/frontend/src/ui/modals/modals.test.ts
@@ -31,6 +31,9 @@ function makePlan(overrides: Partial<ImportOptionsPlan> = {}): ImportOptionsPlan
         bytes: 2048,
         oversize: 0,
         archives: 0,
+        ignored: 0,
+        maxItems: 10_000,
+        limitExceeded: false,
         maxBytes: 1024 * 1024,
         errors: [],
         ...overrides,
@@ -212,6 +215,70 @@ describe('ImportOptionsModal', () => {
         expect(body).toContain('1 file over 1.0 MB will be skipped');
         expect(body).toContain('import-options-extract-row');
         expect(body).toContain('import-options-encrypt-row');
+    });
+
+    it('explains when generated and cache entries will be skipped', () => {
+        importOptionsModal.open({
+            plan: makePlan({ ignored: 137 }),
+            personal: false,
+            hasArchives: false,
+        });
+
+        const { body } = render(ImportOptionsModal, {
+            props: { onCancel: noop, onConfirm: noop, onToggle: noop },
+        });
+
+        expect(body).toContain('137 generated/cache entries will be skipped');
+    });
+
+    it('blocks an oversized import with actionable guidance', () => {
+        importOptionsModal.open({
+            plan: makePlan({ files: 10_001, maxItems: 10_000, limitExceeded: true }),
+            personal: false,
+            hasArchives: false,
+        });
+
+        const { body } = render(ImportOptionsModal, {
+            props: { onCancel: noop, onConfirm: noop, onToggle: noop },
+        });
+        const confirm = body.match(/<button[^>]*id="import-options-confirm"[^>]*>/)?.[0] ?? '';
+
+        expect(body).toContain('Keep it under 10,000 items');
+        expect(body).toContain('removing generated/cache folders or splitting it into smaller batches');
+        expect(confirm).toContain('disabled');
+    });
+
+    it('keeps the confirm action enabled for imports within the limit', () => {
+        importOptionsModal.open({
+            plan: makePlan({ files: 9_999, maxItems: 10_000, limitExceeded: false }),
+            personal: false,
+            hasArchives: false,
+        });
+
+        const { body } = render(ImportOptionsModal, {
+            props: { onCancel: noop, onConfirm: noop, onToggle: noop },
+        });
+        const confirm = body.match(/<button[^>]*id="import-options-confirm"[^>]*>/)?.[0] ?? '';
+
+        expect(confirm).not.toContain('disabled');
+    });
+
+    it('prevents confirmation while an option replan is pending', () => {
+        importOptionsModal.open({
+            plan: makePlan(),
+            personal: true,
+            hasArchives: true,
+            replanning: true,
+        });
+
+        const { body } = render(ImportOptionsModal, {
+            props: { onCancel: noop, onConfirm: noop, onToggle: noop },
+        });
+        const confirm = body.match(/<button[^>]*id="import-options-confirm"[^>]*>/)?.[0] ?? '';
+
+        expect(confirm).toContain('disabled');
+        expect(confirm).toContain('aria-busy="true"');
+        expect(body).toContain('Checking…');
     });
 });
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -116,7 +116,11 @@ export namespace file {
 	    bytes: number;
 	    oversize: number;
 	    archives: number;
+	    ignored: number;
 	    maxBytes: number;
+	    maxItems: number;
+	    limitExceeded: boolean;
+	    errorCount: number;
 	    errors: string[];
 	
 	    static createFrom(source: any = {}) {
@@ -130,7 +134,11 @@ export namespace file {
 	        this.bytes = source["bytes"];
 	        this.oversize = source["oversize"];
 	        this.archives = source["archives"];
+	        this.ignored = source["ignored"];
 	        this.maxBytes = source["maxBytes"];
+	        this.maxItems = source["maxItems"];
+	        this.limitExceeded = source["limitExceeded"];
+	        this.errorCount = source["errorCount"];
 	        this.errors = source["errors"];
 	    }
 	}


### PR DESCRIPTION
## Summary
- prune generated/cache trees conservatively during folder and archive imports while preserving explicit user selections
- enforce a 10,000 remote-object admission limit before any remote mutation
- walk folders and inspect archives with bounded retained state, then upload in 128-item windows with natural backpressure
- collapse import progress into aggregate backend events and O(1) frontend state instead of one row or map entry per file
- coordinate Telegram writes and shared server-directed FLOOD_WAIT cooldowns while keeping upload parts concurrent
- resolve peers once per upload/import and reuse idempotency keys across safe control-write retries

## Review blockers resolved
- rebased onto current `master` at `64fccb7` and regenerated Wails bindings so updater models and expanded `file.ImportPlan` fields coexist
- mark Telegram-accepted/local-projection-failed control writes with `projection.ErrControlProjection` and stop all dependent import scheduling, including nested folders
- emit authoritative `done`, `failed`, or `canceled` completion status plus the fatal error and actual scheduled upload count
- keep folder-only fatal imports visibly failed and avoid duplicate frontend finalization after the Wails promise rejects
- calculate upload failures from actual scheduled work, so a successful raw-archive fallback reports `uploaded: 1`, `failed: 0`
- count archive parent directories only for members that can actually upload
- stop archive-fallback scheduling immediately when the raw-archive upload window returns a fatal error, preserving the first fatal result
- reserve `Import failed` for backend-declared fatal completion while retaining partial results such as `Imported 999 files · 1 failed`
- remove the dead archive item-limit branch and redundant retained-entry guard without weakening the raw scan cap

## Verification
- `go test ./... -count=1`
- `go test -race ./backend/services/file ./backend/tgclient ./backend/core -count=1`
- `go vet ./backend/core ./backend/services/file ./backend/projection ./backend/tgclient`
- `wails build -nopackage -m`
- `npm run test:coverage` — 61 files, 310 tests; 92.3% statements and 92.48% lines
- `npm run typecheck` — 0 errors, 0 warnings
- `npm run lint` — 0 errors; the repository's existing warning-only `no-explicit-any` backlog remains
- `npm run build`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `git diff --check`
- independent general, Go, TypeScript, and security reviews — no blocking findings

## Coverage note
Focused package coverage is `file 74.9%`, `tgclient 36.6%`, `core 41.5%`, and `projection 72.0%`. These broad packages remain below the repository's stated 80% target; this PR adds regression coverage for every changed blocker path without padding unrelated legacy code.

## Non-blocking follow-ups
- a safe archive plan cache needs bounded lifetime and file-identity/TOCTOU handling; this blocker fix intentionally avoids a naive metadata cache
- progress phase-label smoothing and typed Telegram RPC classification should be handled as separately tested behavior changes
- the 10,000-item cap on the public multi-file upload path is intentional protection against accidental or generated upload storms

## Notes
- Draft PR only; do not merge yet.
- Local verification is complete. CI was not awaited.
