### PR TITLE
fix: skip theme view transitions on linux webkit

### DIFF
--- a/frontend/src/ui/theme/theme-controller.dom.test.ts
+++ b/frontend/src/ui/theme/theme-controller.dom.test.ts
@@ -228,6 +228,36 @@ describe('theme controller', () => {
         controller.destroy();
     });
 
+    it('takes the CSS fallback instead of a view transition on Linux WebKit', () => {
+        vi.useFakeTimers();
+        const startViewTransition = vi.fn((update: () => void) => {
+            update();
+            return { finished: Promise.resolve() };
+        });
+        Object.defineProperty(document, 'startViewTransition', {
+            configurable: true,
+            value: startViewTransition,
+        });
+        const controller = createThemeController({
+            document,
+            storage,
+            reducedMotion: createMediaQuery(false),
+            userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+        });
+        controller.start();
+
+        controller.setPreferredTheme('dark', 'nord', { x: 120, y: 84 });
+
+        expect(startViewTransition).not.toHaveBeenCalled();
+        expect(document.documentElement.dataset.theme).toBe('nord');
+        expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(true);
+        expect(document.documentElement.style.getPropertyValue('--theme-origin-x')).toBe('120px');
+
+        vi.advanceTimersByTime(1250);
+        expect(document.documentElement.classList.contains('theme-transition-fallback')).toBe(false);
+        controller.destroy();
+    });
+
     it('keeps working when storage is unavailable and ignores invalid runtime input', () => {
         const unavailableStorage = {
             getItem: () => { throw new Error('blocked'); },

--- a/frontend/src/ui/theme/theme-controller.test.ts
+++ b/frontend/src/ui/theme/theme-controller.test.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 import { describe, expect, it } from 'vitest';
-import { createThemeController } from './theme-controller';
+import { createThemeController, isLinuxWebKit } from './theme-controller';
 
 describe('theme controller without a browser runtime', () => {
     it('preserves the explicit dark default without a browser document', () => {
@@ -25,5 +25,26 @@ describe('theme controller without a browser runtime', () => {
         expect(get(controller.state).resolvedThemeId).toBe('tokyo-night');
 
         expect(() => controller.destroy()).not.toThrow();
+    });
+});
+
+describe('isLinuxWebKit', () => {
+    const webkitGtk = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+
+    it.each([
+        ['WebKitGTK (Wails on Linux)', webkitGtk, true],
+        ['WebKitGTK with the Wails application tag', `${webkitGtk} wails.io/`, true],
+        ['WPE on aarch64', 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15', true],
+        ['Chromium on Linux', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36', false],
+        ['WKWebView on macOS', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)', false],
+        ['Safari on macOS', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15', false],
+        ['WebView2 on Windows', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.0.0', false],
+        ['Firefox on Linux', 'Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0', false],
+        ['happy-dom on Linux CI', 'Mozilla/5.0 (X11; Linux x64) AppleWebKit/537.36 (KHTML, like Gecko) HappyDOM/20.10.6', false],
+        ['jsdom on Linux CI', 'Mozilla/5.0 (linux) AppleWebKit/537.36 (KHTML, like Gecko) jsdom/24.0.0', false],
+        ['empty', '', false],
+        ['undefined', undefined, false],
+    ])('%s', (_name, userAgent, expected) => {
+        expect(isLinuxWebKit(userAgent)).toBe(expected);
     });
 });

--- a/frontend/src/ui/theme/theme-controller.test.ts
+++ b/frontend/src/ui/theme/theme-controller.test.ts
@@ -36,6 +36,7 @@ describe('isLinuxWebKit', () => {
         ['WebKitGTK with the Wails application tag', `${webkitGtk} wails.io/`, true],
         ['WPE on aarch64', 'Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15', true],
         ['Chromium on Linux', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36', false],
+        ['Headless Chromium on Linux', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/128.0.0.0 Safari/537.36', false],
         ['WKWebView on macOS', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)', false],
         ['Safari on macOS', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15', false],
         ['WebView2 on Windows', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.0.0', false],

--- a/frontend/src/ui/theme/theme-controller.ts
+++ b/frontend/src/ui/theme/theme-controller.ts
@@ -266,15 +266,16 @@ function resolveEnvironment(environment: ThemeControllerEnvironment): ResolvedEn
 
 /**
  * True for WebKitGTK/WPE (Wails and Tauri on Linux, Epiphany), which report
- * `Linux` + `AppleWebKit` + `Safari` without a Chromium token. Chromium and
- * test DOMs (happy-dom, jsdom) never carry the `Safari/` product token.
+ * `Linux` + `AppleWebKit` + `Safari` without a Chromium token (matched without
+ * a word boundary so `HeadlessChrome/` is excluded too). Test DOMs (happy-dom,
+ * jsdom) never carry the `Safari/` product token.
  */
 export function isLinuxWebKit(userAgent: string | undefined): boolean {
     if (!userAgent) return false;
     return /\bLinux\b/.test(userAgent)
         && /AppleWebKit\//.test(userAgent)
         && /\bSafari\//.test(userAgent)
-        && !/\b(?:Chrome|Chromium|CriOS|Edg|OPR)\//.test(userAgent);
+        && !/(?:Chrome|Chromium|CriOS|Edg|OPR)\//.test(userAgent);
 }
 
 function getBrowserDocument(): Document | undefined {

--- a/frontend/src/ui/theme/theme-controller.ts
+++ b/frontend/src/ui/theme/theme-controller.ts
@@ -38,6 +38,7 @@ export interface ThemeControllerEnvironment {
     readonly document?: Document;
     readonly storage?: ThemeStorage;
     readonly reducedMotion?: MediaQueryList;
+    readonly userAgent?: string;
 }
 
 export interface ThemeController {
@@ -56,6 +57,7 @@ interface ResolvedEnvironment {
     readonly document?: Document;
     readonly storage?: ThemeStorage;
     readonly reducedMotion?: MediaQueryList;
+    readonly userAgent?: string;
 }
 
 export function createThemeController(
@@ -114,6 +116,10 @@ export function createThemeController(
         const targetDocument = activeEnvironment?.document;
         const startViewTransition = targetDocument?.startViewTransition;
         if (!targetDocument || typeof startViewTransition !== 'function') return false;
+        // WebKitGTK exposes the API, but a root view transition forces the
+        // page into accelerated compositing that the Wails Linux webview does
+        // not have: the view paints black or the transition never settles.
+        if (isLinuxWebKit(activeEnvironment?.userAgent)) return false;
 
         const generation = beginTransition(targetDocument, THEME_TRANSITION_CLASS, origin);
         let stateApplied = false;
@@ -254,7 +260,21 @@ function resolveEnvironment(environment: ThemeControllerEnvironment): ResolvedEn
         document: targetDocument,
         storage: environment.storage ?? getBrowserStorage(targetWindow),
         reducedMotion: environment.reducedMotion ?? queryMedia(targetWindow, REDUCED_MOTION_QUERY),
+        userAgent: environment.userAgent ?? targetWindow?.navigator?.userAgent,
     };
+}
+
+/**
+ * True for WebKitGTK/WPE (Wails and Tauri on Linux, Epiphany), which report
+ * `Linux` + `AppleWebKit` + `Safari` without a Chromium token. Chromium and
+ * test DOMs (happy-dom, jsdom) never carry the `Safari/` product token.
+ */
+export function isLinuxWebKit(userAgent: string | undefined): boolean {
+    if (!userAgent) return false;
+    return /\bLinux\b/.test(userAgent)
+        && /AppleWebKit\//.test(userAgent)
+        && /\bSafari\//.test(userAgent)
+        && !/\b(?:Chrome|Chromium|CriOS|Edg|OPR)\//.test(userAgent);
 }
 
 function getBrowserDocument(): Document | undefined {


### PR DESCRIPTION
Theme switch on the Linux AppImage (v1.7.0) turned the webview solid black: `document.startViewTransition()` forces WebKitGTK into accelerated compositing the Wails window doesn't have (same bug as block/buzz#5768, cc-switch#2502). Linux WebKit now takes the existing CSS fallback; other platforms unchanged.