### PR TITLE
fix: bump daemon protocol for personal-drive commands

### DIFF
--- a/backend/daemon/protocol.go
+++ b/backend/daemon/protocol.go
@@ -5,7 +5,15 @@ import (
 	"fmt"
 )
 
-const ProtocolVersion = 1
+// ProtocolVersion gates every request frame. The CLI reuses an already
+// running daemon, so an upgrade can leave a new CLI talking to a daemon from
+// the previous install. Bump this whenever commands or response shapes
+// change, so that pairing fails with a clear version error instead of an
+// obscure unknown-command one.
+//
+// 2: personal-drive setup commands, and AuthLoginResponse carries the setup
+// state instead of an InitDrive string (v1.7.1).
+const ProtocolVersion = 2
 
 const (
 	CommandStatus             = "daemon.status"

--- a/backend/daemon/protocol_version_test.go
+++ b/backend/daemon/protocol_version_test.go
@@ -1,0 +1,37 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+)
+
+// A daemon left running from an older install must reject a newer CLI by
+// version rather than by unknown command, so the fix is "restart the
+// daemon" rather than a puzzle.
+func TestValidateRequestRejectsForeignProtocolVersions(t *testing.T) {
+	for _, version := range []int{0, ProtocolVersion - 1, ProtocolVersion + 1} {
+		err := validateRequest(Request{Version: version, Command: CommandStatus})
+		if err == nil {
+			t.Fatalf("protocol version %d was accepted, want rejection", version)
+		}
+		if !strings.Contains(err.Error(), "unsupported daemon protocol version") {
+			t.Fatalf("version %d error = %q, want a version error", version, err)
+		}
+	}
+	if err := validateRequest(Request{Version: ProtocolVersion, Command: CommandStatus}); err != nil {
+		t.Fatalf("current protocol version rejected: %v", err)
+	}
+}
+
+// The personal-drive commands are what made the current version incompatible
+// with v1.7.0's daemon; they must ship inside the bumped version.
+func TestPersonalDriveCommandsRequireCurrentProtocolVersion(t *testing.T) {
+	if ProtocolVersion < 2 {
+		t.Fatalf("ProtocolVersion = %d, want >= 2 now that personal-drive commands exist", ProtocolVersion)
+	}
+	for _, command := range []string{CommandPersonalDrivePrepare, CommandPersonalDriveSelect, CommandPersonalDriveCreate} {
+		if err := validateRequest(Request{Version: ProtocolVersion, Command: command}); err != nil {
+			t.Fatalf("command %q rejected at current version: %v", command, err)
+		}
+	}
+}


### PR DESCRIPTION
#86 added `personal_drive.*` commands and changed `AuthLoginResponse`, but left `ProtocolVersion` at 1.

The CLI reuses an already-running daemon, so upgrading can leave a v1.7.1 CLI talking to a v1.7.0 daemon. At version 1 that daemon accepts the frame and then fails on an unknown command; bumped, it fails immediately with `unsupported daemon protocol version`, which points at the actual fix (restart the daemon).

Tests cover the rejection on both sides of the current version, and pin the personal-drive commands to a version >= 2.

- `go test ./...`