### PR TITLE
fix: scan the whole channel history instead of stopping at a short page

### DIFF
--- a/backend/mountadapter/remote.go
+++ b/backend/mountadapter/remote.go
@@ -355,7 +355,11 @@ func (remote *TelegramRemote) ReconcileReceipt(
 	if err != nil {
 		return mountwrite.MutationResult{}, false, err
 	}
-	if len(messages) != 1 || messages[0].MsgID != msgID {
+	// A placeholder means the commit message was deleted on Telegram, which is
+	// the same "no commit to reconcile against" case as it not being returned
+	// at all. Treating it as content would parse an empty caption and report a
+	// hard conflict instead of letting the caller retry.
+	if len(messages) != 1 || messages[0].MsgID != msgID || messages[0].Placeholder {
 		return mountwrite.MutationResult{}, false, nil
 	}
 	message := messages[0]

--- a/backend/projection/channels.go
+++ b/backend/projection/channels.go
@@ -167,16 +167,17 @@ func GetChannel(db *sql.DB, channelID int64) (Channel, error) {
 	var (
 		c                                                Channel
 		hasUnseen, initialSyncDone, personalBackfillDone int
+		needsRebuild                                     int
 	)
 	err := db.QueryRow(`
 		SELECT channel_id, access_hash, title, kind, COALESCE(invite_link, ''), joined_at,
 		       last_synced_msg, last_viewed_msg, has_unseen_content,
-		       initial_sync_done, personal_backfill_done
+		       initial_sync_done, personal_backfill_done, needs_projection_rebuild
 		FROM channels WHERE channel_id = ?
 	`, channelID).Scan(
 		&c.ChannelID, &c.AccessHash, &c.Title, &c.Kind, &c.InviteLink, &c.JoinedAt,
 		&c.LastSyncedMsg, &c.LastViewedMsg, &hasUnseen,
-		&initialSyncDone, &personalBackfillDone,
+		&initialSyncDone, &personalBackfillDone, &needsRebuild,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return Channel{}, fmt.Errorf("projection: channel %d not found", channelID)
@@ -187,6 +188,7 @@ func GetChannel(db *sql.DB, channelID int64) (Channel, error) {
 	c.HasUnseenContent = hasUnseen != 0
 	c.InitialSyncDone = initialSyncDone != 0
 	c.PersonalBackfillDone = personalBackfillDone != 0
+	c.NeedsProjectionRebuild = needsRebuild != 0
 	return c, nil
 }
 

--- a/backend/projection/rebuild.go
+++ b/backend/projection/rebuild.go
@@ -115,3 +115,25 @@ func rebuildProjectionTx(tx *sql.Tx, channelID int64) (applied, rejected int, er
 	}
 	return applied, rejected, nil
 }
+
+// RebuildProjectionTx replays a channel's whole replay_log inside a caller's
+// transaction, and clears the rebuild flag that requested it.
+//
+// A history scan that reaches ops it had never seen before cannot simply apply
+// them: ops already in the log were skipped as "already applied" the first time
+// round, including the renames and deletes that silently no-oped because their
+// target had not been read yet. Replaying the completed log from scratch is the
+// only way to land those in order. Sharing the caller's transaction keeps the
+// repair atomic with the scan that earned it.
+func RebuildProjectionTx(tx *sql.Tx, channelID int64) (applied, rejected int, err error) {
+	applied, rejected, err = rebuildProjectionTx(tx, channelID)
+	if err != nil {
+		return 0, 0, err
+	}
+	if _, err := tx.Exec(
+		`UPDATE channels SET needs_projection_rebuild = 0 WHERE channel_id = ?`, channelID,
+	); err != nil {
+		return 0, 0, fmt.Errorf("projection: clear rebuild flag: %w", err)
+	}
+	return applied, rejected, nil
+}

--- a/backend/projection/schema.go
+++ b/backend/projection/schema.go
@@ -28,7 +28,8 @@ func EnsureSchema(db *sql.DB) error {
 			last_viewed_msg        INTEGER NOT NULL DEFAULT 0,
 			has_unseen_content     INTEGER NOT NULL DEFAULT 0,
 			initial_sync_done      INTEGER NOT NULL DEFAULT 0,
-			personal_backfill_done INTEGER NOT NULL DEFAULT 0
+			personal_backfill_done INTEGER NOT NULL DEFAULT 0,
+			needs_projection_rebuild INTEGER NOT NULL DEFAULT 0
 		);`,
 		`CREATE TABLE IF NOT EXISTS replay_log (
 			channel_id      INTEGER NOT NULL,
@@ -337,7 +338,10 @@ func MigratePersonalChannel(db *sql.DB, personalChannelID int64) error {
 	}
 
 	if v < 9 {
-		if err := rescanTruncatedChannels(tx); err != nil {
+		if err := addChannelRebuildColumn(tx); err != nil {
+			return err
+		}
+		if err := flagTruncatedScansForRebuild(tx); err != nil {
 			return err
 		}
 	}
@@ -756,11 +760,16 @@ func tableColumnSet(tx *sql.Tx, name string) (map[string]struct{}, error) {
 	return out, rows.Err()
 }
 
-// danglingParentChannels selects channels holding a live row whose parent
-// folder has no record at all. A tombstoned parent is a real delete and is
-// deliberately not matched; only a wholly absent one means the mkdir that
-// would have created it was never read from the channel.
-const danglingParentChannels = `
+// truncatedScanChannels selects channels whose projection shows the signature
+// of a history scan that ended early: an op that landed while the object it
+// depends on had not been read yet.
+//
+// Two shapes, because the two op generations fail differently. Legacy mkdir and
+// file ops do not validate their parent, so they leave a live row pointing at a
+// folder that has no record. Writable ops do validate, so they leave no row at
+// all and show up only as a rejected op. A tombstoned parent is deliberately
+// not matched: that is a real delete, not a truncated scan.
+const truncatedScanChannels = `
 	SELECT channel_id FROM folders f
 	WHERE f.tombstoned = 0 AND f.parent_id <> ''
 	  AND NOT EXISTS (
@@ -771,34 +780,49 @@ const danglingParentChannels = `
 	WHERE f.tombstoned = 0 AND f.parent_id <> ''
 	  AND NOT EXISTS (
 	    SELECT 1 FROM folders p WHERE p.channel_id = f.channel_id AND p.id = f.parent_id
-	  )`
+	  )
+	UNION
+	SELECT channel_id FROM replay_log_rejects WHERE error LIKE '%' || ? || '%'`
 
-// rescanTruncatedChannels repairs drives left half-scanned by the history
-// pagination bug, where a page thinned by deletions ended the backwards walk
-// early and the channel was still marked authoritative at the newest id seen.
-// Such a drive keeps every row it did read but has no way back to the ops it
-// skipped, so folders orphaned below a missing ancestor stay invisible forever.
+// flagTruncatedScansForRebuild marks drives left half-scanned by the history
+// pagination bug so the next sync re-reads the channel in full and replays the
+// result from scratch.
 //
-// Clearing the watermark sends those channels back through a full scan. Ops
-// already in replay_log re-apply idempotently; the ones that were rejected for
-// a parent that had not been read yet are dropped from the log first, because
-// replay_log membership alone would otherwise make the scan skip them again.
-func rescanTruncatedChannels(tx *sql.Tx) error {
+// Clearing the watermark alone is not enough. An op whose target had not been
+// read yet did not fail: applyRename, applyMove and applyRmdir all issue an
+// UPDATE that matches no rows and returns nil, so the op sits in replay_log
+// marked as applied and ProjectFromOpTx skips it forever after. Rejected
+// writable ops are skipped the same way, by op_id in projection_operations.
+// Re-reading the missing ancestors would therefore restore the objects but
+// none of the renames, moves or deletes that followed them.
+//
+// The rebuild flag is consumed inside the scan's own transaction, so the drive
+// is either fully repaired or left exactly as it was.
+func flagTruncatedScansForRebuild(tx *sql.Tx) error {
 	if _, err := tx.Exec(`
-		DELETE FROM replay_log
-		WHERE (channel_id, msg_id) IN (SELECT channel_id, msg_id FROM replay_log_rejects)
-		  AND channel_id IN (` + danglingParentChannels + `)`); err != nil {
-		return fmt.Errorf("projection: clear rejected ops for rescan: %w", err)
+		UPDATE channels
+		SET last_synced_msg = 0, initial_sync_done = 0, needs_projection_rebuild = 1
+		WHERE channel_id IN (`+truncatedScanChannels+`)`, ErrObjectNotFound.Error()); err != nil {
+		return fmt.Errorf("projection: flag truncated history scan: %w", err)
 	}
-	if _, err := tx.Exec(`
-		DELETE FROM replay_log_rejects
-		WHERE channel_id IN (` + danglingParentChannels + `)`); err != nil {
-		return fmt.Errorf("projection: clear rejects for rescan: %w", err)
+	return nil
+}
+
+func addChannelRebuildColumn(tx *sql.Tx) error {
+	if !tableExists(tx, "channels") {
+		return nil
 	}
-	if _, err := tx.Exec(`
-		UPDATE channels SET last_synced_msg = 0, initial_sync_done = 0
-		WHERE channel_id IN (` + danglingParentChannels + `)`); err != nil {
-		return fmt.Errorf("projection: reset truncated history scan: %w", err)
+	cols, err := tableColumnSet(tx, "channels")
+	if err != nil {
+		return err
+	}
+	if _, present := cols["needs_projection_rebuild"]; present {
+		return nil
+	}
+	if _, err := tx.Exec(
+		`ALTER TABLE channels ADD COLUMN needs_projection_rebuild INTEGER NOT NULL DEFAULT 0`,
+	); err != nil {
+		return fmt.Errorf("projection: add channels.needs_projection_rebuild: %w", err)
 	}
 	return nil
 }

--- a/backend/projection/schema.go
+++ b/backend/projection/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const currentSchemaVersion = 8
+const currentSchemaVersion = 9
 
 func EnsureSchema(db *sql.DB) error {
 	if db == nil {
@@ -332,6 +332,12 @@ func MigratePersonalChannel(db *sql.DB, personalChannelID int64) error {
 	}
 	if v < 8 {
 		if err := migrateWritableProjection(tx); err != nil {
+			return err
+		}
+	}
+
+	if v < 9 {
+		if err := rescanTruncatedChannels(tx); err != nil {
 			return err
 		}
 	}
@@ -748,4 +754,51 @@ func tableColumnSet(tx *sql.Tx, name string) (map[string]struct{}, error) {
 		out[cname] = struct{}{}
 	}
 	return out, rows.Err()
+}
+
+// danglingParentChannels selects channels holding a live row whose parent
+// folder has no record at all. A tombstoned parent is a real delete and is
+// deliberately not matched; only a wholly absent one means the mkdir that
+// would have created it was never read from the channel.
+const danglingParentChannels = `
+	SELECT channel_id FROM folders f
+	WHERE f.tombstoned = 0 AND f.parent_id <> ''
+	  AND NOT EXISTS (
+	    SELECT 1 FROM folders p WHERE p.channel_id = f.channel_id AND p.id = f.parent_id
+	  )
+	UNION
+	SELECT channel_id FROM files f
+	WHERE f.tombstoned = 0 AND f.parent_id <> ''
+	  AND NOT EXISTS (
+	    SELECT 1 FROM folders p WHERE p.channel_id = f.channel_id AND p.id = f.parent_id
+	  )`
+
+// rescanTruncatedChannels repairs drives left half-scanned by the history
+// pagination bug, where a page thinned by deletions ended the backwards walk
+// early and the channel was still marked authoritative at the newest id seen.
+// Such a drive keeps every row it did read but has no way back to the ops it
+// skipped, so folders orphaned below a missing ancestor stay invisible forever.
+//
+// Clearing the watermark sends those channels back through a full scan. Ops
+// already in replay_log re-apply idempotently; the ones that were rejected for
+// a parent that had not been read yet are dropped from the log first, because
+// replay_log membership alone would otherwise make the scan skip them again.
+func rescanTruncatedChannels(tx *sql.Tx) error {
+	if _, err := tx.Exec(`
+		DELETE FROM replay_log
+		WHERE (channel_id, msg_id) IN (SELECT channel_id, msg_id FROM replay_log_rejects)
+		  AND channel_id IN (` + danglingParentChannels + `)`); err != nil {
+		return fmt.Errorf("projection: clear rejected ops for rescan: %w", err)
+	}
+	if _, err := tx.Exec(`
+		DELETE FROM replay_log_rejects
+		WHERE channel_id IN (` + danglingParentChannels + `)`); err != nil {
+		return fmt.Errorf("projection: clear rejects for rescan: %w", err)
+	}
+	if _, err := tx.Exec(`
+		UPDATE channels SET last_synced_msg = 0, initial_sync_done = 0
+		WHERE channel_id IN (` + danglingParentChannels + `)`); err != nil {
+		return fmt.Errorf("projection: reset truncated history scan: %w", err)
+	}
+	return nil
 }

--- a/backend/projection/types.go
+++ b/backend/projection/types.go
@@ -116,6 +116,10 @@ type Channel struct {
 	HasUnseenContent     bool
 	InitialSyncDone      bool
 	PersonalBackfillDone bool
+	// NeedsProjectionRebuild marks a drive whose replay_log is known to be
+	// missing history. The next full scan re-reads the channel and replays the
+	// completed log from scratch, then clears the flag.
+	NeedsProjectionRebuild bool
 }
 
 type Folder struct {

--- a/backend/sync/sync.go
+++ b/backend/sync/sync.go
@@ -395,9 +395,12 @@ func (e *Engine) planHistory(ctx context.Context, channelID int64, peer tgclient
 			PagesDone:    len(lowestPerPage),
 			MessagesDone: messages,
 		})
-		if len(page) < defaultPageSize {
-			break
-		}
+		// Only an empty page proves the channel is exhausted. A short page
+		// does not: Telegram returns fewer than the limit whenever the window
+		// it scanned is thinned by deletions or service events. Stopping on
+		// one silently truncated the scan, and because the caller then marks
+		// the channel authoritative at the highest id seen, every later pass
+		// starts above the history that was skipped and can never reach it.
 		if offsetID != 0 && lowestInPage >= offsetID {
 			return historyPlan{}, errHistoryPaginationNoProgress
 		}

--- a/backend/sync/sync.go
+++ b/backend/sync/sync.go
@@ -162,6 +162,18 @@ func (e *Engine) Incremental(ctx context.Context, channelID int64) error {
 }
 
 func (e *Engine) incrementalLocked(ctx context.Context, channelID int64) error {
+	// A drive flagged for rebuild cannot be moved forward from its watermark:
+	// the ops below it were never read, and the ones above were applied against
+	// objects that did not exist. It needs the full scan, which owns the repair.
+	channel, err := projection.GetChannel(e.db, channelID)
+	if err != nil {
+		return fmt.Errorf("sync: read channel authority: %w", err)
+	}
+	if channel.NeedsProjectionRebuild {
+		slog.Info("sync: rebuild pending, escalating to a full history scan", "channel_id", channelID)
+		return e.authoritativeLocked(ctx, channelID)
+	}
+
 	peer, err := e.peers.ResolvePeer(ctx, channelID)
 	if err != nil {
 		return fmt.Errorf("sync: resolve peer: %w", err)
@@ -267,18 +279,30 @@ func (e *Engine) EnsureAuthoritative(ctx context.Context, channelID int64) error
 	lk := e.lockFor(channelID)
 	lk.Lock()
 	defer lk.Unlock()
-	start := time.Now()
 
 	channel, err := projection.GetChannel(e.db, channelID)
 	if err != nil {
 		return fmt.Errorf("sync: read channel authority: %w", err)
 	}
-	if channel.InitialSyncDone {
+	// A pending rebuild means the log is known to be missing history, so the
+	// incremental path would refresh from a watermark that was never earned.
+	if channel.InitialSyncDone && !channel.NeedsProjectionRebuild {
 		slog.Debug("sync: channel already authoritative, running incremental refresh", "channel_id", channelID)
 		return e.incrementalLocked(ctx, channelID)
 	}
+	return e.authoritativeLocked(ctx, channelID)
+}
+
+// authoritativeLocked runs the full-history scan. The caller must already hold
+// the channel lock.
+func (e *Engine) authoritativeLocked(ctx context.Context, channelID int64) error {
+	start := time.Now()
 	slog.Info("sync: establishing authoritative full history scan", "channel_id", channelID)
 
+	channel, err := projection.GetChannel(e.db, channelID)
+	if err != nil {
+		return fmt.Errorf("sync: read channel authority: %w", err)
+	}
 	parseOpts, err := parseOptionsForChannel(e.db, channelID)
 	if err != nil {
 		return err
@@ -310,7 +334,7 @@ func (e *Engine) EnsureAuthoritative(ctx context.Context, channelID int64) error
 		slog.Info("sync: authoritative scan found no history", "channel_id", channelID, "elapsed", time.Since(start))
 		return markInitialSyncDone(e.db, channelID, 0)
 	}
-	err = e.applyInitialHistoryPlan(ctx, channelID, peer, 0, plan, parseOpts)
+	err = e.applyInitialHistoryPlan(ctx, channelID, peer, 0, plan, parseOpts, channel.NeedsProjectionRebuild)
 	if err != nil {
 		slog.Error("sync: authoritative scan failed", "channel_id", channelID, "elapsed", time.Since(start), "error", err)
 		return err
@@ -356,7 +380,7 @@ func (e *Engine) InitialSyncEmptyChannel(ctx context.Context, channelID int64) e
 		slog.Info("sync: initial sync found no history", "channel_id", channelID, "elapsed", time.Since(start))
 		return markInitialSyncDone(e.db, channelID, watermark)
 	}
-	err = e.applyInitialHistoryPlan(ctx, channelID, peer, watermark, plan, parseOpts)
+	err = e.applyInitialHistoryPlan(ctx, channelID, peer, watermark, plan, parseOpts, false)
 	if err != nil {
 		slog.Error("sync: initial sync failed", "channel_id", channelID, "elapsed", time.Since(start), "error", err)
 		return err
@@ -483,7 +507,7 @@ func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgc
 	return nil
 }
 
-func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan, parseOpts ParseOptions) error {
+func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan, parseOpts ParseOptions, rebuild bool) error {
 	tx, err := e.db.Begin()
 	if err != nil {
 		return fmt.Errorf("sync: begin initial projection: %w", err)
@@ -519,6 +543,18 @@ func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, p
 		e.applyProgress(channelID, plan, i, messagesDone)
 	}
 
+	// The scan has now read everything the log was missing, but the ops that
+	// depended on those objects were banked as applied the first time round and
+	// were skipped again just now. Replaying the completed log from scratch is
+	// what actually lands them, and doing it here keeps repair and scan atomic.
+	if rebuild {
+		applied, rejected, err := projection.RebuildProjectionTx(tx, channelID)
+		if err != nil {
+			return fmt.Errorf("sync: rebuild projection after full scan: %w", err)
+		}
+		slog.Info("sync: rebuilt projection from the completed log", "channel_id", channelID,
+			"applied", applied, "rejected", rejected)
+	}
 	if err := markInitialSyncDoneTx(tx, channelID, plan.highestSeen); err != nil {
 		return err
 	}

--- a/backend/sync/truncated_history_test.go
+++ b/backend/sync/truncated_history_test.go
@@ -91,27 +91,92 @@ func TestEnsureAuthoritativeScansPastPagesThinnedByDeletions(t *testing.T) {
 	}
 }
 
+// TestFullScanRepairsOpsBankedAgainstUnreadObjects is the reported drive's
+// exact shape. A rename landed while the folder it targets had not been read,
+// so applyRename updated no rows, returned nil, and the op was banked in
+// replay_log as applied. Re-reading the mkdir alone therefore restores the
+// folder under its original name; only replaying the completed log applies the
+// rename that followed.
+func TestFullScanRepairsOpsBankedAgainstUnreadObjects(t *testing.T) {
+	db, _, _ := newSyncEnv(t)
+
+	mkdir := projection.Op{Type: projection.OpMkdir, Obj: "d:autodesk", Parent: projection.RootParent, Name: "Software"}
+	rename := projection.Op{Type: projection.OpRename, Obj: "d:autodesk", Name: "Autodesk"}
+
+	// The truncated scan read only the rename, which silently did nothing.
+	if _, err := projection.ProjectFromOp(db, testChan, 2411, rename, 7, projection.Format(rename)); err != nil {
+		t.Fatalf("seed banked rename: %v", err)
+	}
+	var folders int
+	if err := db.QueryRow(`SELECT count(*) FROM folders WHERE channel_id = ?`, testChan).Scan(&folders); err != nil {
+		t.Fatalf("count folders: %v", err)
+	}
+	if folders != 0 {
+		t.Fatalf("seeded folders = %d, want the rename to have been a silent no-op", folders)
+	}
+	if _, err := db.Exec(
+		`UPDATE channels SET last_synced_msg = 0, initial_sync_done = 0, needs_projection_rebuild = 1
+		 WHERE channel_id = ?`, testChan); err != nil {
+		t.Fatalf("flag rebuild: %v", err)
+	}
+
+	live := []tgclient.HistoryMessage{
+		{MsgID: 10, Text: projection.Format(mkdir)},
+		{MsgID: 2411, Text: projection.Format(rename)},
+	}
+	engine := NewEngine(db, &shortPagePager{Fake: tgclient.NewFake(7), live: live, pageCap: 60}, fakePeers{})
+	if err := engine.EnsureAuthoritative(context.Background(), testChan); err != nil {
+		t.Fatalf("EnsureAuthoritative() error = %v", err)
+	}
+
+	var name string
+	if err := db.QueryRow(
+		`SELECT name FROM folders WHERE channel_id = ? AND id = 'd:autodesk' AND tombstoned = 0`,
+		testChan).Scan(&name); err != nil {
+		t.Fatalf("folder missing after repair: %v", err)
+	}
+	if name != "Autodesk" {
+		t.Fatalf("folder name = %q, want the banked rename replayed as %q", name, "Autodesk")
+	}
+
+	channel, err := projection.GetChannel(db, testChan)
+	if err != nil {
+		t.Fatalf("GetChannel() error = %v", err)
+	}
+	if channel.NeedsProjectionRebuild {
+		t.Fatal("rebuild flag survived the repair, so every later sync would rescan")
+	}
+}
+
 // TestRescanTruncatedChannelsClearsWatermarkForOrphanedDrives covers the repair
 // path for drives already left half-scanned by the old pagination, which cannot
 // heal on their own: the channel reads as fully synced, so every later pass
 // starts above the history it skipped.
 func TestRescanTruncatedChannelsClearsWatermarkForOrphanedDrives(t *testing.T) {
-	orphaned := seedScannedChannel(t, 4384929171, "d:present", "d:never-read")
-	if orphaned.LastSyncedMsg != 0 || orphaned.InitialSyncDone {
-		t.Fatalf("orphaned drive = %#v, want watermark cleared for a full rescan", orphaned)
+	orphaned := seedScannedChannel(t, 4384929171, "d:never-read", false)
+	if orphaned.LastSyncedMsg != 0 || orphaned.InitialSyncDone || !orphaned.NeedsProjectionRebuild {
+		t.Fatalf("orphaned drive = %#v, want it flagged for a full rescan", orphaned)
+	}
+
+	// A writable-op drive rejects rather than orphaning, so it leaves no dangling
+	// row and is recognised only by the rejected op it recorded.
+	rejected := seedScannedChannel(t, 4384929173, "", true)
+	if rejected.LastSyncedMsg != 0 || rejected.InitialSyncDone || !rejected.NeedsProjectionRebuild {
+		t.Fatalf("writable-op drive = %#v, want it flagged for a full rescan", rejected)
 	}
 
 	// A tombstoned parent is a real delete, not a truncated scan. Those drives
 	// must keep their watermark instead of re-reading the whole channel.
-	deleted := seedScannedChannel(t, 4384929172, "d:present", "d:tombstoned")
-	if deleted.LastSyncedMsg != 2458 || !deleted.InitialSyncDone {
-		t.Fatalf("deleted-folder drive = %#v, want watermark preserved", deleted)
+	deleted := seedScannedChannel(t, 4384929172, "d:tombstoned", false)
+	if deleted.LastSyncedMsg != 2458 || !deleted.InitialSyncDone || deleted.NeedsProjectionRebuild {
+		t.Fatalf("deleted-folder drive = %#v, want it left alone", deleted)
 	}
 }
 
 // seedScannedChannel builds a pre-migration drive whose live child hangs off
-// parentID, then migrates it and reports the resulting channel row.
-func seedScannedChannel(t *testing.T, channelID int64, presentID, parentID string) projection.Channel {
+// parentID, optionally with a rejected op instead, then migrates it and reports
+// the resulting channel row.
+func seedScannedChannel(t *testing.T, channelID int64, parentID string, rejectedOp bool) projection.Channel {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -128,12 +193,17 @@ func seedScannedChannel(t *testing.T, channelID int64, presentID, parentID strin
 		channelID); err != nil {
 		t.Fatalf("seed channel: %v", err)
 	}
-	if _, err := db.Exec(
+	if rejectedOp {
+		if _, err := db.Exec(
+			`INSERT INTO replay_log_rejects (channel_id, msg_id, error, detected_at)
+			 VALUES (?, 2403, 'projection: object not found', 0)`, channelID); err != nil {
+			t.Fatalf("seed rejected op: %v", err)
+		}
+	} else if _, err := db.Exec(
 		`INSERT INTO folders (channel_id, id, name, parent_id, tombstoned) VALUES
-		   (?, ?, 'Present', '', 0),
 		   (?, 'd:tombstoned', 'Deleted', '', 1),
 		   (?, 'd:child', 'Orphan', ?, 0)`,
-		channelID, presentID, channelID, channelID, parentID); err != nil {
+		channelID, channelID, parentID); err != nil {
 		t.Fatalf("seed folders: %v", err)
 	}
 	if _, err := db.Exec(`DELETE FROM schema_version; INSERT INTO schema_version (version) VALUES (8)`); err != nil {

--- a/backend/sync/truncated_history_test.go
+++ b/backend/sync/truncated_history_test.go
@@ -1,0 +1,151 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"TDrive/backend/projection"
+	"TDrive/backend/tgclient"
+)
+
+// shortPagePager serves real history but hands back fewer messages per call
+// than asked for, which is what Telegram does whenever the window it scanned is
+// thinned by deletions or service events. Only an empty page means the channel
+// is exhausted, so a caller that stops on a short one silently loses the rest.
+type shortPagePager struct {
+	*tgclient.Fake
+	live    []tgclient.HistoryMessage // ascending by MsgID
+	pageCap int
+}
+
+func (pager *shortPagePager) GetHistory(
+	_ context.Context,
+	_ tgclient.InputPeer,
+	minID, offsetID int64,
+	limit int,
+) ([]tgclient.HistoryMessage, error) {
+	if pager.pageCap < limit {
+		limit = pager.pageCap
+	}
+	page := make([]tgclient.HistoryMessage, 0, limit)
+	for index := len(pager.live) - 1; index >= 0 && len(page) < limit; index-- {
+		msg := pager.live[index]
+		if msg.MsgID <= minID || (offsetID != 0 && msg.MsgID >= offsetID) {
+			continue
+		}
+		page = append(page, msg)
+	}
+	return page, nil
+}
+
+// TestEnsureAuthoritativeScansPastPagesThinnedByDeletions reproduces the drive
+// reported in issue #88. A stretch of deleted messages sits between the newest
+// history and the mkdir that creates the root folder. The scan used to stop at
+// the short page, mark the channel authoritative at the newest id it had seen,
+// and strand every folder below the ancestor it never read.
+func TestEnsureAuthoritativeScansPastPagesThinnedByDeletions(t *testing.T) {
+	db, _, _ := newSyncEnv(t)
+
+	root := projection.Op{Type: projection.OpMkdir, Obj: "d:root", Parent: projection.RootParent, Name: "New Volume"}
+	child := projection.Op{Type: projection.OpMkdir, Obj: "d:child", Parent: "d:root", Name: "Revit"}
+
+	// The ancestor mkdir is the oldest message in the channel; the child that
+	// depends on it sits near the newest. Anything that stops paging before
+	// reaching msg 10 keeps the child and strands it under a parent that has
+	// no record, which is exactly what the reported drive looked like.
+	live := []tgclient.HistoryMessage{{MsgID: 10, Text: projection.Format(root)}}
+	for id := int64(201); id <= 300; id++ {
+		msg := tgclient.HistoryMessage{MsgID: id}
+		if id == 260 {
+			msg.Text = projection.Format(child)
+		}
+		live = append(live, msg)
+	}
+
+	engine := NewEngine(db, &shortPagePager{Fake: tgclient.NewFake(7), live: live, pageCap: 60}, fakePeers{})
+	if err := engine.EnsureAuthoritative(context.Background(), testChan); err != nil {
+		t.Fatalf("EnsureAuthoritative() error = %v", err)
+	}
+
+	for _, folder := range []struct{ id, name string }{{"d:root", "New Volume"}, {"d:child", "Revit"}} {
+		var name string
+		err := db.QueryRow(
+			`SELECT name FROM folders WHERE channel_id = ? AND id = ? AND tombstoned = 0`,
+			testChan, folder.id,
+		).Scan(&name)
+		if err != nil {
+			t.Fatalf("folder %s missing after full scan: %v", folder.id, err)
+		}
+		if name != folder.name {
+			t.Fatalf("folder %s name = %q, want %q", folder.id, name, folder.name)
+		}
+	}
+
+	channel, err := projection.GetChannel(db, testChan)
+	if err != nil {
+		t.Fatalf("GetChannel() error = %v", err)
+	}
+	if !channel.InitialSyncDone || channel.LastSyncedMsg != 300 {
+		t.Fatalf("channel state = %#v, want authoritative through 300", channel)
+	}
+}
+
+// TestRescanTruncatedChannelsClearsWatermarkForOrphanedDrives covers the repair
+// path for drives already left half-scanned by the old pagination, which cannot
+// heal on their own: the channel reads as fully synced, so every later pass
+// starts above the history it skipped.
+func TestRescanTruncatedChannelsClearsWatermarkForOrphanedDrives(t *testing.T) {
+	orphaned := seedScannedChannel(t, 4384929171, "d:present", "d:never-read")
+	if orphaned.LastSyncedMsg != 0 || orphaned.InitialSyncDone {
+		t.Fatalf("orphaned drive = %#v, want watermark cleared for a full rescan", orphaned)
+	}
+
+	// A tombstoned parent is a real delete, not a truncated scan. Those drives
+	// must keep their watermark instead of re-reading the whole channel.
+	deleted := seedScannedChannel(t, 4384929172, "d:present", "d:tombstoned")
+	if deleted.LastSyncedMsg != 2458 || !deleted.InitialSyncDone {
+		t.Fatalf("deleted-folder drive = %#v, want watermark preserved", deleted)
+	}
+}
+
+// seedScannedChannel builds a pre-migration drive whose live child hangs off
+// parentID, then migrates it and reports the resulting channel row.
+func seedScannedChannel(t *testing.T, channelID int64, presentID, parentID string) projection.Channel {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	// Build the current schema, seed the half-scanned state into it, then wind
+	// the recorded version back so the repair migration runs over it.
+	if err := projection.MigratePersonalChannel(db, channelID); err != nil {
+		t.Fatalf("build schema: %v", err)
+	}
+	if _, err := db.Exec(
+		`UPDATE channels SET last_synced_msg = 2458, initial_sync_done = 1 WHERE channel_id = ?`,
+		channelID); err != nil {
+		t.Fatalf("seed channel: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO folders (channel_id, id, name, parent_id, tombstoned) VALUES
+		   (?, ?, 'Present', '', 0),
+		   (?, 'd:tombstoned', 'Deleted', '', 1),
+		   (?, 'd:child', 'Orphan', ?, 0)`,
+		channelID, presentID, channelID, channelID, parentID); err != nil {
+		t.Fatalf("seed folders: %v", err)
+	}
+	if _, err := db.Exec(`DELETE FROM schema_version; INSERT INTO schema_version (version) VALUES (8)`); err != nil {
+		t.Fatalf("rewind schema version: %v", err)
+	}
+
+	if err := projection.MigratePersonalChannel(db, channelID); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	channel, err := projection.GetChannel(db, channelID)
+	if err != nil {
+		t.Fatalf("GetChannel() error = %v", err)
+	}
+	return channel
+}

--- a/backend/tgclient/client.go
+++ b/backend/tgclient/client.go
@@ -172,6 +172,11 @@ type Client interface {
 	// default history order: newest first. minID filters out messages at or
 	// below that watermark; offsetID pages older than a previous page.
 	// Callers must sort before applying projection ops.
+	//
+	// Every message Telegram returns is reported, including service messages
+	// and the empty placeholders left by deletions. Those carry no projectable
+	// payload, but they do occupy message ids, so silently dropping them would
+	// make a full page look short and mislead callers paginating on page size.
 	GetHistory(ctx context.Context, peer InputPeer, minID, offsetID int64, limit int) ([]HistoryMessage, error)
 
 	// GetFileDocument resolves one Telegram message into a downloadable

--- a/backend/tgclient/client.go
+++ b/backend/tgclient/client.go
@@ -76,6 +76,11 @@ type HistoryMessage struct {
 	DocumentName       string
 	DocumentAccessHash int64
 	Thumbs             []FileThumb
+	// Placeholder marks an entry that occupies a message id but carries no
+	// content: a service event, or the stub left where a message was deleted.
+	// It is reported so page lengths match what Telegram sent, and callers
+	// looking for real content must skip it.
+	Placeholder bool
 }
 
 // SendFileResult is what SendFile returns. We split it from a bare msgID

--- a/backend/tgclient/gotd.go
+++ b/backend/tgclient/gotd.go
@@ -333,6 +333,21 @@ func (g *Gotd) SendFileWithRandomID(ctx context.Context, peer InputPeer, r io.Re
 	return result, err
 }
 
+// placeholderMessage reports the id of a history entry that carries no
+// projectable payload: a service event, or the stub Telegram substitutes for a
+// deleted message. Only the id is meaningful, and it is what lets a caller keep
+// paging backwards past a stretch of them.
+func placeholderMessage(msg tg.MessageClass) (msgID int64, date int64, ok bool) {
+	switch m := msg.(type) {
+	case *tg.MessageService:
+		return int64(m.ID), int64(m.Date), true
+	case *tg.MessageEmpty:
+		return int64(m.ID), 0, true
+	default:
+		return 0, 0, false
+	}
+}
+
 func (g *Gotd) GetHistory(ctx context.Context, peer InputPeer, minID, offsetID int64, limit int) ([]HistoryMessage, error) {
 	if limit <= 0 {
 		limit = 100
@@ -363,6 +378,14 @@ func (g *Gotd) GetHistory(ctx context.Context, peer InputPeer, minID, offsetID i
 		for _, msg := range messages {
 			fullMsg, ok := msg.(*tg.Message)
 			if !ok {
+				// Service messages and the placeholders left behind by
+				// deletions hold nothing to project, but they still consume
+				// message ids. Report them so callers paginating on page size
+				// can tell a page thinned by deletions from the end of the
+				// channel, and so backwards paging can step over a run of them.
+				if id, date, ok := placeholderMessage(msg); ok {
+					out = append(out, HistoryMessage{MsgID: id, Date: date})
+				}
 				continue
 			}
 			text := strings.TrimRight(fullMsg.Message, "\r\n")

--- a/backend/tgclient/gotd.go
+++ b/backend/tgclient/gotd.go
@@ -383,8 +383,11 @@ func (g *Gotd) GetHistory(ctx context.Context, peer InputPeer, minID, offsetID i
 				// message ids. Report them so callers paginating on page size
 				// can tell a page thinned by deletions from the end of the
 				// channel, and so backwards paging can step over a run of them.
-				if id, date, ok := placeholderMessage(msg); ok {
-					out = append(out, HistoryMessage{MsgID: id, Date: date})
+				// A non-positive id cannot be paged from, so reporting one
+				// would let a caller reset its cursor and walk the same pages
+				// forever. Those are dropped as before.
+				if id, date, ok := placeholderMessage(msg); ok && id > 0 {
+					out = append(out, HistoryMessage{MsgID: id, Date: date, Placeholder: true})
 				}
 				continue
 			}

--- a/backend/tgclient/history_placeholder_test.go
+++ b/backend/tgclient/history_placeholder_test.go
@@ -1,0 +1,33 @@
+package tgclient
+
+import (
+	"testing"
+
+	"github.com/gotd/td/tg"
+)
+
+// Telegram returns service events and deletion stubs alongside real messages,
+// and they count against the page limit it was given. Reporting them keeps a
+// page's length equal to what Telegram actually sent, so a caller paging on
+// page size cannot mistake a thinned page for the end of the channel.
+func TestPlaceholderMessageReportsIDsThatOccupyHistorySlots(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		msg      tg.MessageClass
+		wantID   int64
+		wantDate int64
+		wantOK   bool
+	}{
+		{"service event", &tg.MessageService{ID: 1942, Date: 1787832319}, 1942, 1787832319, true},
+		{"deleted message stub", &tg.MessageEmpty{ID: 2403}, 2403, 0, true},
+		{"real message is not a placeholder", &tg.Message{ID: 2458}, 0, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			id, date, ok := placeholderMessage(tc.msg)
+			if ok != tc.wantOK || id != tc.wantID || date != tc.wantDate {
+				t.Fatalf("placeholderMessage() = (%d, %d, %v), want (%d, %d, %v)",
+					id, date, ok, tc.wantID, tc.wantDate, tc.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #88.

`planHistory` stopped the backwards walk on any page shorter than the limit, but Telegram returns short pages whenever the window it scanned is thinned by deletions or service events. The scan then marked the channel authoritative at the newest id it had seen, so later passes started above the skipped history and could never reach it. The reporter's drive read only msgs 1942 to 2458 of his channel: 241 folders and 149 files survived, but three ancestor mkdirs sat below 1942, stranding 67 folders and 59.9 GB under parents that had no record.

**Scan**
- `planHistory` stops only on an empty page.
- `GetHistory` reports service messages and deletion stubs, marked `Placeholder`, so a page's length matches what Telegram sent. Ids of zero or less are still dropped, since paging from one would reset the cursor and loop forever.
- `mountadapter` skips placeholders, so a deleted commit message stays the retryable "not committed yet" instead of becoming a hard conflict.

**Repair**
Clearing the watermark is not enough on its own. An op whose target had not been read yet did not fail: `applyRename`, `applyMove` and `applyRmdir` all issue an UPDATE that matches no rows and returns nil, so the op sits in `replay_log` marked as applied and `ProjectFromOpTx` skips it forever after. Rejected writable ops are skipped the same way, by `op_id` in `projection_operations`. Re-reading the missing ancestors alone would restore the objects but none of the renames, moves or deletes that followed them.

So schema v9 flags affected drives instead, and the full scan consumes the flag by replaying the completed log through the existing `rebuildProjectionTx`, inside the scan's own transaction. The drive is either fully repaired or left exactly as it was. Detection covers both op generations: legacy ops leave a live row under an absent parent, writable ops leave only a rejected op. A tombstoned parent is never matched, since that is a real delete.

Verified against the reporter's actual database: detection matches his channel, and he has 15 moves, trashes, tombs and renames that the watermark reset alone would have replayed incorrectly.
