### PR TITLE
fix: reveal native video behind the themed root canvas

### DIFF
--- a/frontend/src/modules/modals/video.ts
+++ b/frontend/src/modules/modals/video.ts
@@ -18,6 +18,7 @@ import {
 import { EventsOn, WindowFullscreen, WindowIsFullscreen, WindowUnfullscreen } from "../../../wailsjs/runtime/runtime";
 import { formatBytes } from "../../utils";
 import { isWebviewDirectVideo, videoFormatLabel } from "../media-types";
+import { setNativeVideoLayerActive } from "../video/native-video-layer";
 import { installModalA11y } from "../../ui/modals/modal-a11y";
 import VideoModal from "../../ui/video/VideoModal.svelte";
 import { mountSvelte, type SvelteMountHandle } from "../../ui/mount";
@@ -586,7 +587,9 @@ function setChromeVisible(visible: boolean) {
 function setNativeMode(visible: boolean, fallback = false) {
     modalEl?.classList.toggle("is-video-native", visible);
     modalEl?.classList.toggle("is-video-native-fallback", visible && fallback);
-    document.body.classList.toggle("native-video-active", visible && !fallback);
+    // Only the overlay layout renders mpv underneath the WebView; the fallback
+    // layout puts a native child window on top and needs the canvas left alone.
+    setNativeVideoLayerActive(document, visible && !fallback);
     syncFallbackNativeViewportInsets();
 }
 

--- a/frontend/src/modules/video/native-video-layer.dom.test.ts
+++ b/frontend/src/modules/video/native-video-layer.dom.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { NATIVE_VIDEO_LAYER_CLASS, setNativeVideoLayerActive } from './native-video-layer';
+
+afterEach(() => {
+    setNativeVideoLayerActive(document, false);
+});
+
+describe('native video layer', () => {
+    it('clears the root canvas as well as the body while mpv renders underneath', () => {
+        setNativeVideoLayerActive(document, true);
+
+        // <html> matters as much as <body>: a themed background on the root
+        // element stops body transparency from reaching the page canvas, and
+        // the video disappears behind a flat --color-canvas rectangle.
+        expect(document.documentElement.classList.contains(NATIVE_VIDEO_LAYER_CLASS)).toBe(true);
+        expect(document.body.classList.contains(NATIVE_VIDEO_LAYER_CLASS)).toBe(true);
+    });
+
+    it('restores the app backdrop on both elements when playback ends', () => {
+        setNativeVideoLayerActive(document, true);
+        setNativeVideoLayerActive(document, false);
+
+        expect(document.documentElement.classList.contains(NATIVE_VIDEO_LAYER_CLASS)).toBe(false);
+        expect(document.body.classList.contains(NATIVE_VIDEO_LAYER_CLASS)).toBe(false);
+    });
+
+    it('is a no-op without a document, so teardown after unmount stays safe', () => {
+        expect(() => setNativeVideoLayerActive(undefined, false)).not.toThrow();
+    });
+});

--- a/frontend/src/modules/video/native-video-layer.ts
+++ b/frontend/src/modules/video/native-video-layer.ts
@@ -1,0 +1,18 @@
+/**
+ * macOS embeds libmpv as a sibling view *below* the transparent WebView so the
+ * HTML transport controls stay interactive on top of the picture. That only
+ * works while nothing in the document paints over the video: the marker class
+ * below drives the CSS that clears the page canvas.
+ *
+ * It has to land on <html> as well as <body>. A background on <body> alone
+ * propagates to the page canvas, so clearing <body> used to be enough - but the
+ * moment <html> carries a background of its own (the themed backdrop does),
+ * propagation stops and <html> paints an opaque rectangle over the video.
+ */
+export const NATIVE_VIDEO_LAYER_CLASS = "native-video-active";
+
+/** Reveals (or re-covers) the native renderer sitting behind the WebView. */
+export function setNativeVideoLayerActive(target: Document | undefined, active: boolean): void {
+    target?.documentElement?.classList.toggle(NATIVE_VIDEO_LAYER_CLASS, active);
+    target?.body?.classList.toggle(NATIVE_VIDEO_LAYER_CLASS, active);
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -92,7 +92,15 @@ html.theme-transition-fallback #app {
         animation: none;
     }
 }
-body.native-video-active { background-color: transparent; }
+/* macOS layers libmpv *below* the transparent WebView, so every element that
+   paints between the viewer and that view has to clear out or the video stays
+   hidden behind the app backdrop. Clear the whole root chain, not just <body>:
+   once <html> carries a themed background of its own, body transparency no
+   longer propagates to the page canvas and the video renders as a flat
+   --color-canvas rectangle. */
+html.native-video-active,
+html.native-video-active body,
+html.native-video-active #app { background: transparent; }
 body.native-video-active #auth-wrapper,
 body.native-video-active #success-screen,
 body.native-video-active #context-menu,

--- a/frontend/src/ui/theme/theme-style-contract.test.ts
+++ b/frontend/src/ui/theme/theme-style-contract.test.ts
@@ -12,6 +12,10 @@ function sectionBetween(startMarker: string, endMarker: string): string {
     return globalCss.slice(start, end);
 }
 
+function stripComments(css: string): string {
+    return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
 function ruleFor(selector: string): string {
     const start = globalCss.indexOf(`${selector} {`);
     if (start < 0) throw new Error(`missing CSS rule: ${selector}`);
@@ -24,6 +28,28 @@ function ruleFor(selector: string): string {
 }
 
 describe('global theme style contract', () => {
+    it('lets the themed backdrop step aside for the native video renderer', () => {
+        // macOS renders libmpv below the WebView, so anything left painting in
+        // the root chain hides the picture behind a flat themed rectangle. Each
+        // element that carries a background must be cleared while the marker
+        // class is set: clearing <body> alone is not enough, because giving
+        // <html> a background stops body transparency reaching the canvas.
+        const paintedBy = new Set<string>();
+        const clearedBy = new Set<string>();
+        for (const [, selectors, declarations] of stripComments(globalCss).matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+            const background = /(?:^|;)\s*background(?:-color|-image)?\s*:\s*([^;]+)/.exec(declarations)?.[1]?.trim();
+            if (!background) continue;
+            const target = /^(transparent|none)$/.test(background) ? clearedBy : paintedBy;
+            for (const selector of selectors.split(',')) target.add(selector.trim());
+        }
+
+        expect(paintedBy).toContain('html');
+        for (const selector of ['html', 'body', '#app']) {
+            if (!paintedBy.has(selector)) continue;
+            expect(clearedBy).toContain(`html.native-video-active ${selector}`.replace(' html', ''));
+        }
+    });
+
     it('keeps palette colors out of the lower-specificity bare root', () => {
         const root = /:root\s*\{([\s\S]*?)\n\}/.exec(globalCss)?.[1];
         expect(root).toBeDefined();


### PR DESCRIPTION
#76 gave <html> its own background, so the body-only transparency escape hatch stopped reaching the page canvas and mpv (which macOS layers below the WebView) was hidden behind a flat --color-canvas rectangle. Shipped broken in v1.7.0.

Clears the whole root chain instead, and adds a CSS contract test so a future palette change can't silently repaint over the video.