### PR TITLE
Fix legacy folder-download filename aliases

### DIFF
--- a/backend/projection/namespace.go
+++ b/backend/projection/namespace.go
@@ -70,6 +70,10 @@ func objectKind(objectID string) (string, error) {
 }
 
 func legacyPortableName(name, kind, objectID string) string {
+	return buildLegacyPortableName(name, kind == "file")
+}
+
+func buildLegacyPortableName(name string, preserveFileExtension bool) string {
 	name = norm.NFC.String(strings.ToValidUTF8(name, "_"))
 	var b strings.Builder
 	for _, r := range name {
@@ -89,7 +93,17 @@ func legacyPortableName(name, kind, objectID string) string {
 	}
 	// A leading underscore also makes Windows device basenames portable.
 	candidate = "_" + candidate
+	if preserveFileExtension {
+		stem, extension := splitLegacyFileExtension(candidate)
+		return truncatePortableName(stem, extension)
+	}
 	return truncatePortableName(candidate, "")
+}
+
+// legacyPortableNameV8 preserves the original v8 truncation order so the v10
+// migration can recognize aliases already stored by that release.
+func legacyPortableNameV8(name string) string {
+	return buildLegacyPortableName(name, false)
 }
 
 func legacyCollisionAlias(name, kind, objectID string, attempt int) string {

--- a/backend/projection/namespace.go
+++ b/backend/projection/namespace.go
@@ -94,16 +94,38 @@ func legacyPortableName(name, kind, objectID string) string {
 
 func legacyCollisionAlias(name, kind, objectID string, attempt int) string {
 	base := legacyPortableName(name, kind, objectID)
+	suffix := legacyCollisionSuffix(kind, objectID, attempt)
+	if kind != "file" {
+		return truncatePortableName(base, suffix)
+	}
+	stem, extension := splitLegacyFileExtension(base)
+	return truncatePortableName(stem, suffix+extension)
+}
+
+func legacyCollisionSuffix(kind, objectID string, attempt int) string {
+	if attempt > 0 {
+		return fmt.Sprintf(" (%s %s-%d)", kind, legacyCollisionToken(objectID), attempt)
+	}
+	return fmt.Sprintf(" (%s %s)", kind, legacyCollisionToken(objectID))
+}
+
+func legacyCollisionToken(objectID string) string {
 	token := strings.TrimPrefix(objectID, FileIDPrefix)
 	token = strings.TrimPrefix(token, FolderIDPrefix)
 	if len(token) > 12 {
 		token = token[len(token)-12:]
 	}
-	suffix := fmt.Sprintf(" (%s %s)", kind, token)
-	if attempt > 0 {
-		suffix = fmt.Sprintf(" (%s %s-%d)", kind, token, attempt)
+	return token
+}
+
+// splitLegacyFileExtension identifies the short final extension whose placement
+// must survive a collision alias.
+func splitLegacyFileExtension(name string) (stem, extension string) {
+	dot := strings.LastIndexByte(name, '.')
+	if dot <= 0 || len(name)-dot > 32 {
+		return name, ""
 	}
-	return truncatePortableName(base, suffix)
+	return name[:dot], name[dot:]
 }
 
 func truncatePortableName(name, suffix string) string {

--- a/backend/projection/schema.go
+++ b/backend/projection/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const currentSchemaVersion = 9
+const currentSchemaVersion = 10
 
 func EnsureSchema(db *sql.DB) error {
 	if db == nil {
@@ -342,6 +342,11 @@ func MigratePersonalChannel(db *sql.DB, personalChannelID int64) error {
 			return err
 		}
 		if err := flagTruncatedScansForRebuild(tx); err != nil {
+			return err
+		}
+	}
+	if v < 10 {
+		if err := repairLegacyCollisionAliasExtensions(tx); err != nil {
 			return err
 		}
 	}

--- a/backend/projection/writable_schema.go
+++ b/backend/projection/writable_schema.go
@@ -258,7 +258,7 @@ func legacyCollisionAliasV8Attempt(name, kind, objectID, displayName string) (in
 }
 
 func legacyCollisionAliasV8(name, kind, objectID string, attempt int) string {
-	base := legacyPortableName(name, kind, objectID)
+	base := legacyPortableNameV8(name)
 	return truncatePortableName(base, legacyCollisionSuffix(kind, objectID, attempt))
 }
 

--- a/backend/projection/writable_schema.go
+++ b/backend/projection/writable_schema.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
+	"strings"
 )
 
 func migrateWritableProjection(tx *sql.Tx) error {
@@ -167,6 +169,134 @@ func insertLegacyDirent(tx *sql.Tx, entry legacyDirentRow) error {
 		}
 		return nil
 	}
+}
+
+type legacyCollisionAliasDirent struct {
+	channelID   int64
+	objectID    string
+	parentID    string
+	displayName string
+	sourceName  string
+}
+
+// repairLegacyCollisionAliasExtensions repairs only aliases that v8 generated
+// from the file's current source name and immutable logical ID. Matching the
+// old generated form exactly leaves any user-authored lookalike untouched.
+func repairLegacyCollisionAliasExtensions(tx *sql.Tx) error {
+	rows, err := tx.Query(`
+		SELECT d.channel_id, d.object_id, d.parent_id, d.display_name, f.name
+		FROM dirents d
+		JOIN files f
+		  ON f.channel_id=d.channel_id AND d.object_id='f:' || CAST(f.msg_id AS TEXT)
+		WHERE d.object_kind='file' AND d.tombstoned=0 AND f.tombstoned=0
+		ORDER BY d.channel_id, d.parent_id, d.object_id
+	`)
+	if err != nil {
+		return fmt.Errorf("projection: read legacy collision aliases: %w", err)
+	}
+	var entries []legacyCollisionAliasDirent
+	for rows.Next() {
+		var entry legacyCollisionAliasDirent
+		if err := rows.Scan(
+			&entry.channelID, &entry.objectID, &entry.parentID,
+			&entry.displayName, &entry.sourceName,
+		); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("projection: scan legacy collision alias: %w", err)
+		}
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("projection: iterate legacy collision aliases: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("projection: close legacy collision aliases: %w", err)
+	}
+
+	for _, entry := range entries {
+		attempt, generated := legacyCollisionAliasV8Attempt(
+			entry.sourceName, "file", entry.objectID, entry.displayName,
+		)
+		if !generated {
+			continue
+		}
+		name, key, err := allocateRepairedLegacyCollisionAlias(tx, entry, attempt)
+		if err != nil {
+			return err
+		}
+		if name == entry.displayName {
+			continue
+		}
+		if _, err := tx.Exec(`
+			UPDATE dirents SET display_name=?, name_key=?
+			WHERE channel_id=? AND object_id=? AND tombstoned=0 AND display_name=?
+		`, name, key, entry.channelID, entry.objectID, entry.displayName); err != nil {
+			return fmt.Errorf("projection: repair legacy collision alias %s: %w", entry.objectID, err)
+		}
+	}
+	return nil
+}
+
+func legacyCollisionAliasV8Attempt(name, kind, objectID, displayName string) (int, bool) {
+	if displayName == legacyCollisionAliasV8(name, kind, objectID, 0) {
+		return 0, true
+	}
+	prefix := fmt.Sprintf(" (%s %s-", kind, legacyCollisionToken(objectID))
+	if !strings.HasSuffix(displayName, ")") {
+		return 0, false
+	}
+	start := strings.LastIndex(displayName, prefix)
+	if start < 0 {
+		return 0, false
+	}
+	attempt, err := strconv.Atoi(displayName[start+len(prefix) : len(displayName)-1])
+	if err != nil || attempt <= 0 || displayName != legacyCollisionAliasV8(name, kind, objectID, attempt) {
+		return 0, false
+	}
+	return attempt, true
+}
+
+func legacyCollisionAliasV8(name, kind, objectID string, attempt int) string {
+	base := legacyPortableName(name, kind, objectID)
+	return truncatePortableName(base, legacyCollisionSuffix(kind, objectID, attempt))
+}
+
+func allocateRepairedLegacyCollisionAlias(
+	tx *sql.Tx,
+	entry legacyCollisionAliasDirent,
+	firstAttempt int,
+) (string, string, error) {
+	var siblings int
+	if err := tx.QueryRow(`
+		SELECT COUNT(*) FROM dirents
+		WHERE channel_id=? AND parent_id=? AND tombstoned=0
+	`, entry.channelID, entry.parentID).Scan(&siblings); err != nil {
+		return "", "", fmt.Errorf("projection: count legacy alias siblings: %w", err)
+	}
+	for offset := 0; offset <= siblings; offset++ {
+		attempt := firstAttempt + offset
+		if attempt < firstAttempt {
+			break
+		}
+		name := legacyCollisionAlias(entry.sourceName, "file", entry.objectID, attempt)
+		key, err := CanonicalNameKey(name)
+		if err != nil {
+			return "", "", fmt.Errorf("projection: canonicalize repaired legacy alias %q: %w", name, err)
+		}
+		var owner string
+		err = tx.QueryRow(`
+			SELECT object_id FROM dirents
+			WHERE channel_id=? AND parent_id=? AND name_key=? AND tombstoned=0
+		`, entry.channelID, entry.parentID, key).Scan(&owner)
+		if errors.Is(err, sql.ErrNoRows) || owner == entry.objectID {
+			return name, key, nil
+		}
+		if err != nil {
+			return "", "", fmt.Errorf("projection: inspect repaired legacy alias sibling: %w", err)
+		}
+	}
+	return "", "", fmt.Errorf("projection: allocate repaired legacy alias for %s", entry.objectID)
 }
 
 func syncLegacyFolderDirent(tx *sql.Tx, channelID int64, folderID string) error {

--- a/backend/projection/writable_schema_test.go
+++ b/backend/projection/writable_schema_test.go
@@ -471,6 +471,82 @@ func TestMigrateV7CollisionAliasKeepsEncryptedFileExtension(t *testing.T) {
 	}
 }
 
+func TestMigrateV7OverlongCollisionAliasKeepsFileExtension(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := seedV7Projection(t, db); err != nil {
+		t.Fatal(err)
+	}
+
+	overlongName := strings.Repeat("a", maxPortableNameBytes) + ".rar"
+	if _, err := db.Exec(`UPDATE files SET name=? WHERE channel_id=? AND msg_id=41`, overlongName, migPersonalChan); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO files (channel_id, msg_id, name, size, upload_time)
+		VALUES (?, 6012, ?, 1, 100)
+	`, migPersonalChan, overlongName); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigratePersonalChannel(db, migPersonalChan); err != nil {
+		t.Fatalf("migrate duplicate overlong archives: %v", err)
+	}
+
+	rows, err := db.Query(`
+		SELECT object_id, display_name, name_key FROM dirents
+		WHERE channel_id=? AND object_id IN ('f:41', 'f:6012')
+		ORDER BY object_id
+	`, migPersonalChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	seenKeys := make(map[string]bool)
+	count := 0
+	displayNames := make(map[string]string)
+	for rows.Next() {
+		var objectID, displayName, key string
+		if err := rows.Scan(&objectID, &displayName, &key); err != nil {
+			t.Fatal(err)
+		}
+		displayNames[objectID] = displayName
+		if !strings.HasSuffix(displayName, ".rar") {
+			t.Errorf("dirent %s display name %q lost .rar extension", objectID, displayName)
+		}
+		if len([]byte(displayName)) > maxPortableNameBytes {
+			t.Errorf("dirent %s display name is %d bytes, want at most %d", objectID, len([]byte(displayName)), maxPortableNameBytes)
+		}
+		canonical, err := CanonicalNameKey(displayName)
+		if err != nil {
+			t.Errorf("dirent %s display name %q is not portable: %v", objectID, displayName, err)
+		} else if key != canonical {
+			t.Errorf("dirent %s key = %q, want %q", objectID, key, canonical)
+		}
+		if seenKeys[key] {
+			t.Errorf("dirent %s reused sibling name key %q", objectID, key)
+		}
+		seenKeys[key] = true
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("migrated dirents = %d, want 2", count)
+	}
+	if strings.Contains(displayNames["f:41"], " (file ") {
+		t.Fatalf("first overlong archive display name %q unexpectedly received a collision suffix", displayNames["f:41"])
+	}
+	if !strings.HasSuffix(displayNames["f:6012"], " (file 6012).rar") {
+		t.Fatalf("duplicate overlong archive display name = %q, want collision suffix before .rar", displayNames["f:6012"])
+	}
+}
+
 func TestMigrateV9RepairsGeneratedCollisionAliasesWithoutClobberingSiblings(t *testing.T) {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -571,6 +647,82 @@ func TestMigrateV9RepairsGeneratedCollisionAliasesWithoutClobberingSiblings(t *t
 	}
 	if version != currentSchemaVersion {
 		t.Fatalf("schema version = %d, want %d", version, currentSchemaVersion)
+	}
+}
+
+func TestMigrateV9RepairsOverlongCollisionAliasWithFileExtension(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := seedV7Projection(t, db); err != nil {
+		t.Fatal(err)
+	}
+
+	overlongName := strings.Repeat("a", maxPortableNameBytes) + ".rar"
+	if _, err := db.Exec(`UPDATE files SET name=? WHERE channel_id=? AND msg_id=41`, overlongName, migPersonalChan); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO files (channel_id, msg_id, name, size, upload_time)
+		VALUES (?, 6012, ?, 1, 100)
+	`, migPersonalChan, overlongName); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigratePersonalChannel(db, migPersonalChan); err != nil {
+		t.Fatalf("build v9 overlong alias fixture: %v", err)
+	}
+
+	// Reconstruct the historical v8 spelling independently so this fixture
+	// still catches changes that would make the detector forget old aliases.
+	oldName := truncatePortableName("_"+overlongName, legacyCollisionSuffix("file", "f:6012", 0))
+	if strings.HasSuffix(oldName, ".rar") {
+		t.Fatalf("historical v8 fixture %q unexpectedly preserved .rar", oldName)
+	}
+	oldKey, err := CanonicalNameKey(oldName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		UPDATE dirents SET display_name=?, name_key=?
+		WHERE channel_id=? AND object_id='f:6012'
+	`, oldName, oldKey, migPersonalChan); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DELETE FROM schema_version`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_version(version) VALUES (9)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigratePersonalChannel(db, migPersonalChan); err != nil {
+		t.Fatalf("repair v9 overlong collision alias: %v", err)
+	}
+
+	var displayName, key string
+	if err := db.QueryRow(`
+		SELECT display_name, name_key FROM dirents
+		WHERE channel_id=? AND object_id='f:6012'
+	`, migPersonalChan).Scan(&displayName, &key); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(displayName, ".rar") {
+		t.Fatalf("repaired overlong alias %q lost .rar extension", displayName)
+	}
+	if !strings.HasSuffix(displayName, " (file 6012).rar") {
+		t.Fatalf("repaired overlong alias = %q, want collision suffix before .rar", displayName)
+	}
+	if len([]byte(displayName)) > maxPortableNameBytes {
+		t.Fatalf("repaired overlong alias is %d bytes, want at most %d", len([]byte(displayName)), maxPortableNameBytes)
+	}
+	wantKey, err := CanonicalNameKey(displayName)
+	if err != nil {
+		t.Fatalf("repaired overlong alias %q is not portable: %v", displayName, err)
+	}
+	if key != wantKey {
+		t.Fatalf("repaired overlong alias key = %q, want %q", key, wantKey)
 	}
 }
 

--- a/backend/projection/writable_schema_test.go
+++ b/backend/projection/writable_schema_test.go
@@ -2,6 +2,7 @@ package projection
 
 import (
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 	"unicode"
@@ -425,6 +426,151 @@ func TestMigrateLegacyPortableNameCollisionsUsesDeterministicAliases(t *testing.
 	}
 	if count != 2 {
 		t.Fatalf("dirents = %d, want 2", count)
+	}
+}
+
+func TestMigrateV7CollisionAliasKeepsEncryptedFileExtension(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := seedV7Projection(t, db); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE files SET name='archive.rar' WHERE channel_id=? AND msg_id=41`, migPersonalChan); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO files (
+			channel_id, msg_id, name, size, upload_time,
+			encrypted, plaintext_size, encryption_version
+		) VALUES (?, 6012, 'archive.rar', 1, 100, 1, 1, 1)
+	`, migPersonalChan); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigratePersonalChannel(db, migPersonalChan); err != nil {
+		t.Fatalf("migrate duplicate encrypted archive: %v", err)
+	}
+
+	var displayName, key string
+	if err := db.QueryRow(`
+		SELECT display_name, name_key FROM dirents
+		WHERE channel_id=? AND object_id='f:6012'
+	`, migPersonalChan).Scan(&displayName, &key); err != nil {
+		t.Fatal(err)
+	}
+	const wantName = "archive (file 6012).rar"
+	wantKey, err := CanonicalNameKey(wantName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if displayName != wantName || key != wantKey {
+		t.Fatalf("encrypted archive alias = (%q, %q), want (%q, %q)", displayName, key, wantName, wantKey)
+	}
+}
+
+func TestMigrateV9RepairsGeneratedCollisionAliasesWithoutClobberingSiblings(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := seedV7Projection(t, db); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE files SET name='archive.rar' WHERE channel_id=? AND msg_id=41`, migPersonalChan); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO files (channel_id, msg_id, name, size, upload_time)
+		VALUES (?, 6012, 'archive.rar', 1, 100)
+	`, migPersonalChan); err != nil {
+		t.Fatal(err)
+	}
+	if err := MigratePersonalChannel(db, migPersonalChan); err != nil {
+		t.Fatalf("build v9 fixture: %v", err)
+	}
+
+	oldName := legacyCollisionAliasV8("archive.rar", "file", "f:6012", 0)
+	oldKey, err := CanonicalNameKey(oldName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+		UPDATE dirents SET display_name=?, name_key=?
+		WHERE channel_id=? AND object_id='f:6012'
+	`, oldName, oldKey, migPersonalChan); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range []struct {
+		msgID       int64
+		sourceName  string
+		displayName string
+	}{
+		{7000, "occupied.bin", "archive (file 6012).rar"},
+		{7010, "manual.rar (file 7010)", "manual.rar (file 7010)"},
+	} {
+		key, err := CanonicalNameKey(file.displayName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`
+			INSERT INTO files (channel_id, msg_id, name, size, upload_time)
+			VALUES (?, ?, ?, 1, ?)
+		`, migPersonalChan, file.msgID, file.sourceName, file.msgID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(`
+			INSERT INTO dirents (
+				channel_id, object_id, object_kind, parent_id, display_name,
+				name_key, revision, tombstoned
+			) VALUES (?, ?, 'file', '', ?, ?, 1, 0)
+		`, migPersonalChan, FileIDPrefix+fmt.Sprint(file.msgID), file.displayName, key); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := db.Exec(`DELETE FROM schema_version`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO schema_version(version) VALUES (9)`); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := MigratePersonalChannel(db, migPersonalChan); err != nil {
+		t.Fatalf("repair v9 collision alias: %v", err)
+	}
+
+	wants := map[string]string{
+		"f:6012": "archive (file 6012-1).rar",
+		"f:7000": "archive (file 6012).rar",
+		"f:7010": "manual.rar (file 7010)",
+	}
+	for objectID, wantName := range wants {
+		var gotName, gotKey string
+		if err := db.QueryRow(`
+			SELECT display_name, name_key FROM dirents
+			WHERE channel_id=? AND object_id=?
+		`, migPersonalChan, objectID).Scan(&gotName, &gotKey); err != nil {
+			t.Fatal(err)
+		}
+		wantKey, err := CanonicalNameKey(wantName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotName != wantName || gotKey != wantKey {
+			t.Fatalf("dirent %s = (%q, %q), want (%q, %q)", objectID, gotName, gotKey, wantName, wantKey)
+		}
+	}
+
+	var version int
+	if err := db.QueryRow(`SELECT version FROM schema_version`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != currentSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, currentSchemaVersion)
 	}
 }
 


### PR DESCRIPTION
Fixes #92

## Summary
- Preserve a file’s final extension when a legacy migration adds a collision alias.
- Repair only v8/v9 aliases reconstructed exactly from the current logical file name and ID.
- Allocate a new alias instead of overwriting an occupied sibling; leave user-authored lookalikes untouched.

## Verification
- `go test ./backend/projection -run 'TestMigrate(V7CollisionAliasKeepsEncryptedFileExtension|V9RepairsGeneratedCollisionAliasesWithoutClobberingSiblings)$' -count=1`
- `go test ./backend/projection -count=1`
- `go test ./backend/services/file -run '^TestDownloadFolderRestoresMixedNestedTreeAndEmptyFolders$' -count=1`
- `go test ./...`