### PR TITLE
feat: hard delete mounted file bodies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,14 @@ jobs:
             throw "no Windows executable found in build/bin"
           }
           ./scripts/package-mpv-windows.ps1 $app.FullName
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Compress-Archive -Force -Path $app.FullName, "build/bin/media" -DestinationPath "dist/TDrive-windows-amd64-ci.zip"
+
+      - name: Upload Windows CI package
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: TDrive-windows-amd64-ci
+          path: dist/TDrive-windows-amd64-ci.zip
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,10 @@ jobs:
       # its tests execute natively on each OS instead of only
       # cross-compiling. Keep in sync with release.yml.
       - name: Run daemon, mount, and folder-download tests
-        run: go test -count=1 ./cmd/tdrive ./backend/daemon ./backend/mountfs ./backend/mountcontent ./backend/mountdav ./backend/mountcontroller ./backend/mountos ./backend/updater ./backend/services/file ./backend/projection
+        run: go test -count=1 ./cmd/tdrive ./backend/daemon ./backend/mountfs ./backend/mountcontent ./backend/mountdav ./backend/mountadapter ./backend/mountwrite ./backend/mountcontroller ./backend/mountos ./backend/tgclient ./backend/updater ./backend/services/file ./backend/projection
 
       - name: Vet platform-specific daemon and CLI code
-        run: go vet ./cmd/tdrive ./backend/daemon ./backend/mountcontroller ./backend/mountos ./backend/updater ./backend/services/file ./backend/projection
+        run: go vet ./cmd/tdrive ./backend/daemon ./backend/mountadapter ./backend/mountwrite ./backend/mountcontroller ./backend/mountos ./backend/tgclient ./backend/updater ./backend/services/file ./backend/projection
 
       - name: Build CLI
         if: runner.os != 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,10 @@ jobs:
           cache: true
 
       - name: Run CLI, daemon, mount, and folder-download tests
-        run: go test -count=1 ./cmd/tdrive ./backend/daemon ./backend/mountfs ./backend/mountcontent ./backend/mountdav ./backend/mountcontroller ./backend/mountos ./backend/updater ./backend/services/file ./backend/projection
+        run: go test -count=1 ./cmd/tdrive ./backend/daemon ./backend/mountfs ./backend/mountcontent ./backend/mountdav ./backend/mountadapter ./backend/mountwrite ./backend/mountcontroller ./backend/mountos ./backend/tgclient ./backend/updater ./backend/services/file ./backend/projection
 
       - name: Vet platform-specific daemon and CLI code
-        run: go vet ./cmd/tdrive ./backend/daemon ./backend/mountcontroller ./backend/mountos ./backend/updater ./backend/services/file ./backend/projection
+        run: go vet ./cmd/tdrive ./backend/daemon ./backend/mountadapter ./backend/mountwrite ./backend/mountcontroller ./backend/mountos ./backend/tgclient ./backend/updater ./backend/services/file ./backend/projection
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/backend/core/engine.go
+++ b/backend/core/engine.go
@@ -605,6 +605,16 @@ func (e *Engine) EnsureEncryptionPolicy(ctx context.Context, channelID int64) er
 	return e.syncEngine.EnsureAuthoritative(ctx, channelID)
 }
 
+// PrepareHardDeleteProjection applies channel history in Telegram message
+// order under the sync engine's per-channel lock. It rebuilds derived state
+// only when locally projected commits were ahead of the sync watermark.
+func (e *Engine) PrepareHardDeleteProjection(ctx context.Context, channelID int64) error {
+	if e == nil || e.syncEngine == nil {
+		return fmt.Errorf("channel sync is unavailable")
+	}
+	return e.syncEngine.PrepareHardDeleteProjection(ctx, channelID)
+}
+
 func (e *Engine) ClearEncryptionSession() {
 	if e == nil {
 		return

--- a/backend/core/engine.go
+++ b/backend/core/engine.go
@@ -106,6 +106,8 @@ type Engine struct {
 	thumbs     *thumbnail.Cache
 	maxUploads int
 	policySync func(context.Context, int64) error
+
+	projectionChanges projectionChangeBroker
 	// mediaEncryptionMu makes encrypted-session publication atomic with vault
 	// locking. The generation is odd while the write-side transition is active,
 	// so network-backed session setup stays outside the lock without admitting
@@ -273,6 +275,7 @@ func (e *Engine) Close() {
 		e.tg.Close()
 	}
 	if e != nil {
+		e.projectionChanges.close()
 		e.ClearEncryptionSession()
 	}
 }
@@ -612,6 +615,10 @@ func (e *Engine) PrepareHardDeleteProjection(ctx context.Context, channelID int6
 	if e == nil || e.syncEngine == nil {
 		return fmt.Errorf("channel sync is unavailable")
 	}
+	// A hard-delete barrier can import unrelated remote mutations before it
+	// reaches the marker. Invalidate mounted snapshots even when a later page
+	// fails, because earlier projection pages commit independently.
+	defer e.notifyProjectionChanged(channelID)
 	return e.syncEngine.PrepareHardDeleteProjection(ctx, channelID)
 }
 
@@ -776,6 +783,7 @@ func (e *Engine) newLifecycleService() *lifecycleservice.Service {
 		Warnf: func(format string, args ...any) {
 			e.warnf(format, args...)
 		},
+		OnProjectionChanged: e.notifyProjectionChanged,
 	})
 }
 

--- a/backend/core/projection_change.go
+++ b/backend/core/projection_change.go
@@ -1,0 +1,84 @@
+package core
+
+import "sync"
+
+// projectionChangeBroker isolates projection producers from mounted
+// filesystem consumers. Notifications are copied under lock and delivered
+// outside it so subscribers cannot block registration or removal.
+type projectionChangeBroker struct {
+	mu        sync.RWMutex
+	nextID    uint64
+	listeners map[uint64]func(int64)
+}
+
+func (broker *projectionChangeBroker) subscribe(listener func(int64)) func() {
+	if broker == nil || listener == nil {
+		return func() {}
+	}
+	broker.mu.Lock()
+	if broker.listeners == nil {
+		broker.listeners = make(map[uint64]func(int64))
+	}
+	broker.nextID++
+	id := broker.nextID
+	broker.listeners[id] = listener
+	broker.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			broker.mu.Lock()
+			delete(broker.listeners, id)
+			broker.mu.Unlock()
+		})
+	}
+}
+
+func (broker *projectionChangeBroker) listenersSnapshot() []func(int64) {
+	if broker == nil {
+		return nil
+	}
+	broker.mu.RLock()
+	listeners := make([]func(int64), 0, len(broker.listeners))
+	for _, listener := range broker.listeners {
+		listeners = append(listeners, listener)
+	}
+	broker.mu.RUnlock()
+	return listeners
+}
+
+func (broker *projectionChangeBroker) close() {
+	if broker == nil {
+		return
+	}
+	broker.mu.Lock()
+	broker.listeners = nil
+	broker.mu.Unlock()
+}
+
+// SubscribeProjectionChanges registers a process-local observer for completed
+// projection syncs. The returned function is safe to call more than once.
+func (e *Engine) SubscribeProjectionChanges(listener func(channelID int64)) func() {
+	if e == nil {
+		return func() {}
+	}
+	return e.projectionChanges.subscribe(listener)
+}
+
+func (e *Engine) notifyProjectionChanged(channelID int64) {
+	if e == nil || channelID <= 0 {
+		return
+	}
+	for _, listener := range e.projectionChanges.listenersSnapshot() {
+		e.notifyProjectionChangeListener(listener, channelID)
+	}
+}
+
+func (e *Engine) notifyProjectionChangeListener(listener func(int64), channelID int64) {
+	defer func() {
+		if recovered := recover(); recovered != nil && e.warnf != nil {
+			e.warnf("Warning: projection change subscriber failed: %v\n", recovered)
+		}
+	}()
+	listener(channelID)
+}

--- a/backend/core/projection_change_test.go
+++ b/backend/core/projection_change_test.go
@@ -1,0 +1,44 @@
+package core
+
+import "testing"
+
+func TestProjectionChangeSubscriptionsAreIndependentAndRemovable(t *testing.T) {
+	t.Parallel()
+
+	engine := &Engine{}
+	first := make([]int64, 0, 2)
+	second := make([]int64, 0, 2)
+	unsubscribeFirst := engine.SubscribeProjectionChanges(func(channelID int64) {
+		first = append(first, channelID)
+	})
+	engine.SubscribeProjectionChanges(func(channelID int64) {
+		second = append(second, channelID)
+	})
+
+	engine.notifyProjectionChanged(11)
+	unsubscribeFirst()
+	unsubscribeFirst()
+	engine.notifyProjectionChanged(22)
+
+	if len(first) != 1 || first[0] != 11 {
+		t.Fatalf("first observer channels = %v, want [11]", first)
+	}
+	if len(second) != 2 || second[0] != 11 || second[1] != 22 {
+		t.Fatalf("second observer channels = %v, want [11 22]", second)
+	}
+}
+
+func TestProjectionChangeNotificationContainsSubscriberPanic(t *testing.T) {
+	t.Parallel()
+
+	engine := &Engine{warnf: func(string, ...any) {}}
+	notified := false
+	engine.SubscribeProjectionChanges(func(int64) { panic("subscriber failed") })
+	engine.SubscribeProjectionChanges(func(int64) { notified = true })
+
+	engine.notifyProjectionChanged(11)
+
+	if !notified {
+		t.Fatal("healthy observer was skipped after another observer panicked")
+	}
+}

--- a/backend/mountadapter/constructor_test.go
+++ b/backend/mountadapter/constructor_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -34,8 +35,13 @@ func TestNewBuildsAndOwnsDurableCoordinator(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	t.Cleanup(func() { _ = session.Close(context.Background()) })
-	if info, err := os.Stat(root); err != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+	if info, err := os.Stat(root); err != nil || !info.IsDir() {
 		t.Fatalf("staging root info = %+v, err=%v", info, err)
+	}
+	if runtime.GOOS != "windows" {
+		if info, err := os.Stat(root); err != nil || info.Mode().Perm() != 0o700 {
+			t.Fatalf("staging root permissions = %+v, err=%v", info, err)
+		}
 	}
 	var journalTable string
 	if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name='mount_write_journal'`).Scan(&journalTable); err != nil {

--- a/backend/mountadapter/remote.go
+++ b/backend/mountadapter/remote.go
@@ -209,6 +209,19 @@ func (remote *TelegramRemote) Commit(ctx context.Context, request mountwrite.Com
 	if err != nil {
 		return mountwrite.MutationResult{}, err
 	}
+	if request.Mutation.Kind == mountwrite.MutationHardDelete {
+		if err := projection.RegisterHardDeleteIntent(
+			ctx,
+			remote.db,
+			request.Mutation.DriveID,
+			request.OperationID,
+			request.Mutation.ObjectID,
+			int64(request.Mutation.ExpectedRevision),
+		); err != nil {
+			slog.Warn("mountadapter: Commit failed to register hard-delete intent", "operation_id", request.OperationID, "error", err)
+			return mountwrite.MutationResult{}, errors.Join(mapRejectedProjectionError(err.Error()), err)
+		}
+	}
 	header := projection.Format(op)
 	var msgID int64
 	err = remote.floodWaitRetry.Do(ctx, func() error {
@@ -245,6 +258,11 @@ func (remote *TelegramRemote) Commit(ctx context.Context, request mountwrite.Com
 	}
 	if operation.Outcome == projection.OperationRejected {
 		slog.Warn("mountadapter: Commit rejected by projection", "operation_id", request.OperationID, "msg_id", msgID, "reason", operation.Error)
+		if request.Mutation.Kind == mountwrite.MutationHardDelete {
+			if abandonErr := projection.AbandonHardDeleteIntent(ctx, remote.db, request.Mutation.DriveID, request.OperationID); abandonErr != nil {
+				return mountwrite.MutationResult{}, errors.Join(mapRejectedProjectionError(operation.Error), abandonErr)
+			}
+		}
 		return mountwrite.MutationResult{}, mapRejectedProjectionError(operation.Error)
 	}
 	if operation.Outcome != projection.OperationApplied {
@@ -378,8 +396,23 @@ func (remote *TelegramRemote) Reconcile(ctx context.Context, operationID string)
 	if !candidateFound {
 		return mountwrite.MutationResult{}, false, nil
 	}
-	if err := remote.projectHistory(ctx, remote.driveID, candidate.MsgID, candidate.FromID, candidateOp, projection.Format(candidateOp)); err != nil {
-		return mountwrite.MutationResult{}, false, err
+	var projectErr error
+	if candidateOp.Type == projection.OpHardDeleteTree {
+		projectErr = remote.projectCommitted(
+			ctx,
+			remote.driveID,
+			candidate.MsgID,
+			candidateOp,
+			projection.Format(candidateOp),
+			mountwrite.MutationHardDelete,
+		)
+	} else {
+		projectErr = remote.projectHistory(
+			ctx, remote.driveID, candidate.MsgID, candidate.FromID, candidateOp, projection.Format(candidateOp),
+		)
+	}
+	if projectErr != nil {
+		return mountwrite.MutationResult{}, false, projectErr
 	}
 	result, found, err := remote.reconcileProjected(operationID)
 	return result, found, err

--- a/backend/mountadapter/remote.go
+++ b/backend/mountadapter/remote.go
@@ -24,6 +24,7 @@ const (
 	defaultRevisionRetention = 30 * 24 * time.Hour
 	defaultHistoryPageSize   = 100
 	defaultHistoryPages      = 3
+	hardDeleteBatchSize      = 100
 )
 
 type HiddenStore interface {
@@ -44,6 +45,10 @@ type TelegramRemoteConfig struct {
 	HistoryPageSize int
 	HistoryPages    int
 	FloodWaitRetry  tgclient.FloodWaitRetryPolicy
+	// ProjectThrough synchronizes channel history through the just-sent marker
+	// under the sync engine's per-channel lock. Production wiring supplies it
+	// so hard-delete subtree capture observes earlier writes from other clients.
+	ProjectThrough func(context.Context, int64) error
 }
 
 type TelegramRemote struct {
@@ -57,6 +62,7 @@ type TelegramRemote struct {
 	historyPageSize int
 	historyPages    int
 	floodWaitRetry  tgclient.FloodWaitRetryPolicy
+	projectThrough  func(context.Context, int64) error
 }
 
 func NewTelegramRemote(config TelegramRemoteConfig) (*TelegramRemote, error) {
@@ -92,6 +98,7 @@ func NewTelegramRemote(config TelegramRemoteConfig) (*TelegramRemote, error) {
 		historyPageSize: config.HistoryPageSize,
 		historyPages:    config.HistoryPages,
 		floodWaitRetry:  config.FloodWaitRetry,
+		projectThrough:  config.ProjectThrough,
 	}, nil
 }
 
@@ -224,7 +231,7 @@ func (remote *TelegramRemote) Commit(ctx context.Context, request mountwrite.Com
 			return uncertain, mountwrite.ErrCommitOutcomeUnknown
 		}
 	}
-	if err := remote.project(ctx, request.Mutation.DriveID, msgID, op, header); err != nil {
+	if err := remote.projectCommitted(ctx, request.Mutation.DriveID, msgID, op, header, request.Mutation.Kind); err != nil {
 		slog.Warn("mountadapter: Commit failed to apply projection synchronously", "operation_id", request.OperationID, "msg_id", msgID, "error", err)
 		return uncertain, mountwrite.ErrCommitOutcomeUnknown
 	}
@@ -252,7 +259,80 @@ func (remote *TelegramRemote) Commit(ctx context.Context, request mountwrite.Com
 	return result, nil
 }
 
+func (remote *TelegramRemote) projectCommitted(
+	ctx context.Context,
+	driveID, msgID int64,
+	op projection.Op,
+	header string,
+	kind mountwrite.MutationKind,
+) error {
+	if kind == mountwrite.MutationHardDelete {
+		if remote.projectThrough == nil {
+			return mountwrite.ErrUnavailable
+		}
+		return remote.projectThrough(ctx, driveID)
+	}
+	return remote.project(ctx, driveID, msgID, op, header)
+}
+
 var _ mountwrite.ReceiptReconciler = (*TelegramRemote)(nil)
+var _ mountwrite.HardDeleteRemote = (*TelegramRemote)(nil)
+
+// HardDeletePlan pages the immutable body plan captured by the projection
+// transaction that applied the hard-delete marker. Telegram deletion must not
+// begin until the caller has durably copied and sealed the complete plan.
+func (remote *TelegramRemote) HardDeletePlan(
+	ctx context.Context,
+	operationID string,
+	afterMsgID int64,
+	limit int,
+) ([]int64, int64, bool, error) {
+	if remote == nil || ctx == nil || strings.TrimSpace(operationID) == "" || afterMsgID < 0 || limit <= 0 {
+		return nil, 0, false, mountwrite.ErrInvalidRequest
+	}
+	return projection.HardDeletePlanPage(ctx, remote.db, remote.driveID, operationID, afterMsgID, limit)
+}
+
+// DeleteBodies physically removes one coordinator-sized batch. The retry
+// policy is shared with visibility writes so transient and flood-wait errors
+// remain bounded and cancellation-aware.
+func (remote *TelegramRemote) DeleteBodies(ctx context.Context, operationID string, msgIDs []int64) error {
+	if remote == nil || ctx == nil || strings.TrimSpace(operationID) == "" || len(msgIDs) == 0 || len(msgIDs) > hardDeleteBatchSize {
+		return mountwrite.ErrInvalidRequest
+	}
+	seen := make(map[int64]struct{}, len(msgIDs))
+	for _, msgID := range msgIDs {
+		if msgID <= 0 || msgID > math.MaxInt32 {
+			return mountwrite.ErrInvalidRequest
+		}
+		if _, duplicate := seen[msgID]; duplicate {
+			return mountwrite.ErrInvalidRequest
+		}
+		seen[msgID] = struct{}{}
+	}
+	if err := projection.ValidateHardDeletePlanItems(ctx, remote.db, remote.driveID, operationID, msgIDs); err != nil {
+		if errors.Is(err, projection.ErrHardDeletePlanMismatch) || errors.Is(err, projection.ErrHardDeletePlanNotFound) {
+			return errors.Join(mountwrite.ErrConflict, err)
+		}
+		return err
+	}
+	peer, err := remote.peers.ResolvePeer(ctx, remote.driveID)
+	if err != nil {
+		return err
+	}
+	return remote.floodWaitRetry.Do(ctx, func() error {
+		return remote.telegram.DeleteMessages(ctx, peer, msgIDs)
+	})
+}
+
+// FinalizeHardDelete compacts projection-owned cleanup metadata only after the
+// journal confirms that every planned Telegram body was deleted.
+func (remote *TelegramRemote) FinalizeHardDelete(ctx context.Context, operationID string) error {
+	if remote == nil || ctx == nil || strings.TrimSpace(operationID) == "" {
+		return mountwrite.ErrInvalidRequest
+	}
+	return projection.CompleteHardDeletePlan(ctx, remote.db, remote.driveID, operationID)
+}
 
 func (remote *TelegramRemote) Reconcile(ctx context.Context, operationID string) (mountwrite.MutationResult, bool, error) {
 	if remote == nil {
@@ -367,7 +447,7 @@ func (remote *TelegramRemote) ReconcileReceipt(
 	if err != nil || !projectionOperationMatchesCommit(request, op) {
 		return mountwrite.MutationResult{}, false, mountwrite.ErrConflict
 	}
-	if err := remote.projectHistory(ctx, remote.driveID, message.MsgID, message.FromID, op, projection.Format(op)); err != nil {
+	if err := remote.projectCommitted(ctx, remote.driveID, message.MsgID, op, projection.Format(op), request.Mutation.Kind); err != nil {
 		return mountwrite.MutationResult{}, false, err
 	}
 	result, found, err := remote.reconcileProjected(request.OperationID)
@@ -557,6 +637,10 @@ func buildProjectionOperation(request mountwrite.CommitRequest, now time.Time) (
 		op.ExpectedRevision = int64(request.Mutation.ExpectedRevision)
 		op.DeletedAt = now.Unix()
 		op.PurgeAfter = now.Add(request.Mutation.TrashRetention).Unix()
+	case mountwrite.MutationHardDelete:
+		op.Type = projection.OpHardDeleteTree
+		op.Obj = request.Mutation.ObjectID
+		op.ExpectedRevision = int64(request.Mutation.ExpectedRevision)
 	default:
 		return projection.Op{}, mountwrite.ErrInvalidRequest
 	}
@@ -593,7 +677,7 @@ func (remote *TelegramRemote) objectIDFromProjectionOperation(operation projecti
 		return projection.FileIDPrefix + strconv.FormatInt(operation.MsgID, 10), nil
 	case projection.OpFolderCommit:
 		return deterministicFolderID(operation.OpID), nil
-	case projection.OpFileReplace, projection.OpRelocate, projection.OpTrashTree:
+	case projection.OpFileReplace, projection.OpRelocate, projection.OpTrashTree, projection.OpHardDeleteTree:
 		op, found, err := remote.replayOp(operation.ChannelID, operation.MsgID)
 		if err != nil {
 			return "", err

--- a/backend/mountadapter/remote_test.go
+++ b/backend/mountadapter/remote_test.go
@@ -561,6 +561,19 @@ func TestTelegramRemoteBuildsRetentionAndCASOperations(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "hard delete",
+			request: mountwrite.CommitRequest{OperationID: "hard-delete", Mutation: mountwrite.Mutation{
+				Kind: mountwrite.MutationHardDelete, DriveID: testDriveID,
+				ObjectID: "d:p", ExpectedRevision: 4,
+			}},
+			wantType: projection.OpHardDeleteTree,
+			assert: func(t *testing.T, op projection.Op) {
+				if op.ExpectedRevision != 4 || op.DeletedAt != 0 || op.PurgeAfter != 0 || op.RetainedUntil != 0 {
+					t.Fatalf("hard delete op carries retention fields: %+v", op)
+				}
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -573,6 +586,117 @@ func TestTelegramRemoteBuildsRetentionAndCASOperations(t *testing.T) {
 			}
 			test.assert(t, op)
 		})
+	}
+}
+
+func TestTelegramRemoteHardDeletePlansAndDeletesOnlyFileBodies(t *testing.T) {
+	db := newProjectionDB(t)
+	project(t, db, 20, projection.Op{
+		Type: projection.OpFilePart, UploadUUID: "hard-delete-u", PartIndex: 0, FileSize: 1,
+	})
+	project(t, db, 21, projection.Op{
+		Type: projection.OpFileCommit, ProtocolVersion: 1, OpID: "put-before-hard-delete",
+		Name: "delete-me.txt", UploadUUID: "hard-delete-u", PartCount: 1,
+		FileSize: 1, PlaintextSize: 1,
+	})
+	fakeTG := tgclient.NewFake(7)
+	fakeTG.SeedChannel(tgclient.InputPeer{ChannelID: testDriveID}, "Personal")
+	remote := newTestTelegramRemote(t, db, fakeTG, time.Unix(5_000, 0))
+	barrierCalls := 0
+	remote.projectThrough = func(_ context.Context, driveID int64) error {
+		barrierCalls++
+		controls := fakeTG.SentControls()
+		control := controls[len(controls)-1]
+		op, err := projection.Parse(control.Text)
+		if err != nil {
+			return err
+		}
+		_, err = projection.ProjectFromOp(db, driveID, control.MsgID, op, 7, control.Text)
+		return err
+	}
+
+	result, err := remote.Commit(context.Background(), mountwrite.CommitRequest{
+		OperationID: "hard-delete-from-explorer",
+		CommitTime:  time.Unix(5_000, 0),
+		Mutation: mountwrite.Mutation{
+			Kind: mountwrite.MutationHardDelete, DriveID: testDriveID,
+			ObjectID: "f:21", ExpectedRevision: 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Commit hard delete: %v", err)
+	}
+	if barrierCalls != 1 {
+		t.Fatalf("ordered projection barrier calls = %d, want 1", barrierCalls)
+	}
+	ids, total, done, err := remote.HardDeletePlan(context.Background(), result.OperationID, 0, 100)
+	if err != nil || total != 1 || !done || !slices.Equal(ids, []int64{20}) {
+		t.Fatalf("HardDeletePlan = %v total=%d done=%v err=%v", ids, total, done, err)
+	}
+	if err := remote.DeleteBodies(context.Background(), result.OperationID, ids); err != nil {
+		t.Fatalf("DeleteBodies: %v", err)
+	}
+	if err := remote.FinalizeHardDelete(context.Background(), result.OperationID); err != nil {
+		t.Fatalf("FinalizeHardDelete: %v", err)
+	}
+	controls := fakeTG.SentControls()
+	if len(controls) != 1 {
+		t.Fatalf("controls = %+v", controls)
+	}
+	if batches := fakeTG.DeletedBatches(); len(batches) != 1 || !slices.Equal(batches[0], []int64{20}) {
+		t.Fatalf("deleted batches = %v", batches)
+	}
+	if controls[0].MsgID == 20 {
+		t.Fatal("test setup reused marker and body message IDs")
+	}
+}
+
+func TestTelegramRemoteHardDeleteFailsClosedWithoutOrderingBarrier(t *testing.T) {
+	db := newProjectionDB(t)
+	project(t, db, 20, projection.Op{
+		Type: projection.OpFilePart, UploadUUID: "ordered-delete-u", PartIndex: 0, FileSize: 1,
+	})
+	project(t, db, 21, projection.Op{
+		Type: projection.OpFileCommit, ProtocolVersion: 1, OpID: "ordered-delete-file",
+		Name: "ordered.txt", UploadUUID: "ordered-delete-u", PartCount: 1, FileSize: 1,
+	})
+	remote := newTestTelegramRemote(t, db, tgclient.NewFake(7), time.Unix(5_000, 0))
+	op := projection.Op{
+		Type: projection.OpHardDeleteTree, ProtocolVersion: 1, OpID: "requires-ordering",
+		Obj: "f:21", ExpectedRevision: 1,
+	}
+	err := remote.projectCommitted(
+		context.Background(), testDriveID, 22, op, projection.Format(op), mountwrite.MutationHardDelete,
+	)
+	if !errors.Is(err, mountwrite.ErrUnavailable) {
+		t.Fatalf("hard-delete projection without ordering barrier error=%v, want ErrUnavailable", err)
+	}
+	if _, ok, lookupErr := projection.FileByID(db, testDriveID, 21); lookupErr != nil || !ok {
+		t.Fatalf("unsafe fallback mutated file: ok=%v err=%v", ok, lookupErr)
+	}
+}
+
+func TestTelegramRemoteRejectsDeleteBatchOutsideProjectionPlan(t *testing.T) {
+	db := newProjectionDB(t)
+	project(t, db, 20, projection.Op{Type: projection.OpFilePart, UploadUUID: "allowlist-u", PartIndex: 0, FileSize: 1})
+	project(t, db, 21, projection.Op{
+		Type: projection.OpFileCommit, ProtocolVersion: 1, OpID: "allowlist-file",
+		Name: "allowlist.txt", UploadUUID: "allowlist-u", PartCount: 1, FileSize: 1,
+	})
+	project(t, db, 22, projection.Op{
+		Type: projection.OpHardDeleteTree, ProtocolVersion: 1, OpID: "allowlist-delete",
+		Obj: "f:21", ExpectedRevision: 1,
+	})
+	fakeTG := tgclient.NewFake(7)
+	fakeTG.SeedChannel(tgclient.InputPeer{ChannelID: testDriveID}, "Personal")
+	remote := newTestTelegramRemote(t, db, fakeTG, time.Unix(5_000, 0))
+
+	err := remote.DeleteBodies(context.Background(), "allowlist-delete", []int64{20, 999})
+	if !errors.Is(err, mountwrite.ErrConflict) {
+		t.Fatalf("out-of-plan delete error=%v, want ErrConflict", err)
+	}
+	if batches := fakeTG.DeletedBatches(); len(batches) != 0 {
+		t.Fatalf("out-of-plan messages reached Telegram: %v", batches)
 	}
 }
 

--- a/backend/mountadapter/remote_test.go
+++ b/backend/mountadapter/remote_test.go
@@ -15,6 +15,7 @@ import (
 	"TDrive/backend/mountwrite"
 	"TDrive/backend/projection"
 	fileservice "TDrive/backend/services/file"
+	syncengine "TDrive/backend/sync"
 	"TDrive/backend/tgclient"
 )
 
@@ -639,6 +640,16 @@ func TestTelegramRemoteHardDeletePlansAndDeletesOnlyFileBodies(t *testing.T) {
 	if err := remote.FinalizeHardDelete(context.Background(), result.OperationID); err != nil {
 		t.Fatalf("FinalizeHardDelete: %v", err)
 	}
+	var intents int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM hard_delete_intents
+		WHERE channel_id=? AND op_id=?
+	`, testDriveID, result.OperationID).Scan(&intents); err != nil {
+		t.Fatalf("read hard-delete intent: %v", err)
+	}
+	if intents != 0 {
+		t.Fatalf("completed hard-delete retained %d local intents", intents)
+	}
 	controls := fakeTG.SentControls()
 	if len(controls) != 1 {
 		t.Fatalf("controls = %+v", controls)
@@ -648,6 +659,158 @@ func TestTelegramRemoteHardDeletePlansAndDeletesOnlyFileBodies(t *testing.T) {
 	}
 	if controls[0].MsgID == 20 {
 		t.Fatal("test setup reused marker and body message IDs")
+	}
+}
+
+func TestTelegramRemoteRetainsHardDeleteIntentWhenSendOutcomeIsUnknown(t *testing.T) {
+	db := newProjectionDB(t)
+	project(t, db, 21, projection.Op{
+		Type: projection.OpFileCommit, ProtocolVersion: 1, OpID: "uncertain-delete-file",
+		Name: "uncertain.txt", ContentMsgID: 9001, FileSize: 1,
+	})
+	fakeTG := tgclient.NewFake(7)
+	fakeTG.SeedChannel(tgclient.InputPeer{ChannelID: testDriveID}, "Personal")
+	fakeTG.FailNextSend()
+	remote := newTestTelegramRemote(t, db, fakeTG, time.Unix(5_000, 0))
+
+	_, err := remote.Commit(context.Background(), mountwrite.CommitRequest{
+		OperationID: "uncertain-hard-delete",
+		Mutation: mountwrite.Mutation{
+			Kind: mountwrite.MutationHardDelete, DriveID: testDriveID,
+			ObjectID: "f:21", ExpectedRevision: 1,
+		},
+	})
+	if !errors.Is(err, mountwrite.ErrCommitOutcomeUnknown) {
+		t.Fatalf("Commit error = %v, want ErrCommitOutcomeUnknown", err)
+	}
+	var intents int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM hard_delete_intents
+		WHERE channel_id=? AND op_id='uncertain-hard-delete'
+	`, testDriveID).Scan(&intents); err != nil {
+		t.Fatalf("read hard-delete intent: %v", err)
+	}
+	if intents != 1 {
+		t.Fatalf("hard-delete intents after uncertain send = %d, want 1", intents)
+	}
+	if _, found, err := projection.FileByID(db, testDriveID, 21); err != nil || !found {
+		t.Fatalf("uncertain send changed namespace: found=%v err=%v", found, err)
+	}
+}
+
+func TestTelegramRemoteAbandonsHardDeleteIntentAfterDefinitiveProjectionRejection(t *testing.T) {
+	db := newProjectionDB(t)
+	project(t, db, 21, projection.Op{
+		Type: projection.OpFileCommit, ProtocolVersion: 1, OpID: "rejected-delete-file",
+		Name: "before.txt", ContentMsgID: 9001, FileSize: 1,
+	})
+	fakeTG := tgclient.NewFake(7)
+	fakeTG.SeedChannel(tgclient.InputPeer{ChannelID: testDriveID}, "Personal")
+	remote := newTestTelegramRemote(t, db, fakeTG, time.Unix(5_000, 0))
+	remote.projectThrough = func(_ context.Context, driveID int64) error {
+		rename := projection.Op{
+			Type: projection.OpRename, Obj: "f:21", Name: "after.txt", ExpectedRevision: 1,
+		}
+		if _, err := projection.ProjectFromOp(db, driveID, 99, rename, 7, projection.Format(rename)); err != nil {
+			return err
+		}
+		control := fakeTG.SentControls()[0]
+		op, err := projection.Parse(control.Text)
+		if err != nil {
+			return err
+		}
+		_, err = projection.ProjectFromOp(db, driveID, control.MsgID, op, 7, control.Text)
+		return err
+	}
+
+	_, err := remote.Commit(context.Background(), mountwrite.CommitRequest{
+		OperationID: "rejected-hard-delete",
+		Mutation: mountwrite.Mutation{
+			Kind: mountwrite.MutationHardDelete, DriveID: testDriveID,
+			ObjectID: "f:21", ExpectedRevision: 1,
+		},
+	})
+	if !errors.Is(err, mountwrite.ErrPreconditionFailed) {
+		t.Fatalf("Commit error = %v, want ErrPreconditionFailed", err)
+	}
+	var intents int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM hard_delete_intents
+		WHERE channel_id=? AND op_id='rejected-hard-delete'
+	`, testDriveID).Scan(&intents); err != nil {
+		t.Fatalf("read hard-delete intent: %v", err)
+	}
+	if intents != 0 {
+		t.Fatalf("rejected hard-delete retained %d intents", intents)
+	}
+}
+
+func TestTelegramRemoteReconcileHardDeleteUsesOrderingBarrier(t *testing.T) {
+	db := newProjectionDB(t)
+	root := projection.Op{
+		Type: projection.OpFolderCommit, ProtocolVersion: 1, OpID: "reconcile-root",
+		Obj: "d:root", Name: "Root",
+	}
+	part := projection.Op{Type: projection.OpFilePart, UploadUUID: "reconcile-part", PartIndex: 0, FileSize: 1}
+	file := projection.Op{
+		Type: projection.OpFileCommit, ProtocolVersion: 1, OpID: "reconcile-file",
+		Parent: "d:root", Name: "preserve.txt", UploadUUID: "reconcile-part", PartCount: 1, FileSize: 1,
+	}
+	destination := projection.Op{
+		Type: projection.OpFolderCommit, ProtocolVersion: 1, OpID: "reconcile-destination",
+		Obj: "d:outside", Name: "Outside",
+	}
+	move := projection.Op{
+		Type: projection.OpRelocate, ProtocolVersion: 1, OpID: "reconcile-move",
+		Obj: "f:102", Parent: "d:outside", Name: "preserve.txt", ExpectedRevision: 1,
+	}
+	hardDelete := projection.Op{
+		Type: projection.OpHardDeleteTree, ProtocolVersion: 1, OpID: "reconcile-hard-delete",
+		Obj: "d:root", ExpectedRevision: 1,
+	}
+
+	project(t, db, 100, root)
+	project(t, db, 101, part)
+	project(t, db, 102, file)
+	// The move is locally known before its destination and is initially
+	// rejected. Recovery must synchronize/rebuild in Telegram order before
+	// it captures the hard-delete body plan.
+	if _, err := projection.ProjectFromOp(db, testDriveID, 104, move, 1, projection.Format(move)); err != nil {
+		t.Fatalf("project locally-ahead move: %v", err)
+	}
+	if err := projection.RegisterHardDeleteIntent(
+		context.Background(), db, testDriveID, hardDelete.OpID, hardDelete.Obj, hardDelete.ExpectedRevision,
+	); err != nil {
+		t.Fatalf("register hard-delete intent: %v", err)
+	}
+
+	fakeTG := tgclient.NewFake(1)
+	fakeTG.SeedChannel(tgclient.InputPeer{ChannelID: testDriveID}, "Personal")
+	fakeTG.SeedHistory(
+		tgclient.HistoryMessage{MsgID: 100, FromID: 1, Text: projection.Format(root)},
+		tgclient.HistoryMessage{MsgID: 101, FromID: 1, Text: projection.Format(part)},
+		tgclient.HistoryMessage{MsgID: 102, FromID: 1, Text: projection.Format(file)},
+		tgclient.HistoryMessage{MsgID: 103, FromID: 1, Text: projection.Format(destination)},
+		tgclient.HistoryMessage{MsgID: 104, FromID: 1, Text: projection.Format(move)},
+		tgclient.HistoryMessage{MsgID: 105, FromID: 1, Text: projection.Format(hardDelete)},
+	)
+	remote := newTestTelegramRemote(t, db, fakeTG, time.Unix(5_000, 0))
+	syncer := syncengine.NewEngine(db, fakeTG, testPeerResolver{peer: tgclient.InputPeer{ChannelID: testDriveID}})
+	remote.projectThrough = syncer.PrepareHardDeleteProjection
+
+	result, found, err := remote.Reconcile(context.Background(), hardDelete.OpID)
+	if err != nil || !found || result.ObjectID != "d:root" {
+		t.Fatalf("Reconcile = %+v, found=%v, err=%v", result, found, err)
+	}
+	preserved, found, err := projection.FileByID(db, testDriveID, 102)
+	if err != nil || !found || preserved.ParentID != "d:outside" {
+		t.Fatalf("moved-out file = %+v, found=%v, err=%v", preserved, found, err)
+	}
+	ids, total, done, err := projection.HardDeletePlanPage(
+		context.Background(), db, testDriveID, hardDelete.OpID, 0, 10,
+	)
+	if err != nil || len(ids) != 0 || total != 0 || !done {
+		t.Fatalf("hard-delete plan = (%v,%d,%t,%v), want empty safe plan", ids, total, done, err)
 	}
 }
 

--- a/backend/mountadapter/session.go
+++ b/backend/mountadapter/session.go
@@ -243,14 +243,12 @@ func (s *Session) Delete(ctx context.Context, request mountdav.DeleteRequest) (m
 	if err := evaluateMutationConditions(request.Conditions, resource, map[string]conditionResource{request.Path: resource}); err != nil {
 		return mountdav.MutationResult{}, err
 	}
-	result, err := s.engine.Delete(ctx, mountwrite.DeleteRequest{
+	result, err := s.engine.HardDelete(ctx, mountwrite.HardDeleteRequest{
 		OperationID:      request.OperationID,
 		DriveID:          s.driveID,
 		ObjectID:         target.ObjectID,
 		ParentID:         target.ParentID,
 		ExpectedRevision: target.Revision,
-		Recursive:        target.Kind == mountfs.KindDirectory,
-		TrashRetention:   defaultTrashRetention,
 	})
 	if err != nil {
 		return mountdav.MutationResult{}, mapWriteError(err)

--- a/backend/mountadapter/session_test.go
+++ b/backend/mountadapter/session_test.go
@@ -324,18 +324,45 @@ func TestUnlockedEncryptedSessionEncryptsPutsAndAllowsEncryptedMetadataMutations
 	})
 }
 
-func TestSessionDeleteUsesThirtyDayTrashAndRecursiveFolders(t *testing.T) {
-	resolver := newFakeResolver(
-		Node{ObjectID: "d:docs", Name: "Docs", Kind: mountfs.KindDirectory, Revision: 9},
-	)
-	engine := &fakeEngine{deleteResult: mountwrite.MutationResult{ObjectID: "d:docs", Revision: 10}}
-	session := newTestSession(resolver, engine)
-
-	if _, err := session.Delete(context.Background(), mountdav.DeleteRequest{OperationID: "op-delete", Path: "/Docs"}); err != nil {
-		t.Fatalf("Delete: %v", err)
+func TestSessionDeleteUsesHardDeleteForFilesAndRecursiveFolders(t *testing.T) {
+	tests := []struct {
+		name string
+		node Node
+	}{
+		{
+			name: "file",
+			node: Node{ObjectID: "f:41", ParentID: "d:docs", Name: "notes.txt",
+				Kind: mountfs.KindFile, Revision: 7},
+		},
+		{
+			name: "folder",
+			node: Node{ObjectID: "d:docs", Name: "Docs", Kind: mountfs.KindDirectory,
+				Revision: 9},
+		},
 	}
-	if !engine.deleteRequest.Recursive || engine.deleteRequest.TrashRetention != defaultTrashRetention {
-		t.Fatalf("Delete request = %+v", engine.deleteRequest)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := newFakeResolver(test.node)
+			engine := &fakeEngine{hardDeleteResult: mountwrite.MutationResult{
+				ObjectID: test.node.ObjectID, Revision: test.node.Revision + 1,
+			}}
+			session := newTestSession(resolver, engine)
+
+			if _, err := session.Delete(context.Background(), mountdav.DeleteRequest{
+				OperationID: "op-hard-delete", Path: "/" + test.node.Name,
+			}); err != nil {
+				t.Fatalf("Delete: %v", err)
+			}
+			request := engine.hardDeleteRequest
+			if request.OperationID != "op-hard-delete" || request.DriveID != testDriveID ||
+				request.ObjectID != test.node.ObjectID || request.ParentID != test.node.ParentID ||
+				request.ExpectedRevision != test.node.Revision {
+				t.Fatalf("HardDelete request = %+v", request)
+			}
+			if engine.deleteRequest != (mountwrite.DeleteRequest{}) {
+				t.Fatalf("soft Delete unexpectedly called with %+v", engine.deleteRequest)
+			}
+		})
 	}
 }
 
@@ -515,22 +542,25 @@ func (r *fakeResolver) Resolve(_ context.Context, path string) (Node, bool, erro
 }
 
 type fakeEngine struct {
-	putRequest    mountwrite.PutRequest
-	mkdirRequest  mountwrite.MkdirRequest
-	moveRequest   mountwrite.MoveRequest
-	deleteRequest mountwrite.DeleteRequest
-	putResult     mountwrite.MutationResult
-	mkdirResult   mountwrite.MutationResult
-	moveResult    mountwrite.MutationResult
-	deleteResult  mountwrite.MutationResult
-	putErr        error
-	mkdirErr      error
-	moveErr       error
-	deleteErr     error
-	callCount     int
-	drainCalls    int
-	closeCalls    int
-	recoverCalls  int
+	putRequest        mountwrite.PutRequest
+	mkdirRequest      mountwrite.MkdirRequest
+	moveRequest       mountwrite.MoveRequest
+	deleteRequest     mountwrite.DeleteRequest
+	hardDeleteRequest mountwrite.HardDeleteRequest
+	putResult         mountwrite.MutationResult
+	mkdirResult       mountwrite.MutationResult
+	moveResult        mountwrite.MutationResult
+	deleteResult      mountwrite.MutationResult
+	hardDeleteResult  mountwrite.MutationResult
+	putErr            error
+	mkdirErr          error
+	moveErr           error
+	deleteErr         error
+	hardDeleteErr     error
+	callCount         int
+	drainCalls        int
+	closeCalls        int
+	recoverCalls      int
 }
 
 func (e *fakeEngine) Put(_ context.Context, request mountwrite.PutRequest, body io.Reader) (mountwrite.MutationResult, error) {
@@ -563,6 +593,12 @@ func (e *fakeEngine) Delete(_ context.Context, request mountwrite.DeleteRequest)
 	e.callCount++
 	e.deleteRequest = request
 	return e.deleteResult, e.deleteErr
+}
+
+func (e *fakeEngine) HardDelete(_ context.Context, request mountwrite.HardDeleteRequest) (mountwrite.MutationResult, error) {
+	e.callCount++
+	e.hardDeleteRequest = request
+	return e.hardDeleteResult, e.hardDeleteErr
 }
 
 func (e *fakeEngine) Recover(context.Context) (mountwrite.RecoveryReport, error) {

--- a/backend/mountadapter/types.go
+++ b/backend/mountadapter/types.go
@@ -36,6 +36,7 @@ type Engine interface {
 	Mkdir(context.Context, mountwrite.MkdirRequest) (mountwrite.MutationResult, error)
 	Move(context.Context, mountwrite.MoveRequest) (mountwrite.MutationResult, error)
 	Delete(context.Context, mountwrite.DeleteRequest) (mountwrite.MutationResult, error)
+	HardDelete(context.Context, mountwrite.HardDeleteRequest) (mountwrite.MutationResult, error)
 	Recover(context.Context) (mountwrite.RecoveryReport, error)
 	Status() mountwrite.Status
 	Drain(context.Context) error

--- a/backend/mountcache/coalescer.go
+++ b/backend/mountcache/coalescer.go
@@ -252,6 +252,31 @@ func (loads *Coalescer[K, V]) Invalidate(
 	}
 }
 
+// InvalidateAll atomically detaches every current load and evicts all cached
+// values. Future loads remain allowed. The eviction callback runs while the
+// load-group lock is held, preventing an older completion from publishing a
+// value between load cancellation and cache eviction.
+func (loads *Coalescer[K, V]) InvalidateAll(terminalErr error, evict func()) {
+	if terminalErr == nil {
+		terminalErr = context.Canceled
+	}
+	if loads == nil {
+		if evict != nil {
+			evict()
+		}
+		return
+	}
+
+	loads.mu.Lock()
+	for key := range loads.loads {
+		loads.invalidateLocked(key, terminalErr)
+	}
+	if evict != nil {
+		evict()
+	}
+	loads.mu.Unlock()
+}
+
 // Close permanently rejects new loads and cancels all active loads.
 func (loads *Coalescer[K, V]) Close(terminalErr error) {
 	if loads == nil {

--- a/backend/mountcache/coalescer_test.go
+++ b/backend/mountcache/coalescer_test.go
@@ -250,6 +250,55 @@ func TestCoalescerInvalidationWalksDependentKeysOnce(t *testing.T) {
 	}
 }
 
+func TestCoalescerInvalidateAllEvictsValuesAndDetachesEveryLoad(t *testing.T) {
+	errInvalidated := errors.New("all invalidated")
+	cache := NewLRU[string, string](LRUConfig[string]{Capacity: 4})
+	cache.Put("cached-a", "stale-a")
+	cache.Put("cached-b", "stale-b")
+	loads := NewCoalescer[string, string](0)
+
+	started := make(chan string, 2)
+	results := make(chan loadResult[string], 2)
+	for _, key := range []string{"loading-a", "loading-b"} {
+		key := key
+		go func() {
+			value, err := loads.Load(
+				context.Background(),
+				context.Background(),
+				key,
+				nil,
+				func(ctx context.Context) (string, error) {
+					started <- key
+					<-ctx.Done()
+					return "stale", nil
+				},
+				func(value string) { cache.Put(key, value) },
+			)
+			results <- loadResult[string]{value: value, err: err}
+		}()
+	}
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for active loads")
+		}
+	}
+
+	loads.InvalidateAll(errInvalidated, cache.Clear)
+	for range 2 {
+		if result := waitResult(t, results); !errors.Is(result.err, errInvalidated) {
+			t.Fatalf("invalidated load error = %v, want sentinel", result.err)
+		}
+	}
+	if got := cache.Len(); got != 0 {
+		t.Fatalf("cache length after InvalidateAll = %d, want 0", got)
+	}
+	if got := loads.Len(); got != 0 {
+		t.Fatalf("active loads after InvalidateAll = %d, want 0", got)
+	}
+}
+
 type loadResult[V any] struct {
 	value V
 	err   error

--- a/backend/mountcontroller/aggregate_session.go
+++ b/backend/mountcontroller/aggregate_session.go
@@ -81,6 +81,7 @@ func (controller *Controller) prepareSession(
 			FS:       filesystem,
 		})
 	}
+	controller.setFilesystems(active, filesystems)
 
 	if len(active.drives) == 1 {
 		filesystem := filesystems[active.drives[0].ID]
@@ -104,6 +105,12 @@ func (controller *Controller) prepareSession(
 		}
 	}
 	return aggregate, nil
+}
+
+func (controller *Controller) setFilesystems(active *session, filesystems map[int64]*mountfs.FS) {
+	controller.mu.Lock()
+	active.filesystemsByDrive = filesystems
+	controller.mu.Unlock()
 }
 
 func (controller *Controller) prepareWriter(

--- a/backend/mountcontroller/controller.go
+++ b/backend/mountcontroller/controller.go
@@ -42,33 +42,37 @@ type operation struct {
 }
 
 type session struct {
-	drive        Drive
-	drives       []Drive
-	selection    string
-	label        string
-	windowsDrive string
-	mode         Mode
-	writeState   WriteState
-	key          MountKeyLease
-	content      ContentLifetime
-	writer       WriteSession
-	attachment   mountos.Attachment
+	drive              Drive
+	drives             []Drive
+	selection          string
+	label              string
+	windowsDrive       string
+	mode               Mode
+	writeState         WriteState
+	key                MountKeyLease
+	content            ContentLifetime
+	writer             WriteSession
+	attachment         mountos.Attachment
+	filesystemsByDrive map[int64]*mountfs.FS
 }
 
 // Controller serializes the lifecycle of one mounted drive. Expensive work is
 // performed without holding mu so Status remains responsive during OS calls.
 type Controller struct {
-	mu          sync.Mutex
-	filesystems FilesystemBuilder
-	writers     WriterBuilder
-	keys        MountKeyLeaser
-	endpoint    Endpoint
-	connector   mountos.Connector
-	fsOptions   mountfs.Options
-	status      Status
-	session     *session
-	operation   *operation
-	lastErr     error
+	mu                    sync.Mutex
+	filesystems           FilesystemBuilder
+	writers               WriterBuilder
+	keys                  MountKeyLeaser
+	endpoint              Endpoint
+	connector             mountos.Connector
+	fsOptions             mountfs.Options
+	status                Status
+	session               *session
+	operation             *operation
+	lastErr               error
+	projectionChanges     ProjectionChangeSource
+	projectionChangesMu   sync.Mutex
+	stopProjectionChanges func()
 }
 
 // New creates a production controller around the Engine already owned by the
@@ -99,10 +103,11 @@ func NewWithConnector(engine *core.Engine, connector mountos.Connector) (*Contro
 			peers:  engine,
 			ranges: ranges,
 		},
-		Writers:   newEngineWriterBuilder(engine),
-		Keys:      engineMountKeyLeaser{engine: engine},
-		Endpoint:  newWebDAVEndpoint(),
-		Connector: connector,
+		Writers:           newEngineWriterBuilder(engine),
+		Keys:              engineMountKeyLeaser{engine: engine},
+		Endpoint:          newWebDAVEndpoint(),
+		Connector:         connector,
+		ProjectionChanges: engine,
 	})
 }
 
@@ -120,15 +125,18 @@ func NewWithDependencies(dependencies Dependencies) (*Controller, error) {
 		options.SnapshotTTL = defaultMountSnapshotTTL
 	}
 
-	return &Controller{
-		filesystems: dependencies.Filesystems,
-		writers:     dependencies.Writers,
-		keys:        dependencies.Keys,
-		endpoint:    dependencies.Endpoint,
-		connector:   dependencies.Connector,
-		fsOptions:   options,
-		status:      Status{Phase: PhaseStopped},
-	}, nil
+	controller := &Controller{
+		filesystems:       dependencies.Filesystems,
+		writers:           dependencies.Writers,
+		keys:              dependencies.Keys,
+		endpoint:          dependencies.Endpoint,
+		connector:         dependencies.Connector,
+		fsOptions:         options,
+		status:            Status{Phase: PhaseStopped},
+		projectionChanges: dependencies.ProjectionChanges,
+	}
+	controller.subscribeProjectionChanges()
+	return controller, nil
 }
 
 // Start mounts one drive without changing the Engine's active drive. It keeps
@@ -153,6 +161,7 @@ func (controller *Controller) startDrives(ctx context.Context, requested []Drive
 	if err := ctx.Err(); err != nil {
 		return controller.Status(), err
 	}
+	controller.subscribeProjectionChanges()
 	drives, err := normalizeDriveSelection(requested)
 	if err != nil {
 		return controller.Status(), err
@@ -307,6 +316,7 @@ func (controller *Controller) runStart(ctx context.Context, current *operation, 
 	status := controller.status
 	controller.completeLocked(current, status, nil)
 	controller.mu.Unlock()
+	controller.subscribeProjectionChanges()
 	return status, nil
 }
 
@@ -520,7 +530,53 @@ func (controller *Controller) Status() Status {
 // Close applies the same safe detach-first lifecycle as Stop.
 func (controller *Controller) Close(ctx context.Context) error {
 	_, err := controller.Stop(ctx)
+	if err == nil {
+		controller.unsubscribeProjectionChanges()
+	}
 	return err
+}
+
+func (controller *Controller) subscribeProjectionChanges() {
+	if controller == nil || controller.projectionChanges == nil {
+		return
+	}
+	controller.projectionChangesMu.Lock()
+	defer controller.projectionChangesMu.Unlock()
+	if controller.stopProjectionChanges == nil {
+		unsubscribe := controller.projectionChanges.SubscribeProjectionChanges(
+			controller.invalidateProjection,
+		)
+		if unsubscribe == nil {
+			unsubscribe = func() {}
+		}
+		controller.stopProjectionChanges = unsubscribe
+	}
+}
+
+func (controller *Controller) unsubscribeProjectionChanges() {
+	if controller == nil {
+		return
+	}
+	controller.projectionChangesMu.Lock()
+	unsubscribe := controller.stopProjectionChanges
+	controller.stopProjectionChanges = nil
+	controller.projectionChangesMu.Unlock()
+	if unsubscribe != nil {
+		unsubscribe()
+	}
+}
+
+func (controller *Controller) invalidateProjection(channelID int64) {
+	if controller == nil || channelID <= 0 {
+		return
+	}
+	controller.mu.Lock()
+	var filesystem *mountfs.FS
+	if controller.session != nil {
+		filesystem = controller.session.filesystemsByDrive[channelID]
+	}
+	controller.mu.Unlock()
+	filesystem.InvalidateAll()
 }
 
 func (controller *Controller) waitLocked(ctx context.Context, current *operation) (Status, error) {

--- a/backend/mountcontroller/controller_test.go
+++ b/backend/mountcontroller/controller_test.go
@@ -7,10 +7,98 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"TDrive/backend/mountfs"
 	"TDrive/backend/mountos"
 )
+
+func TestProjectionSyncInvalidatesOnlyTheMatchingMountedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	source := newProjectionRefreshSource([]mountfs.SourceEntry{{
+		ID:       "f:before",
+		ParentID: mountfs.RootID,
+		Name:     "before.txt",
+		Kind:     mountfs.KindFile,
+	}})
+	filesystem, err := mountfs.NewWithOptions(
+		personalDrive().ID,
+		source,
+		emptyContentOpener{},
+		mountfs.Options{SnapshotTTL: time.Hour},
+	)
+	if err != nil {
+		t.Fatalf("mountfs.NewWithOptions() error = %v", err)
+	}
+	changes := &fakeProjectionChangeSource{}
+	controller := newTestController(t, Dependencies{
+		Filesystems:       &fakeFilesystemBuilder{fs: filesystem, content: &fakeContent{}},
+		Endpoint:          &fakeEndpoint{endpoint: testEndpoint},
+		Connector:         &fakeConnector{},
+		ProjectionChanges: changes,
+	})
+	if _, err := controller.Start(context.Background(), personalDrive(), StartOptions{}); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() { _, _ = controller.Stop(context.Background()) })
+
+	entries, err := filesystem.ReadDir(context.Background(), "/")
+	if err != nil || len(entries) != 1 || entries[0].Name != "before.txt" {
+		t.Fatalf("warm ReadDir() = %#v, %v", entries, err)
+	}
+	source.replace([]mountfs.SourceEntry{{
+		ID:       "f:after",
+		ParentID: mountfs.RootID,
+		Name:     "after.txt",
+		Kind:     mountfs.KindFile,
+	}})
+	changes.notify(999)
+	entries, err = filesystem.ReadDir(context.Background(), "/")
+	if err != nil || len(entries) != 1 || entries[0].Name != "before.txt" {
+		t.Fatalf("unrelated sync refreshed cache: entries=%#v error=%v", entries, err)
+	}
+
+	changes.notify(personalDrive().ID)
+	entries, err = filesystem.ReadDir(context.Background(), "/")
+	if err != nil || len(entries) != 1 || entries[0].Name != "after.txt" {
+		t.Fatalf("ReadDir() after matching sync = %#v, %v; want fresh projection", entries, err)
+	}
+}
+
+func TestProjectionChangeSubscriptionFollowsControllerLifecycle(t *testing.T) {
+	t.Parallel()
+
+	changes := &fakeProjectionChangeSource{}
+	controller := newTestController(t, Dependencies{
+		Filesystems:       &fakeFilesystemBuilder{content: &fakeContent{}},
+		Endpoint:          &fakeEndpoint{endpoint: testEndpoint},
+		Connector:         &fakeConnector{},
+		ProjectionChanges: changes,
+	})
+	if subscribed, unsubscribed := changes.counts(); subscribed != 1 || unsubscribed != 0 {
+		t.Fatalf("constructor subscriptions = (%d, %d), want (1, 0)", subscribed, unsubscribed)
+	}
+	if err := controller.Close(context.Background()); err != nil {
+		t.Fatalf("Close() while stopped error = %v", err)
+	}
+	if subscribed, unsubscribed := changes.counts(); subscribed != 1 || unsubscribed != 1 {
+		t.Fatalf("closed subscriptions = (%d, %d), want (1, 1)", subscribed, unsubscribed)
+	}
+
+	if _, err := controller.Start(context.Background(), personalDrive(), StartOptions{}); err != nil {
+		t.Fatalf("Start() after Close error = %v", err)
+	}
+	if subscribed, unsubscribed := changes.counts(); subscribed != 2 || unsubscribed != 1 {
+		t.Fatalf("restart subscriptions = (%d, %d), want (2, 1)", subscribed, unsubscribed)
+	}
+	if err := controller.Close(context.Background()); err != nil {
+		t.Fatalf("final Close() error = %v", err)
+	}
+	if subscribed, unsubscribed := changes.counts(); subscribed != 2 || unsubscribed != 2 {
+		t.Fatalf("final subscriptions = (%d, %d), want (2, 2)", subscribed, unsubscribed)
+	}
+}
 
 func TestDisplayLabel(t *testing.T) {
 	t.Parallel()
@@ -1183,6 +1271,69 @@ type emptyContentOpener struct{}
 
 func (emptyContentOpener) OpenContent(context.Context, int64, mountfs.SourceEntry) (mountfs.RandomAccessContent, error) {
 	return nil, mountfs.ErrNotFound
+}
+
+type projectionRefreshSource struct {
+	mu      sync.Mutex
+	entries []mountfs.SourceEntry
+}
+
+func newProjectionRefreshSource(entries []mountfs.SourceEntry) *projectionRefreshSource {
+	return &projectionRefreshSource{entries: append([]mountfs.SourceEntry(nil), entries...)}
+}
+
+func (source *projectionRefreshSource) ListDirectory(
+	context.Context,
+	int64,
+	string,
+) ([]mountfs.SourceEntry, error) {
+	source.mu.Lock()
+	defer source.mu.Unlock()
+	return append([]mountfs.SourceEntry(nil), source.entries...), nil
+}
+
+func (source *projectionRefreshSource) replace(entries []mountfs.SourceEntry) {
+	source.mu.Lock()
+	source.entries = append([]mountfs.SourceEntry(nil), entries...)
+	source.mu.Unlock()
+}
+
+type fakeProjectionChangeSource struct {
+	mu              sync.Mutex
+	listener        func(int64)
+	subscriptions   int
+	unsubscriptions int
+}
+
+func (source *fakeProjectionChangeSource) SubscribeProjectionChanges(listener func(int64)) func() {
+	source.mu.Lock()
+	source.listener = listener
+	source.subscriptions++
+	source.mu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			source.mu.Lock()
+			source.listener = nil
+			source.unsubscriptions++
+			source.mu.Unlock()
+		})
+	}
+}
+
+func (source *fakeProjectionChangeSource) notify(channelID int64) {
+	source.mu.Lock()
+	listener := source.listener
+	source.mu.Unlock()
+	if listener != nil {
+		listener(channelID)
+	}
+}
+
+func (source *fakeProjectionChangeSource) counts() (int, int) {
+	source.mu.Lock()
+	defer source.mu.Unlock()
+	return source.subscriptions, source.unsubscriptions
 }
 
 type fakeEndpoint struct {

--- a/backend/mountcontroller/types.go
+++ b/backend/mountcontroller/types.go
@@ -192,6 +192,12 @@ type FilesystemBuilder interface {
 	Build(context.Context, int64, mountfs.Options, MountKeyLease) (*mountfs.FS, ContentLifetime, error)
 }
 
+// ProjectionChangeSource publishes successful remote projection refreshes.
+// Controllers subscribe once and invalidate only the matching mounted drive.
+type ProjectionChangeSource interface {
+	SubscribeProjectionChanges(func(channelID int64)) func()
+}
+
 // EndpointConfig is private-by-convention backend data. Endpoint must never be
 // serialized or copied into Status.
 type EndpointConfig struct {
@@ -226,12 +232,13 @@ type Endpoint interface {
 // Controller. SnapshotOptions with a zero TTL selects the mount-specific TTL,
 // while the remaining zero fields retain mountfs production defaults.
 type Dependencies struct {
-	Filesystems     FilesystemBuilder
-	Writers         WriterBuilder
-	Keys            MountKeyLeaser
-	Endpoint        Endpoint
-	Connector       mountos.Connector
-	SnapshotOptions mountfs.Options
+	Filesystems       FilesystemBuilder
+	Writers           WriterBuilder
+	Keys              MountKeyLeaser
+	Endpoint          Endpoint
+	Connector         mountos.Connector
+	ProjectionChanges ProjectionChangeSource
+	SnapshotOptions   mountfs.Options
 }
 
 // WriteStatus is a cheap, capability-free snapshot used during eject. Active

--- a/backend/mountcontroller/writer.go
+++ b/backend/mountcontroller/writer.go
@@ -68,12 +68,13 @@ func (builder engineWriterBuilder) Build(ctx context.Context, drive Drive, files
 		return nil, fmt.Errorf("%w: writable namespace resolver is unavailable", ErrInvalidConfiguration)
 	}
 	remote, err := mountadapter.NewTelegramRemote(mountadapter.TelegramRemoteConfig{
-		DB:       backend.DB,
-		DriveID:  drive.ID,
-		Files:    builder.engine.FileService(),
-		Telegram: builder.engine.Telegram(),
-		Peers:    builder.engine,
-		ActorID:  builder.engine.ActorID,
+		DB:             backend.DB,
+		DriveID:        drive.ID,
+		Files:          builder.engine.FileService(),
+		Telegram:       builder.engine.Telegram(),
+		Peers:          builder.engine,
+		ActorID:        builder.engine.ActorID,
+		ProjectThrough: builder.engine.PrepareHardDeleteProjection,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%w: writable Telegram adapter is unavailable", ErrInvalidConfiguration)

--- a/backend/mountdav/write_test.go
+++ b/backend/mountdav/write_test.go
@@ -31,6 +31,47 @@ type recordingWriteCoordinator struct {
 	err          error
 }
 
+type blockingDeleteCoordinator struct {
+	*recordingWriteCoordinator
+	started chan struct{}
+	release chan struct{}
+}
+
+func (writer *blockingDeleteCoordinator) Delete(_ context.Context, request DeleteRequest) (MutationResult, error) {
+	writer.mu.Lock()
+	writer.deleteRequest = request
+	writer.mu.Unlock()
+	close(writer.started)
+	<-writer.release
+	return writer.deleteResult, writer.err
+}
+
+type statusRecordingResponseWriter struct {
+	header http.Header
+	status chan int
+	once   sync.Once
+}
+
+func newStatusRecordingResponseWriter() *statusRecordingResponseWriter {
+	return &statusRecordingResponseWriter{
+		header: make(http.Header),
+		status: make(chan int, 1),
+	}
+}
+
+func (writer *statusRecordingResponseWriter) Header() http.Header {
+	return writer.header
+}
+
+func (writer *statusRecordingResponseWriter) WriteHeader(status int) {
+	writer.once.Do(func() { writer.status <- status })
+}
+
+func (writer *statusRecordingResponseWriter) Write(body []byte) (int, error) {
+	writer.WriteHeader(http.StatusOK)
+	return len(body), nil
+}
+
 func (writer *recordingWriteCoordinator) Put(ctx context.Context, request PutRequest, body io.Reader) (MutationResult, error) {
 	data, err := io.ReadAll(body)
 	if err != nil {
@@ -451,6 +492,121 @@ func TestWindowsMiniRedirectorDeleteIgnoresDepthForFiles(t *testing.T) {
 
 			if recorder.Code != http.StatusNoContent || writer.deleteRequest.Path != "/Docs/note.txt" {
 				t.Fatalf("DELETE Depth %q = %d, request %+v, body=%q", depth, recorder.Code, writer.deleteRequest, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestFileManagerDeleteRequestsShareProtocolPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		userAgent string
+		depth     string
+	}{
+		{name: "macOS Finder WebDAVFS", userAgent: "WebDAVFS/3.0.0 (03008000) Darwin/24.0.0", depth: "infinity"},
+		{name: "Windows MiniRedir", userAgent: "Microsoft-WebDAV-MiniRedir/10.0.26100", depth: "0"},
+		{name: "Linux GVfs", userAgent: "gvfs/1.54.1", depth: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writer := &recordingWriteCoordinator{}
+			handler := newWritableTestHandler(t, writer)
+			request := trustedRequest(http.MethodDelete, testCapability+"/Docs/note.txt", nil)
+			request.Header.Set("User-Agent", test.userAgent)
+			if test.depth != "" {
+				request.Header.Set("Depth", test.depth)
+			}
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, request)
+
+			if recorder.Code != http.StatusNoContent {
+				t.Fatalf("DELETE status = %d, body=%q, want 204", recorder.Code, recorder.Body.String())
+			}
+			if writer.deleteRequest.Path != "/Docs/note.txt" || writer.deleteRequest.OperationID == "" {
+				t.Fatalf("DELETE request = %+v, want shared canonical path and operation ID", writer.deleteRequest)
+			}
+		})
+	}
+}
+
+func TestDeleteWaitsForCoordinatorBeforeWritingNoContent(t *testing.T) {
+	writer := &blockingDeleteCoordinator{
+		recordingWriteCoordinator: &recordingWriteCoordinator{},
+		started:                   make(chan struct{}),
+		release:                   make(chan struct{}),
+	}
+	handler := newWritableTestHandler(t, writer)
+	response := newStatusRecordingResponseWriter()
+	request := trustedRequest(http.MethodDelete, testCapability+"/Docs/note.txt", nil)
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-writer.release:
+		default:
+			close(writer.release)
+		}
+	})
+
+	go func() {
+		defer close(done)
+		handler.ServeHTTP(response, request)
+	}()
+
+	select {
+	case <-writer.started:
+	case <-time.After(time.Second):
+		t.Fatal("DELETE did not reach coordinator")
+	}
+	select {
+	case status := <-response.status:
+		t.Fatalf("DELETE wrote status %d before coordinator completed", status)
+	default:
+	}
+
+	close(writer.release)
+	select {
+	case status := <-response.status:
+		if status != http.StatusNoContent {
+			t.Fatalf("DELETE status = %d, want 204", status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("DELETE did not write a response after coordinator completed")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("DELETE handler did not return after coordinator completed")
+	}
+}
+
+func TestDeletePendingCleanupReturnsRetryableUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "service unavailable", err: ErrWriteUnavailable},
+		{name: "durable cleanup pending", err: errors.Join(errors.New("hard-delete cleanup pending"), ErrWriteUnavailable)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writer := &recordingWriteCoordinator{err: test.err}
+			handler := newWritableTestHandler(t, writer)
+			request := trustedRequest(http.MethodDelete, testCapability+"/Docs/note.txt", nil)
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, request)
+
+			if recorder.Code != http.StatusServiceUnavailable {
+				t.Fatalf("DELETE status = %d, body=%q, want 503", recorder.Code, recorder.Body.String())
+			}
+			if got := recorder.Header().Get("Retry-After"); got != serverBusyRetrySeconds {
+				t.Fatalf("DELETE Retry-After = %q, want %q", got, serverBusyRetrySeconds)
+			}
+			if strings.Contains(recorder.Body.String(), "hard-delete") {
+				t.Fatalf("DELETE leaked internal cleanup state: %q", recorder.Body.String())
 			}
 		})
 	}

--- a/backend/mountfs/cache.go
+++ b/backend/mountfs/cache.go
@@ -127,6 +127,16 @@ func (cache *snapshotCache) invalidateSubtree(rootID string) {
 	})
 }
 
+// invalidateAll evicts the entire snapshot generation. It is used when a
+// remote sync may have changed arbitrary directories and therefore cannot
+// provide the narrower parent IDs used by local mutations.
+func (cache *snapshotCache) invalidateAll() {
+	if cache == nil {
+		return
+	}
+	cache.loads.InvalidateAll(errSnapshotInvalidated, cache.entries.Clear)
+}
+
 func (cache *snapshotCache) len() int {
 	if cache == nil {
 		return 0

--- a/backend/mountfs/fs.go
+++ b/backend/mountfs/fs.go
@@ -165,6 +165,15 @@ func (fs *FS) InvalidateSubtree(rootID string) {
 	fs.cache.invalidateSubtree(rootID)
 }
 
+// InvalidateAll evicts every cached directory snapshot for this drive. Use it
+// when an external projection refresh may have changed arbitrary paths.
+func (fs *FS) InvalidateAll() {
+	if fs == nil || fs.cache == nil {
+		return
+	}
+	fs.cache.invalidateAll()
+}
+
 func (fs *FS) ready(ctx context.Context) error {
 	if fs == nil || fs.source == nil || fs.opener == nil || fs.channelID <= 0 {
 		return ErrInvalidConfiguration

--- a/backend/mountfs/invalidation_test.go
+++ b/backend/mountfs/invalidation_test.go
@@ -260,12 +260,55 @@ func TestInvalidationIsSafeWithDisabledCacheAndNilFilesystem(t *testing.T) {
 	var nilFS *FS
 	nilFS.InvalidateDirectories(RootID, "d:any")
 	nilFS.InvalidateSubtree(RootID)
+	nilFS.InvalidateAll()
 
 	fs := mustNewFSWithOptions(t, 42, newMutableDirectorySource(nil), &fakeContentOpener{}, Options{
 		DisableSnapshotCache: true,
 	})
 	fs.InvalidateDirectories(RootID, "d:any")
 	fs.InvalidateSubtree(RootID)
+	fs.InvalidateAll()
+}
+
+func TestInvalidateAllRefreshesEveryCachedDirectory(t *testing.T) {
+	t.Parallel()
+
+	source := newMutableDirectorySource(map[string][]SourceEntry{
+		RootID: {
+			{ID: "d:first", ParentID: RootID, Name: "first", Kind: KindDirectory},
+			{ID: "d:second", ParentID: RootID, Name: "second", Kind: KindDirectory},
+		},
+		"d:first":  {{ID: "f:old-first", ParentID: "d:first", Name: "old-first.txt", Kind: KindFile}},
+		"d:second": {{ID: "f:old-second", ParentID: "d:second", Name: "old-second.txt", Kind: KindFile}},
+	})
+	fs := mustNewFSWithOptions(t, 42, source, &fakeContentOpener{}, Options{
+		SnapshotTTL:          time.Hour,
+		MaxCachedDirectories: 8,
+	})
+	for _, path := range []string{"/first", "/second"} {
+		if _, err := fs.ReadDir(context.Background(), path); err != nil {
+			t.Fatalf("warm ReadDir(%q) error = %v", path, err)
+		}
+	}
+	source.replace("d:first", nil)
+	source.replace("d:second", nil)
+
+	fs.InvalidateAll()
+
+	for _, path := range []string{"/first", "/second"} {
+		entries, err := fs.ReadDir(context.Background(), path)
+		if err != nil {
+			t.Fatalf("refreshed ReadDir(%q) error = %v", path, err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("refreshed ReadDir(%q) = %#v, want empty", path, entries)
+		}
+	}
+	for _, parentID := range []string{RootID, "d:first", "d:second"} {
+		if got := source.callsFor(parentID); got != 2 {
+			t.Errorf("loads for %q = %d, want 2", parentID, got)
+		}
+	}
 }
 
 type mutableDirectorySource struct {

--- a/backend/mountwrite/coordinator.go
+++ b/backend/mountwrite/coordinator.go
@@ -241,6 +241,9 @@ func (c *Coordinator) existingResult(ctx context.Context, record JournalRecord) 
 		}
 		result, err := c.finalizeCommitted(ctx, record)
 		return result, true, err
+	case StateDeletePlanPending, StateDeletingBodies, StateDeleteFinalizing:
+		result, err := c.resumeHardDelete(ctx, record)
+		return result, true, err
 	default:
 		return MutationResult{}, false, nil
 	}

--- a/backend/mountwrite/coordinator_test.go
+++ b/backend/mountwrite/coordinator_test.go
@@ -1030,9 +1030,11 @@ func TestNilCoordinatorIsSafelyUnavailable(t *testing.T) {
 }
 
 func TestCoordinatorBoundsAdmittedAndConcurrentOperations(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
+	// This test already creates deliberate concurrency. Keep it out of the
+	// package-wide parallel pool so filesystem-backed SQLite startup latency on
+	// loaded Windows runners cannot consume the synchronization budget.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
 	db := openJournalDB(t, filepath.Join(t.TempDir(), "journal.db"))
 	if err := EnsureJournalSchema(ctx, db); err != nil {
 		t.Fatalf("ensure schema: %v", err)
@@ -1066,8 +1068,15 @@ func TestCoordinatorBoundsAdmittedAndConcurrentOperations(t *testing.T) {
 	}
 
 	results := make(chan error, 5)
+	var operations sync.WaitGroup
+	t.Cleanup(func() {
+		remote.releaseAll()
+		operations.Wait()
+	})
 	startMove := func(index int) {
+		operations.Add(1)
 		go func() {
+			defer operations.Done()
 			_, moveErr := coordinator.Move(ctx, MoveRequest{
 				OperationID:         fmt.Sprintf("bounded-%d", index),
 				DriveID:             42,
@@ -1081,11 +1090,11 @@ func TestCoordinatorBoundsAdmittedAndConcurrentOperations(t *testing.T) {
 	}
 	startMove(0)
 	startMove(1)
-	remote.waitForEntered(t, 2)
+	remote.waitForEntered(ctx, t, 2)
 	startMove(2)
 	startMove(3)
 	startMove(4)
-	waitForStatus(t, coordinator, Status{Accepting: true, Active: 5})
+	waitForStatus(ctx, t, coordinator, Status{Accepting: true, Active: 5})
 
 	_, err = coordinator.Move(ctx, MoveRequest{
 		OperationID:         "rejected-sixth",
@@ -1107,7 +1116,7 @@ func TestCoordinatorBoundsAdmittedAndConcurrentOperations(t *testing.T) {
 	if remote.maxConcurrent() != 2 || remote.commitCount() != 5 {
 		t.Fatalf("remote max=%d commits=%d, want max=2 commits=5", remote.maxConcurrent(), remote.commitCount())
 	}
-	waitForStatus(t, coordinator, Status{Accepting: true})
+	waitForStatus(ctx, t, coordinator, Status{Accepting: true})
 }
 
 func newTestCoordinator(t *testing.T, remote Remote, invalidator SnapshotInvalidator) (*Coordinator, Journal, *DiskStagingStore) {
@@ -1226,13 +1235,13 @@ func (r *concurrencyRemote) DiscardHidden(context.Context, string, *RemoteBody) 
 	return nil
 }
 
-func (r *concurrencyRemote) waitForEntered(t *testing.T, count int) {
+func (r *concurrencyRemote) waitForEntered(ctx context.Context, t *testing.T, count int) {
 	t.Helper()
 	for range count {
 		select {
 		case <-r.entered:
-		case <-time.After(time.Second):
-			t.Fatal("remote operation did not enter")
+		case <-ctx.Done():
+			t.Fatalf("remote operation did not enter: %v", ctx.Err())
 		}
 	}
 }
@@ -1253,16 +1262,20 @@ func (r *concurrencyRemote) commitCount() int {
 	return r.commits
 }
 
-func waitForStatus(t *testing.T, coordinator *Coordinator, want Status) {
+func waitForStatus(ctx context.Context, t *testing.T, coordinator *Coordinator, want Status) {
 	t.Helper()
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
 		if got := coordinator.Status(); got == want {
 			return
 		}
-		time.Sleep(time.Millisecond)
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			t.Fatalf("status = %#v, want %#v: %v", coordinator.Status(), want, ctx.Err())
+		}
 	}
-	t.Fatalf("status = %#v, want %#v", coordinator.Status(), want)
 }
 
 func (r *fakeRemote) UploadHidden(_ context.Context, request HiddenUpload, source io.ReadSeeker) (RemoteBody, error) {

--- a/backend/mountwrite/hard_delete.go
+++ b/backend/mountwrite/hard_delete.go
@@ -1,0 +1,184 @@
+package mountwrite
+
+import (
+	"context"
+	"log/slog"
+)
+
+const (
+	hardDeletePlanPageSize = 500
+	hardDeleteBatchSize    = 100
+)
+
+// HardDelete commits a durable namespace marker, imports the exact backing
+// message plan into the local journal, and synchronously deletes every body.
+// A caller receives success only after the projection has finalized the plan.
+func (c *Coordinator) HardDelete(ctx context.Context, request HardDeleteRequest) (MutationResult, error) {
+	if c == nil || ctx == nil {
+		return MutationResult{}, newOperationError(request.OperationID, MutationHardDelete, ErrInvalidRequest)
+	}
+	if err := request.Validate(); err != nil {
+		return MutationResult{}, newOperationError(request.OperationID, MutationHardDelete, err)
+	}
+	if _, _, err := c.hardDeleteCapabilities(); err != nil {
+		return MutationResult{}, newOperationError(request.OperationID, MutationHardDelete, err)
+	}
+
+	operationID := c.operationID(request.OperationID)
+	mutation := request.mutation()
+	result, err := c.withOperation(ctx, operationID, mutation, func(ctx context.Context, record JournalRecord) (MutationResult, error) {
+		prepared, transitionErr := c.transition(ctx, record, StateStaged, JournalPatch{})
+		if transitionErr != nil {
+			c.markAborted(ctx, record, transitionErr)
+			return MutationResult{}, operationError(record, transitionErr)
+		}
+		return c.commitPrepared(ctx, prepared)
+	})
+	if err != nil {
+		slog.Warn("mountwrite: hard delete pending", "object_id", request.ObjectID, "operation_id", operationID, "error", err)
+	}
+	return result, err
+}
+
+func (c *Coordinator) hardDeleteCapabilities() (HardDeleteJournal, HardDeleteRemote, error) {
+	journal, journalOK := c.journal.(HardDeleteJournal)
+	remote, remoteOK := c.remote.(HardDeleteRemote)
+	if !journalOK || !remoteOK {
+		return nil, nil, ErrUnavailable
+	}
+	return journal, remote, nil
+}
+
+func (c *Coordinator) resumeHardDelete(ctx context.Context, record JournalRecord) (MutationResult, error) {
+	if record.Mutation.Kind != MutationHardDelete {
+		return MutationResult{}, operationError(record, ErrInvalidRequest)
+	}
+	result, err := requireResult(record)
+	if err != nil {
+		return MutationResult{}, operationError(record, err)
+	}
+	journal, remote, err := c.hardDeleteCapabilities()
+	if err != nil {
+		return MutationResult{}, operationError(record, err)
+	}
+
+	current := record
+	if current.State == StateRemoteCommitted {
+		if err := c.invalidator.Invalidate(ctx, c.exactInvalidation(current, result)); err != nil {
+			return MutationResult{}, operationError(current, err)
+		}
+		current, err = c.transition(ctx, current, StateDeletePlanPending, JournalPatch{Result: &result})
+		if err != nil {
+			return MutationResult{}, operationError(record, err)
+		}
+	}
+	if current.State == StateDeletePlanPending {
+		if err := c.importHardDeletePlan(ctx, current, journal, remote); err != nil {
+			return MutationResult{}, operationError(current, err)
+		}
+		current, err = c.transition(ctx, current, StateDeletingBodies, JournalPatch{})
+		if err != nil {
+			return MutationResult{}, operationError(current, err)
+		}
+	}
+	if current.State == StateDeletingBodies {
+		current, err = c.deleteHardDeleteBodies(ctx, current, journal, remote)
+		if err != nil {
+			return MutationResult{}, operationError(current, err)
+		}
+	}
+	if current.State == StateDeleteFinalizing {
+		if err := remote.FinalizeHardDelete(ctx, current.OperationID); err != nil {
+			return MutationResult{}, operationError(current, err)
+		}
+		if err := journal.CompactHardDeletePlan(ctx, current.OperationID); err != nil {
+			return MutationResult{}, operationError(current, err)
+		}
+		current, err = c.transition(ctx, current, StateDone, JournalPatch{Result: &result})
+		if err != nil {
+			return MutationResult{}, operationError(current, err)
+		}
+	}
+	if current.State != StateDone {
+		return MutationResult{}, operationError(current, ErrInvalidTransition)
+	}
+	return result, nil
+}
+
+func (c *Coordinator) importHardDeletePlan(
+	ctx context.Context,
+	record JournalRecord,
+	journal HardDeleteJournal,
+	remote HardDeleteRemote,
+) error {
+	status, found, err := journal.HardDeletePlanStatus(ctx, record.OperationID)
+	if err != nil {
+		return err
+	}
+	for !found || !status.Sealed {
+		messageIDs, total, done, err := remote.HardDeletePlan(
+			ctx,
+			record.OperationID,
+			status.Cursor,
+			hardDeletePlanPageSize,
+		)
+		if err != nil {
+			return err
+		}
+		if len(messageIDs) == 0 && !done {
+			return ErrUnavailable
+		}
+		if len(messageIDs) > 0 && messageIDs[0] <= status.Cursor {
+			return ErrInvalidRequest
+		}
+		if err := journal.AppendHardDeletePlan(ctx, record.OperationID, messageIDs, total, done); err != nil {
+			return err
+		}
+		status, found, err = journal.HardDeletePlanStatus(ctx, record.OperationID)
+		if err != nil {
+			return err
+		}
+	}
+	if status.PlannedCount != status.ExpectedCount || status.CompletedCount > status.PlannedCount {
+		return ErrConflict
+	}
+	return nil
+}
+
+func (c *Coordinator) deleteHardDeleteBodies(
+	ctx context.Context,
+	record JournalRecord,
+	journal HardDeleteJournal,
+	remote HardDeleteRemote,
+) (JournalRecord, error) {
+	current := record
+	for {
+		messageIDs, err := journal.NextHardDeleteBatch(ctx, current.OperationID, hardDeleteBatchSize)
+		if err != nil {
+			return current, err
+		}
+		if len(messageIDs) == 0 {
+			status, found, statusErr := journal.HardDeletePlanStatus(ctx, current.OperationID)
+			if statusErr != nil {
+				return current, statusErr
+			}
+			if !found || !status.Sealed || status.PlannedCount != status.ExpectedCount ||
+				status.CompletedCount != status.ExpectedCount {
+				return current, ErrConflict
+			}
+			return c.transition(ctx, current, StateDeleteFinalizing, JournalPatch{})
+		}
+		if err := remote.DeleteBodies(ctx, current.OperationID, messageIDs); err != nil {
+			return current, err
+		}
+		if err := journal.MarkHardDeleteBatchDone(ctx, current.OperationID, messageIDs); err != nil {
+			// Telegram deletion is idempotent. If this local checkpoint fails,
+			// recovery safely repeats only this uncheckpointed batch.
+			return current, err
+		}
+	}
+}
+
+func isHardDeleteState(state JournalState) bool {
+	return state == StateDeletePlanPending || state == StateDeletingBodies || state == StateDeleteFinalizing
+}

--- a/backend/mountwrite/hard_delete_test.go
+++ b/backend/mountwrite/hard_delete_test.go
@@ -1,0 +1,256 @@
+package mountwrite
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+)
+
+func TestHardDeleteRequestUsesDistinctRetentionFreeMutation(t *testing.T) {
+	t.Parallel()
+
+	request := HardDeleteRequest{
+		OperationID:      "hard-delete-1",
+		DriveID:          42,
+		ObjectID:         "folder-1",
+		ParentID:         "parent-1",
+		ExpectedRevision: 7,
+	}
+	if err := request.Validate(); err != nil {
+		t.Fatalf("validate hard delete: %v", err)
+	}
+	mutation := request.mutation()
+	if mutation.Kind != MutationHardDelete || mutation.TrashRetention != 0 || !mutation.Recursive {
+		t.Fatalf("hard delete mutation = %#v", mutation)
+	}
+
+	invalid := []HardDeleteRequest{
+		{DriveID: 0, ObjectID: "file-1", ExpectedRevision: 1},
+		{DriveID: 42},
+		{DriveID: 42, ObjectID: "file-1"},
+		{OperationID: "bad\noperation", DriveID: 42, ObjectID: "file-1", ExpectedRevision: 1},
+	}
+	for _, candidate := range invalid {
+		if err := candidate.Validate(); !errors.Is(err, ErrInvalidRequest) {
+			t.Fatalf("invalid request %#v error = %v", candidate, err)
+		}
+	}
+}
+
+func TestCoordinatorHardDeleteBatchesOnlyAfterSealedDurablePlan(t *testing.T) {
+	t.Parallel()
+
+	remote := &fakeHardDeleteRemote{fakeRemote: &fakeRemote{}, plan: sequenceMessageIDs(201)}
+	coordinator, journal, _ := newTestCoordinator(t, remote, &fakeInvalidator{})
+	result, err := coordinator.HardDelete(context.Background(), HardDeleteRequest{
+		OperationID:      "hard-delete-batches",
+		DriveID:          42,
+		ObjectID:         "folder-1",
+		ExpectedRevision: 3,
+	})
+	if err != nil {
+		t.Fatalf("hard delete: %v", err)
+	}
+	if result.ObjectID != "folder-1" {
+		t.Fatalf("result = %#v", result)
+	}
+	if got := remote.deleted(); len(got) != 3 || len(got[0]) != 100 || len(got[1]) != 100 || len(got[2]) != 1 {
+		t.Fatalf("delete batches = %#v", got)
+	}
+	if remote.finalized() != 1 {
+		t.Fatalf("finalize calls = %d, want 1", remote.finalized())
+	}
+	if state := mustJournalRecord(t, journal, "hard-delete-batches").State; state != StateDone {
+		t.Fatalf("state = %s, want done", state)
+	}
+	planJournal := journal.(HardDeleteJournal)
+	_, found, err := planJournal.HardDeletePlanStatus(context.Background(), "hard-delete-batches")
+	if err != nil || found {
+		t.Fatalf("completed plan retained hot rows: found=%v err=%v", found, err)
+	}
+}
+
+func TestCoordinatorHardDeleteRecoveryResumesUnresolvedBodies(t *testing.T) {
+	t.Parallel()
+
+	remote := &fakeHardDeleteRemote{
+		fakeRemote:   &fakeRemote{},
+		plan:         sequenceMessageIDs(201),
+		failDeleteAt: 2,
+	}
+	coordinator, journal, _ := newTestCoordinator(t, remote, &fakeInvalidator{})
+	_, err := coordinator.HardDelete(context.Background(), HardDeleteRequest{
+		OperationID:      "hard-delete-recovery",
+		DriveID:          42,
+		ObjectID:         "folder-1",
+		ExpectedRevision: 1,
+	})
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("hard delete error = %v, want ErrUnavailable", err)
+	}
+	if state := mustJournalRecord(t, journal, "hard-delete-recovery").State; state != StateDeletingBodies {
+		t.Fatalf("state after failure = %s, want deleting bodies", state)
+	}
+
+	remote.clearDeleteFailure()
+	report, err := coordinator.Recover(context.Background())
+	if err != nil {
+		t.Fatalf("recover: report=%#v err=%v", report, err)
+	}
+	if state := mustJournalRecord(t, journal, "hard-delete-recovery").State; state != StateDone {
+		t.Fatalf("state after recovery = %s, want done", state)
+	}
+	got := remote.deleted()
+	if len(got) != 4 || !slices.Equal(got[0], sequenceMessageIDs(100)) ||
+		!slices.Equal(got[1], sequenceMessageIDs(201)[100:200]) ||
+		!slices.Equal(got[2], sequenceMessageIDs(201)[100:200]) ||
+		!slices.Equal(got[3], []int64{201}) {
+		t.Fatalf("delete calls = %#v", got)
+	}
+	if remote.commitCalls != 1 {
+		t.Fatalf("commit calls after recovery = %d, want 1", remote.commitCalls)
+	}
+}
+
+func TestCoordinatorHardDeleteFailsClosedWhenDurableCommitTransitionFails(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := openJournalDB(t, filepath.Join(t.TempDir(), "journal.db"))
+	if err := EnsureJournalSchema(ctx, db); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+	base, err := NewSQLiteJournal(db)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	journal := &failingHardDeleteJournal{SQLiteJournal: base, failNext: StateRemoteCommitted}
+	staging, err := NewDiskStagingStore(DiskStagingConfig{
+		Root: filepath.Join(t.TempDir(), "staging"), MaxObjectBytes: 1024,
+		MaxAggregateBytes: 2048, MaxConcurrent: 1,
+	})
+	if err != nil {
+		t.Fatalf("new staging: %v", err)
+	}
+	remote := &fakeHardDeleteRemote{fakeRemote: &fakeRemote{}, plan: []int64{11}}
+	coordinator := buildCoordinator(t, journal, staging, remote, &fakeInvalidator{})
+
+	_, err = coordinator.HardDelete(ctx, HardDeleteRequest{
+		OperationID: "hard-delete-journal-failure", DriveID: 42,
+		ObjectID: "file-1", ExpectedRevision: 1,
+	})
+	if err == nil {
+		t.Fatal("hard delete reported success without a durable remote-committed transition")
+	}
+	if len(remote.deleted()) != 0 {
+		t.Fatalf("body deletion started without durable commit state: %v", remote.deleted())
+	}
+	if state := mustJournalRecord(t, base, "hard-delete-journal-failure").State; state != StateCommitting {
+		t.Fatalf("durable state = %s, want committing for recovery", state)
+	}
+}
+
+func TestCoordinatorHardDeleteDoesNotReturnSuccessWhileCleanupPending(t *testing.T) {
+	t.Parallel()
+
+	remote := &fakeHardDeleteRemote{fakeRemote: &fakeRemote{}, plan: []int64{11}, failAllDeletes: true}
+	coordinator, _, _ := newTestCoordinator(t, remote, &fakeInvalidator{})
+	request := HardDeleteRequest{OperationID: "hard-delete-pending", DriveID: 42, ObjectID: "file-1", ExpectedRevision: 1}
+	if _, err := coordinator.HardDelete(context.Background(), request); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("first hard delete error = %v, want ErrUnavailable", err)
+	}
+	if _, err := coordinator.HardDelete(context.Background(), request); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("repeated hard delete error = %v, want ErrUnavailable", err)
+	}
+	if remote.commitCalls != 1 {
+		t.Fatalf("commit calls = %d, want one durable marker", remote.commitCalls)
+	}
+}
+
+type fakeHardDeleteRemote struct {
+	*fakeRemote
+
+	deleteMu       sync.Mutex
+	plan           []int64
+	deleteCalls    [][]int64
+	failDeleteAt   int
+	failAllDeletes bool
+	finalizeCalls  int
+}
+
+func (r *fakeHardDeleteRemote) HardDeletePlan(_ context.Context, _ string, afterMsgID int64, limit int) ([]int64, int64, bool, error) {
+	start := 0
+	for start < len(r.plan) && r.plan[start] <= afterMsgID {
+		start++
+	}
+	end := min(start+limit, len(r.plan))
+	page := append([]int64(nil), r.plan[start:end]...)
+	return page, int64(len(r.plan)), end == len(r.plan), nil
+}
+
+func (r *fakeHardDeleteRemote) DeleteBodies(_ context.Context, _ string, messageIDs []int64) error {
+	r.deleteMu.Lock()
+	defer r.deleteMu.Unlock()
+	r.deleteCalls = append(r.deleteCalls, append([]int64(nil), messageIDs...))
+	if r.failAllDeletes || (r.failDeleteAt > 0 && len(r.deleteCalls) == r.failDeleteAt) {
+		return errors.New("temporary Telegram delete failure")
+	}
+	return nil
+}
+
+type failingHardDeleteJournal struct {
+	*SQLiteJournal
+	failNext JournalState
+}
+
+func (j *failingHardDeleteJournal) Transition(
+	ctx context.Context,
+	operationID string,
+	expected, next JournalState,
+	patch JournalPatch,
+) (JournalRecord, error) {
+	if next == j.failNext {
+		return JournalRecord{}, errors.New("temporary journal failure")
+	}
+	return j.SQLiteJournal.Transition(ctx, operationID, expected, next, patch)
+}
+
+func (r *fakeHardDeleteRemote) FinalizeHardDelete(context.Context, string) error {
+	r.deleteMu.Lock()
+	defer r.deleteMu.Unlock()
+	r.finalizeCalls++
+	return nil
+}
+
+func (r *fakeHardDeleteRemote) deleted() [][]int64 {
+	r.deleteMu.Lock()
+	defer r.deleteMu.Unlock()
+	result := make([][]int64, len(r.deleteCalls))
+	for i := range r.deleteCalls {
+		result[i] = append([]int64(nil), r.deleteCalls[i]...)
+	}
+	return result
+}
+
+func (r *fakeHardDeleteRemote) finalized() int {
+	r.deleteMu.Lock()
+	defer r.deleteMu.Unlock()
+	return r.finalizeCalls
+}
+
+func (r *fakeHardDeleteRemote) clearDeleteFailure() {
+	r.deleteMu.Lock()
+	defer r.deleteMu.Unlock()
+	r.failDeleteAt = 0
+}
+
+func sequenceMessageIDs(count int) []int64 {
+	result := make([]int64, count)
+	for i := range result {
+		result[i] = int64(i + 1)
+	}
+	return result
+}

--- a/backend/mountwrite/journal.go
+++ b/backend/mountwrite/journal.go
@@ -44,6 +44,28 @@ type Journal interface {
 	ListRecoverable(ctx context.Context) ([]JournalRecord, error)
 }
 
+// HardDeletePlanStatus is a compact summary of a normalized hard-delete plan.
+// Cursor is the greatest durably imported message ID and supports bounded
+// projection paging without loading the entire plan into memory.
+type HardDeletePlanStatus struct {
+	ExpectedCount  int64
+	PlannedCount   int64
+	CompletedCount int64
+	Cursor         int64
+	Sealed         bool
+}
+
+// HardDeleteJournal is an optional journal capability used only by permanent
+// deletes. Keeping it separate preserves compatibility for journals that only
+// support the original writable-mount operations.
+type HardDeleteJournal interface {
+	AppendHardDeletePlan(ctx context.Context, operationID string, messageIDs []int64, total int64, done bool) error
+	NextHardDeleteBatch(ctx context.Context, operationID string, limit int) ([]int64, error)
+	MarkHardDeleteBatchDone(ctx context.Context, operationID string, messageIDs []int64) error
+	HardDeletePlanStatus(ctx context.Context, operationID string) (HardDeletePlanStatus, bool, error)
+	CompactHardDeletePlan(ctx context.Context, operationID string) error
+}
+
 type SQLiteJournal struct {
 	db *sql.DB
 }
@@ -69,6 +91,19 @@ func EnsureJournalSchema(ctx context.Context, db *sql.DB) error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_mount_write_journal_recovery
 			ON mount_write_journal(state, updated_at_ns, operation_id)`,
+		`CREATE TABLE IF NOT EXISTS mount_write_hard_delete_plans (
+			operation_id TEXT PRIMARY KEY NOT NULL,
+			expected_count INTEGER NOT NULL,
+			sealed INTEGER NOT NULL DEFAULT 0 CHECK (sealed IN (0, 1))
+		)`,
+		`CREATE TABLE IF NOT EXISTS mount_write_hard_delete_messages (
+			operation_id TEXT NOT NULL,
+			message_id INTEGER NOT NULL CHECK (message_id > 0),
+			completed INTEGER NOT NULL DEFAULT 0 CHECK (completed IN (0, 1)),
+			PRIMARY KEY (operation_id, message_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_mount_write_hard_delete_pending
+			ON mount_write_hard_delete_messages(operation_id, completed, message_id)`,
 	}
 	for _, statement := range statements {
 		if _, err := db.ExecContext(ctx, statement); err != nil {
@@ -398,7 +433,8 @@ func knownState(state JournalState) bool {
 	switch state {
 	case StateReceiving, StateStaged, StateUploading, StateUploaded, StateCommitting,
 		StateReconciling, StateRemoteCommitted, StateProjectionPending,
-		StateCleanupPending, StateDone, StateAborted:
+		StateCleanupPending, StateDeletePlanPending, StateDeletingBodies,
+		StateDeleteFinalizing, StateDone, StateAborted:
 		return true
 	default:
 		return false

--- a/backend/mountwrite/journal_hard_delete.go
+++ b/backend/mountwrite/journal_hard_delete.go
@@ -1,0 +1,303 @@
+package mountwrite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+const maxHardDeleteJournalBatch = 1000
+
+func (j *SQLiteJournal) AppendHardDeletePlan(
+	ctx context.Context,
+	operationID string,
+	messageIDs []int64,
+	total int64,
+	done bool,
+) error {
+	if j == nil || j.db == nil || ctx == nil || operationID == "" || !validOperationID(operationID) ||
+		total < 0 || len(messageIDs) > maxHardDeleteJournalBatch || !validSortedMessageIDs(messageIDs) {
+		return ErrInvalidRequest
+	}
+	tx, err := j.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin hard-delete plan append: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var kind MutationKind
+	var state JournalState
+	if err := tx.QueryRowContext(ctx, `
+		SELECT kind, state FROM mount_write_journal WHERE operation_id = ?`, operationID,
+	).Scan(&kind, &state); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("load hard-delete journal operation: %w", err)
+	}
+	if kind != MutationHardDelete || state != StateDeletePlanPending {
+		return ErrInvalidTransition
+	}
+
+	expected, sealed, found, err := hardDeletePlanHeader(ctx, tx, operationID)
+	if err != nil {
+		return err
+	}
+	if found && expected != total {
+		return ErrConflict
+	}
+	if !found {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO mount_write_hard_delete_plans (operation_id, expected_count, sealed)
+			VALUES (?, ?, 0)`, operationID, total); err != nil {
+			return fmt.Errorf("create hard-delete plan: %w", err)
+		}
+	}
+	if sealed {
+		matches, err := countPlannedMessageIDs(ctx, tx, operationID, messageIDs)
+		if err != nil {
+			return err
+		}
+		if matches == int64(len(messageIDs)) && done {
+			return tx.Commit()
+		}
+		return ErrConflict
+	}
+
+	for _, messageID := range messageIDs {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO mount_write_hard_delete_messages (operation_id, message_id, completed)
+			VALUES (?, ?, 0)`, operationID, messageID); err != nil {
+			return fmt.Errorf("append hard-delete message: %w", err)
+		}
+	}
+	var planned int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM mount_write_hard_delete_messages WHERE operation_id = ?`, operationID,
+	).Scan(&planned); err != nil {
+		return fmt.Errorf("count hard-delete plan: %w", err)
+	}
+	if planned > total || (done && planned != total) {
+		return ErrConflict
+	}
+	if done {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE mount_write_hard_delete_plans SET sealed = 1 WHERE operation_id = ?`, operationID); err != nil {
+			return fmt.Errorf("seal hard-delete plan: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit hard-delete plan append: %w", err)
+	}
+	return nil
+}
+
+func (j *SQLiteJournal) NextHardDeleteBatch(ctx context.Context, operationID string, limit int) ([]int64, error) {
+	if j == nil || j.db == nil || ctx == nil || operationID == "" || !validOperationID(operationID) ||
+		limit <= 0 || limit > maxHardDeleteJournalBatch {
+		return nil, ErrInvalidRequest
+	}
+	rows, err := j.db.QueryContext(ctx, `
+		SELECT message_id
+		FROM mount_write_hard_delete_messages
+		WHERE operation_id = ? AND completed = 0
+		ORDER BY message_id
+		LIMIT ?`, operationID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list pending hard-delete messages: %w", err)
+	}
+	defer rows.Close()
+	messageIDs := make([]int64, 0, limit)
+	for rows.Next() {
+		var messageID int64
+		if err := rows.Scan(&messageID); err != nil {
+			return nil, fmt.Errorf("scan pending hard-delete message: %w", err)
+		}
+		messageIDs = append(messageIDs, messageID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending hard-delete messages: %w", err)
+	}
+	return messageIDs, nil
+}
+
+func (j *SQLiteJournal) MarkHardDeleteBatchDone(ctx context.Context, operationID string, messageIDs []int64) error {
+	if j == nil || j.db == nil || ctx == nil || operationID == "" || !validOperationID(operationID) ||
+		len(messageIDs) == 0 || len(messageIDs) > maxHardDeleteJournalBatch || !validSortedMessageIDs(messageIDs) {
+		return ErrInvalidRequest
+	}
+	tx, err := j.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin hard-delete checkpoint: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	_, sealed, found, err := hardDeletePlanHeader(ctx, tx, operationID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return ErrNotFound
+	}
+	if !sealed {
+		return ErrInvalidTransition
+	}
+	matches, err := countPlannedMessageIDs(ctx, tx, operationID, messageIDs)
+	if err != nil {
+		return err
+	}
+	if matches != int64(len(messageIDs)) {
+		return ErrConflict
+	}
+	for _, messageID := range messageIDs {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE mount_write_hard_delete_messages
+			SET completed = 1
+			WHERE operation_id = ? AND message_id = ?`, operationID, messageID); err != nil {
+			return fmt.Errorf("checkpoint hard-delete message: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit hard-delete checkpoint: %w", err)
+	}
+	return nil
+}
+
+func (j *SQLiteJournal) HardDeletePlanStatus(
+	ctx context.Context,
+	operationID string,
+) (HardDeletePlanStatus, bool, error) {
+	if j == nil || j.db == nil || ctx == nil || operationID == "" || !validOperationID(operationID) {
+		return HardDeletePlanStatus{}, false, ErrInvalidRequest
+	}
+	return hardDeletePlanStatusTx(ctx, j.db, operationID)
+}
+
+// CompactHardDeletePlan removes per-message progress after remote finalization.
+// StateDeleteFinalizing is itself durable, so a crash after compaction safely
+// repeats this idempotent step without retaining one local row per deleted
+// Telegram body forever.
+func (j *SQLiteJournal) CompactHardDeletePlan(ctx context.Context, operationID string) error {
+	if j == nil || j.db == nil || ctx == nil || operationID == "" || !validOperationID(operationID) {
+		return ErrInvalidRequest
+	}
+	tx, err := j.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin hard-delete plan compaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var kind MutationKind
+	var state JournalState
+	if err := tx.QueryRowContext(ctx, `
+		SELECT kind, state FROM mount_write_journal WHERE operation_id = ?`, operationID,
+	).Scan(&kind, &state); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("load hard-delete operation for compaction: %w", err)
+	}
+	if kind != MutationHardDelete || state != StateDeleteFinalizing {
+		return ErrInvalidTransition
+	}
+
+	status, found, err := hardDeletePlanStatusTx(ctx, tx, operationID)
+	if err != nil {
+		return err
+	}
+	if found {
+		if !status.Sealed || status.PlannedCount != status.ExpectedCount ||
+			status.CompletedCount != status.ExpectedCount {
+			return ErrConflict
+		}
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM mount_write_hard_delete_messages WHERE operation_id = ?`, operationID); err != nil {
+			return fmt.Errorf("compact hard-delete messages: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM mount_write_hard_delete_plans WHERE operation_id = ?`, operationID); err != nil {
+			return fmt.Errorf("compact hard-delete plan: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit hard-delete plan compaction: %w", err)
+	}
+	return nil
+}
+
+func hardDeletePlanStatusTx(
+	ctx context.Context,
+	query queryRower,
+	operationID string,
+) (HardDeletePlanStatus, bool, error) {
+	var status HardDeletePlanStatus
+	var sealed int
+	err := query.QueryRowContext(ctx, `
+		SELECT p.expected_count,
+		       COUNT(m.message_id),
+		       COALESCE(SUM(CASE WHEN m.completed = 1 THEN 1 ELSE 0 END), 0),
+		       COALESCE(MAX(m.message_id), 0),
+		       p.sealed
+		FROM mount_write_hard_delete_plans AS p
+		LEFT JOIN mount_write_hard_delete_messages AS m ON m.operation_id = p.operation_id
+		WHERE p.operation_id = ?
+		GROUP BY p.operation_id, p.expected_count, p.sealed`, operationID,
+	).Scan(&status.ExpectedCount, &status.PlannedCount, &status.CompletedCount, &status.Cursor, &sealed)
+	if errors.Is(err, sql.ErrNoRows) {
+		return HardDeletePlanStatus{}, false, nil
+	}
+	if err != nil {
+		return HardDeletePlanStatus{}, false, fmt.Errorf("read hard-delete plan status: %w", err)
+	}
+	status.Sealed = sealed == 1
+	return status, true, nil
+}
+
+type queryRower interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func hardDeletePlanHeader(ctx context.Context, query queryRower, operationID string) (int64, bool, bool, error) {
+	var expected int64
+	var sealed int
+	err := query.QueryRowContext(ctx, `
+		SELECT expected_count, sealed
+		FROM mount_write_hard_delete_plans
+		WHERE operation_id = ?`, operationID).Scan(&expected, &sealed)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, false, nil
+	}
+	if err != nil {
+		return 0, false, false, fmt.Errorf("read hard-delete plan header: %w", err)
+	}
+	return expected, sealed == 1, true, nil
+}
+
+func countPlannedMessageIDs(ctx context.Context, tx *sql.Tx, operationID string, messageIDs []int64) (int64, error) {
+	var matches int64
+	for _, messageID := range messageIDs {
+		var present int
+		err := tx.QueryRowContext(ctx, `
+			SELECT 1 FROM mount_write_hard_delete_messages
+			WHERE operation_id = ? AND message_id = ?`, operationID, messageID).Scan(&present)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return 0, fmt.Errorf("validate hard-delete message: %w", err)
+		}
+		matches++
+	}
+	return matches, nil
+}
+
+func validSortedMessageIDs(messageIDs []int64) bool {
+	for index, messageID := range messageIDs {
+		if messageID <= 0 || (index > 0 && messageIDs[index-1] >= messageID) {
+			return false
+		}
+	}
+	return true
+}
+
+var _ HardDeleteJournal = (*SQLiteJournal)(nil)

--- a/backend/mountwrite/journal_hard_delete_test.go
+++ b/backend/mountwrite/journal_hard_delete_test.go
@@ -1,0 +1,141 @@
+package mountwrite
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestSQLiteJournalPersistsBoundedHardDeletePlanAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "journal.db")
+	db := openJournalDB(t, dbPath)
+	if err := EnsureJournalSchema(ctx, db); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+	journal, err := NewSQLiteJournal(db)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	now := time.Unix(1_700_000_000, 0).UTC()
+	if err := journal.Create(ctx, JournalRecord{
+		OperationID: "hard-delete-plan",
+		Mutation:    Mutation{Kind: MutationHardDelete, DriveID: 42, ObjectID: "folder-1", ExpectedRevision: 1, Recursive: true},
+		State:       StateDeletePlanPending,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		t.Fatalf("create record: %v", err)
+	}
+	if err := journal.AppendHardDeletePlan(ctx, "hard-delete-plan", []int64{10, 20}, 3, false); err != nil {
+		t.Fatalf("append first page: %v", err)
+	}
+	if err := journal.AppendHardDeletePlan(ctx, "hard-delete-plan", []int64{10, 20}, 3, false); err != nil {
+		t.Fatalf("repeat first page idempotently: %v", err)
+	}
+	if err := journal.AppendHardDeletePlan(ctx, "hard-delete-plan", []int64{30}, 3, true); err != nil {
+		t.Fatalf("seal plan: %v", err)
+	}
+	status, found, err := journal.HardDeletePlanStatus(ctx, "hard-delete-plan")
+	if err != nil || !found {
+		t.Fatalf("status: found=%v err=%v", found, err)
+	}
+	if status != (HardDeletePlanStatus{ExpectedCount: 3, PlannedCount: 3, CompletedCount: 0, Cursor: 30, Sealed: true}) {
+		t.Fatalf("status = %#v", status)
+	}
+	batch, err := journal.NextHardDeleteBatch(ctx, "hard-delete-plan", 2)
+	if err != nil || !slices.Equal(batch, []int64{10, 20}) {
+		t.Fatalf("next batch = %v, err=%v", batch, err)
+	}
+	if err := journal.MarkHardDeleteBatchDone(ctx, "hard-delete-plan", batch); err != nil {
+		t.Fatalf("mark batch done: %v", err)
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
+	}
+	db = openJournalDB(t, dbPath)
+	journal, err = NewSQLiteJournal(db)
+	if err != nil {
+		t.Fatalf("reopen journal: %v", err)
+	}
+	batch, err = journal.NextHardDeleteBatch(ctx, "hard-delete-plan", 100)
+	if err != nil || !slices.Equal(batch, []int64{30}) {
+		t.Fatalf("remaining batch = %v, err=%v", batch, err)
+	}
+	status, found, err = journal.HardDeletePlanStatus(ctx, "hard-delete-plan")
+	if err != nil || !found || status.CompletedCount != 2 {
+		t.Fatalf("reopened status = %#v, found=%v err=%v", status, found, err)
+	}
+	if err := journal.MarkHardDeleteBatchDone(ctx, "hard-delete-plan", batch); err != nil {
+		t.Fatalf("mark final batch done: %v", err)
+	}
+	if _, err := journal.Transition(ctx, "hard-delete-plan", StateDeletePlanPending, StateDeletingBodies, JournalPatch{}); err != nil {
+		t.Fatalf("transition to deleting: %v", err)
+	}
+	if _, err := journal.Transition(ctx, "hard-delete-plan", StateDeletingBodies, StateDeleteFinalizing, JournalPatch{}); err != nil {
+		t.Fatalf("transition to finalizing: %v", err)
+	}
+	if err := journal.CompactHardDeletePlan(ctx, "hard-delete-plan"); err != nil {
+		t.Fatalf("compact plan: %v", err)
+	}
+	if err := journal.CompactHardDeletePlan(ctx, "hard-delete-plan"); err != nil {
+		t.Fatalf("repeat plan compaction after crash: %v", err)
+	}
+	if _, found, err := journal.HardDeletePlanStatus(ctx, "hard-delete-plan"); err != nil || found {
+		t.Fatalf("compacted status: found=%v err=%v", found, err)
+	}
+}
+
+func TestSQLiteJournalRejectsMalformedOrInconsistentHardDeletePlans(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := openJournalDB(t, filepath.Join(t.TempDir(), "journal.db"))
+	if err := EnsureJournalSchema(ctx, db); err != nil {
+		t.Fatalf("ensure schema: %v", err)
+	}
+	journal, err := NewSQLiteJournal(db)
+	if err != nil {
+		t.Fatalf("new journal: %v", err)
+	}
+	now := time.Unix(1_700_000_000, 0).UTC()
+	if err := journal.Create(ctx, JournalRecord{
+		OperationID: "hard-delete-invalid-plan",
+		Mutation:    Mutation{Kind: MutationHardDelete, DriveID: 42, ObjectID: "file-1", ExpectedRevision: 1, Recursive: true},
+		State:       StateDeletePlanPending,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		t.Fatalf("create record: %v", err)
+	}
+	invalidPages := [][]int64{{0}, {2, 1}, {1, 1}}
+	for _, page := range invalidPages {
+		if err := journal.AppendHardDeletePlan(ctx, "hard-delete-invalid-plan", page, 2, false); !errors.Is(err, ErrInvalidRequest) {
+			t.Fatalf("page %v error = %v, want ErrInvalidRequest", page, err)
+		}
+	}
+	if err := journal.AppendHardDeletePlan(ctx, "hard-delete-invalid-plan", []int64{1}, 2, false); err != nil {
+		t.Fatalf("append valid page: %v", err)
+	}
+	if err := journal.AppendHardDeletePlan(ctx, "hard-delete-invalid-plan", []int64{2}, 3, true); !errors.Is(err, ErrConflict) {
+		t.Fatalf("inconsistent total error = %v, want ErrConflict", err)
+	}
+	if err := journal.AppendHardDeletePlan(ctx, "hard-delete-invalid-plan", []int64{2}, 2, false); err != nil {
+		t.Fatalf("append second page: %v", err)
+	}
+	if err := journal.AppendHardDeletePlan(ctx, "hard-delete-invalid-plan", nil, 2, true); err != nil {
+		t.Fatalf("seal exact plan: %v", err)
+	}
+	if err := journal.AppendHardDeletePlan(ctx, "hard-delete-invalid-plan", []int64{3}, 2, true); !errors.Is(err, ErrConflict) {
+		t.Fatalf("append after seal error = %v, want ErrConflict", err)
+	}
+	if err := journal.MarkHardDeleteBatchDone(ctx, "hard-delete-invalid-plan", []int64{99}); !errors.Is(err, ErrConflict) {
+		t.Fatalf("unknown completion error = %v, want ErrConflict", err)
+	}
+}

--- a/backend/mountwrite/operations.go
+++ b/backend/mountwrite/operations.go
@@ -341,12 +341,18 @@ func (c *Coordinator) confirmCommitted(
 	defer cancel()
 	committed, err := c.transition(maintenanceCtx, record, StateRemoteCommitted, JournalPatch{Result: &result})
 	if err != nil {
+		if record.Mutation.Kind == MutationHardDelete {
+			return MutationResult{}, operationError(record, err)
+		}
 		return c.finalizeWithoutDurableCommit(maintenanceCtx, record, result), nil
 	}
 	return c.finalizeCommitted(maintenanceCtx, committed)
 }
 
 func (c *Coordinator) finalizeCommitted(ctx context.Context, record JournalRecord) (MutationResult, error) {
+	if record.Mutation.Kind == MutationHardDelete {
+		return c.resumeHardDelete(ctx, record)
+	}
 	result, err := requireResult(record)
 	if err != nil {
 		return MutationResult{}, operationError(record, err)

--- a/backend/mountwrite/recovery.go
+++ b/backend/mountwrite/recovery.go
@@ -37,7 +37,9 @@ func (c *Coordinator) Recover(ctx context.Context) (RecoveryReport, error) {
 			// blocking the whole mount.
 			// Validation/corruption errors and every commit-state failure remain
 			// fatal so uncertain namespace changes still fail closed.
-			if state == StateCleanupPending && errors.Is(err, ErrUnavailable) {
+			hardDeletePending := listed.Mutation.Kind == MutationHardDelete &&
+				(state == StateRemoteCommitted || isHardDeleteState(state))
+			if (state == StateCleanupPending || hardDeletePending) && errors.Is(err, ErrUnavailable) {
 				slog.Warn("mountwrite: recovery cleanup temporarily unavailable, will retry later", "operation_id", listed.OperationID, "error", err)
 				report.Pending++
 				continue
@@ -67,14 +69,22 @@ func (c *Coordinator) recoverOne(ctx context.Context, operationID string) (Journ
 		return "", newOperationError(operationID, MutationPut, err)
 	}
 	defer finish()
-	release, err := c.locks.Lock(ctx, "operation:"+operationID)
-	if err != nil {
-		return "", newOperationError(operationID, MutationPut, err)
-	}
-	defer release()
 	record, found, err := c.journal.Get(ctx, operationID)
 	if err != nil {
 		return "", newOperationError(operationID, MutationPut, err)
+	}
+	if !found {
+		return StateAborted, nil
+	}
+	keys := append(record.Mutation.lockKeys(), "operation:"+operationID)
+	release, err := c.locks.Lock(ctx, keys...)
+	if err != nil {
+		return "", newOperationError(operationID, record.Mutation.Kind, err)
+	}
+	defer release()
+	record, found, err = c.journal.Get(ctx, operationID)
+	if err != nil {
+		return "", newOperationError(operationID, record.Mutation.Kind, err)
 	}
 	if !found {
 		return StateAborted, nil
@@ -108,6 +118,9 @@ func (c *Coordinator) resumeRecovery(ctx context.Context, record JournalRecord) 
 		return err
 	case StateCleanupPending:
 		return c.recoverCleanup(ctx, record)
+	case StateDeletePlanPending, StateDeletingBodies, StateDeleteFinalizing:
+		_, err := c.resumeHardDelete(ctx, record)
+		return err
 	default:
 		return operationError(record, ErrInvalidTransition)
 	}

--- a/backend/mountwrite/types.go
+++ b/backend/mountwrite/types.go
@@ -23,6 +23,9 @@ const (
 	MutationMkdir  MutationKind = "mkdir"
 	MutationMove   MutationKind = "move"
 	MutationDelete MutationKind = "delete"
+	// MutationHardDelete permanently removes backing content after a durable
+	// control marker has hidden the object from the projected namespace.
+	MutationHardDelete MutationKind = "hard_delete"
 
 	EncryptionNone EncryptionVersion = 0
 	EncryptionTDE1 EncryptionVersion = 1
@@ -42,6 +45,9 @@ const (
 	StateRemoteCommitted   JournalState = "remote_committed"
 	StateProjectionPending JournalState = "projection_pending"
 	StateCleanupPending    JournalState = "cleanup_pending"
+	StateDeletePlanPending JournalState = "delete_plan_pending"
+	StateDeletingBodies    JournalState = "deleting_bodies"
+	StateDeleteFinalizing  JournalState = "delete_finalizing"
 	StateDone              JournalState = "done"
 	StateAborted           JournalState = "aborted"
 )
@@ -254,6 +260,35 @@ func (r DeleteRequest) mutation() Mutation {
 	}
 }
 
+// HardDeleteRequest is intentionally retention-free. It is used by mounted
+// filesystem deletes that must remove Telegram content before reporting
+// success, while DeleteRequest preserves the existing soft-delete contract.
+type HardDeleteRequest struct {
+	OperationID      string
+	DriveID          int64
+	ObjectID         string
+	ParentID         string
+	ExpectedRevision uint64
+}
+
+func (r HardDeleteRequest) Validate() error {
+	if !validOperationID(r.OperationID) || r.DriveID <= 0 || r.ObjectID == "" || r.ExpectedRevision == 0 {
+		return ErrInvalidRequest
+	}
+	return nil
+}
+
+func (r HardDeleteRequest) mutation() Mutation {
+	return Mutation{
+		Kind:                MutationHardDelete,
+		DriveID:             r.DriveID,
+		ObjectID:            r.ObjectID,
+		DestinationParentID: r.ParentID,
+		ExpectedRevision:    r.ExpectedRevision,
+		Recursive:           true,
+	}
+}
+
 type StagedObject struct {
 	Key           string `json:"key"`
 	Path          string `json:"path"`
@@ -422,6 +457,22 @@ type ReceiptReconciler interface {
 	ReconcileReceipt(ctx context.Context, request CommitRequest, commitRef string) (MutationResult, bool, error)
 }
 
+// HardDeleteRemote exposes the projection-owned deletion plan and the
+// Telegram body deletion primitive. Plans must be stable, sorted by message
+// ID, and pageable after the supplied exclusive cursor. DeleteBodies and
+// FinalizeHardDelete must be idempotent because recovery can retry a completed
+// remote call whose local journal checkpoint did not commit.
+type HardDeleteRemote interface {
+	HardDeletePlan(
+		ctx context.Context,
+		operationID string,
+		afterMsgID int64,
+		limit int,
+	) (messageIDs []int64, total int64, done bool, err error)
+	DeleteBodies(ctx context.Context, operationID string, messageIDs []int64) error
+	FinalizeHardDelete(ctx context.Context, operationID string) error
+}
+
 // SnapshotInvalidator invalidates exactly the parents and objects supplied
 // after the corresponding remote commit is confirmed.
 type SnapshotInvalidator interface {
@@ -457,11 +508,14 @@ var allowedTransitions = map[JournalState][]JournalState{
 	StateUploaded:          {StateCommitting, StateCleanupPending, StateAborted},
 	StateCommitting:        {StateRemoteCommitted, StateReconciling, StateCleanupPending, StateAborted},
 	StateReconciling:       {StateRemoteCommitted, StateCommitting, StateCleanupPending, StateAborted},
-	StateRemoteCommitted:   {StateProjectionPending, StateCleanupPending, StateDone},
+	StateRemoteCommitted:   {StateProjectionPending, StateCleanupPending, StateDeletePlanPending, StateDone},
 	StateProjectionPending: {StateCleanupPending, StateDone},
 	// A cleanup-pending self-transition durably refines a receipt-unknown
 	// record with exact recovered body IDs before local staging is removed.
-	StateCleanupPending: {StateCleanupPending, StateDone, StateAborted},
+	StateCleanupPending:    {StateCleanupPending, StateDone, StateAborted},
+	StateDeletePlanPending: {StateDeletingBodies},
+	StateDeletingBodies:    {StateDeleteFinalizing},
+	StateDeleteFinalizing:  {StateDone},
 }
 
 func validName(name string) bool {
@@ -512,7 +566,7 @@ func sortedUnique(values []string, keepEmpty bool) []string {
 }
 
 func validateMutation(m Mutation) error {
-	if m.DriveID == 0 {
+	if m.DriveID <= 0 {
 		return ErrInvalidRequest
 	}
 	if !validEncryptionVersion(m.EncryptionVersion) || (m.Kind != MutationPut && m.EncryptionVersion != EncryptionNone) {
@@ -529,6 +583,10 @@ func validateMutation(m Mutation) error {
 		}
 	case MutationDelete:
 		if m.ObjectID == "" || m.TrashRetention < 0 {
+			return ErrInvalidRequest
+		}
+	case MutationHardDelete:
+		if m.ObjectID == "" || m.ExpectedRevision == 0 || !m.Recursive || m.TrashRetention != 0 {
 			return ErrInvalidRequest
 		}
 	default:

--- a/backend/projection/apply.go
+++ b/backend/projection/apply.go
@@ -74,6 +74,8 @@ func ApplyOp(tx *sql.Tx, channelID int64, msgID int64, op Op, actorID int64) (er
 			applyErr = applyRelocate(tx, channelID, op)
 		case OpTrashTree:
 			applyErr = applyTrashTree(tx, channelID, op)
+		case OpHardDeleteTree:
+			applyErr = applyHardDeleteTree(tx, channelID, msgID, op)
 		}
 		if applyErr != nil {
 			return applyErr

--- a/backend/projection/apply_test.go
+++ b/backend/projection/apply_test.go
@@ -1,6 +1,7 @@
 package projection
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"testing"
@@ -433,6 +434,11 @@ func TestApplyRejectsOverflowFileID(t *testing.T) {
 
 func mustOp(t *testing.T, db *sql.DB, msgID int64, op Op) {
 	t.Helper()
+	if op.Type == OpHardDeleteTree {
+		if err := RegisterHardDeleteIntent(context.Background(), db, testChan, op.OpID, op.Obj, op.ExpectedRevision); err != nil {
+			t.Fatalf("register hard-delete intent msg=%d %v: %v", msgID, op, err)
+		}
+	}
 	if err := runOp(t, db, testChan, msgID, op); err != nil {
 		t.Fatalf("apply msg=%d %v: %v", msgID, op, err)
 	}

--- a/backend/projection/channels.go
+++ b/backend/projection/channels.go
@@ -67,6 +67,8 @@ func DeleteChannel(db *sql.DB, channelID int64) error {
 	defer func() { _ = tx.Rollback() }()
 
 	for _, q := range []string{
+		`DELETE FROM hard_delete_plan_items WHERE channel_id = ?`,
+		`DELETE FROM hard_delete_jobs WHERE channel_id = ?`,
 		`DELETE FROM dirents WHERE channel_id = ?`,
 		`DELETE FROM file_revisions WHERE channel_id = ?`,
 		`DELETE FROM projection_operations WHERE channel_id = ?`,

--- a/backend/projection/channels.go
+++ b/backend/projection/channels.go
@@ -69,6 +69,7 @@ func DeleteChannel(db *sql.DB, channelID int64) error {
 	for _, q := range []string{
 		`DELETE FROM hard_delete_plan_items WHERE channel_id = ?`,
 		`DELETE FROM hard_delete_jobs WHERE channel_id = ?`,
+		`DELETE FROM hard_delete_intents WHERE channel_id = ?`,
 		`DELETE FROM dirents WHERE channel_id = ?`,
 		`DELETE FROM file_revisions WHERE channel_id = ?`,
 		`DELETE FROM projection_operations WHERE channel_id = ?`,

--- a/backend/projection/channels_test.go
+++ b/backend/projection/channels_test.go
@@ -127,19 +127,27 @@ func TestDeleteChannelCascadesAllScopedTables(t *testing.T) {
 	`, sharedID); err != nil {
 		t.Fatalf("seed encryption: %v", err)
 	}
+	if _, err := db.Exec(`
+		INSERT INTO hard_delete_intents
+		  (channel_id, op_id, root_object_id, expected_revision)
+		VALUES (?, 'local-delete', 'f:2', 1)
+	`, sharedID); err != nil {
+		t.Fatalf("seed hard-delete intent: %v", err)
+	}
 
 	if err := DeleteChannel(db, sharedID); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 
 	for table, query := range map[string]string{
-		"channels":          `SELECT 1 FROM channels WHERE channel_id = ?`,
-		"replay_log":        `SELECT 1 FROM replay_log WHERE channel_id = ?`,
-		"replay_log_tamper": `SELECT 1 FROM replay_log_tamper WHERE channel_id = ?`,
-		"folders":           `SELECT 1 FROM folders WHERE channel_id = ?`,
-		"files":             `SELECT 1 FROM files WHERE channel_id = ?`,
-		"backfill_progress": `SELECT 1 FROM backfill_progress WHERE channel_id = ?`,
-		"encryption":        `SELECT 1 FROM encryption WHERE channel_id = ?`,
+		"channels":            `SELECT 1 FROM channels WHERE channel_id = ?`,
+		"replay_log":          `SELECT 1 FROM replay_log WHERE channel_id = ?`,
+		"replay_log_tamper":   `SELECT 1 FROM replay_log_tamper WHERE channel_id = ?`,
+		"folders":             `SELECT 1 FROM folders WHERE channel_id = ?`,
+		"files":               `SELECT 1 FROM files WHERE channel_id = ?`,
+		"backfill_progress":   `SELECT 1 FROM backfill_progress WHERE channel_id = ?`,
+		"encryption":          `SELECT 1 FROM encryption WHERE channel_id = ?`,
+		"hard_delete_intents": `SELECT 1 FROM hard_delete_intents WHERE channel_id = ?`,
 	} {
 		var tmp int
 		err := db.QueryRow(query, sharedID).Scan(&tmp)

--- a/backend/projection/hard_delete.go
+++ b/backend/projection/hard_delete.go
@@ -1,0 +1,603 @@
+package projection
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+)
+
+const maxHardDeletePlanPageSize = 1000
+
+var ErrHardDeletePlanNotFound = errors.New("projection: hard-delete plan not found")
+var ErrHardDeletePlanMismatch = errors.New("projection: hard-delete plan does not contain every message")
+
+type hardDeleteScope struct {
+	channelID  int64
+	objectID   string
+	objectKind string
+	fileMsgID  int64
+	revision   int64
+}
+
+// applyHardDeleteTree captures the complete Telegram body deletion plan and
+// hides the namespace subtree in the same SQLite transaction. The Telegram
+// control message itself stays in replay_log and is never selected as a body.
+func applyHardDeleteTree(tx *sql.Tx, channelID, markerMsgID int64, op Op) error {
+	if markerMsgID <= 0 || op.ExpectedRevision <= 0 {
+		return fmt.Errorf("%w: hard delete requires marker message and expected revision", ErrBadOp)
+	}
+	if err := validateHardDeleteChannel(tx, channelID); err != nil {
+		return err
+	}
+	scope, err := loadHardDeleteScope(tx, channelID, op)
+	if err != nil {
+		return err
+	}
+	if err := validateHardDeleteContent(tx, scope); err != nil {
+		return err
+	}
+
+	completed, exists, err := hardDeleteJobStateTx(tx, channelID, op.OpID, op.Obj)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if err := createHardDeletePlanTx(tx, scope, markerMsgID, op.OpID); err != nil {
+			return err
+		}
+	}
+	if completed {
+		// A rebuild replays body-part ops from the retained local replay log.
+		// Cleanup has already succeeded remotely, so remove those reconstructed
+		// local pointers without recreating a deletion plan.
+		if err := removeHardDeletedPartPointersTx(tx, scope); err != nil {
+			return err
+		}
+	}
+	if err := clearHardDeleteRetentionTx(tx, scope); err != nil {
+		return err
+	}
+	if err := removeHardDeleteTrashEntriesTx(tx, scope); err != nil {
+		return err
+	}
+	if scope.objectKind == ObjectKindFile {
+		return trashFileTreeRoot(tx, channelID, scope.objectID, scope.revision)
+	}
+	return trashFolderTree(tx, channelID, scope.objectID)
+}
+
+func validateHardDeleteChannel(tx *sql.Tx, channelID int64) error {
+	var kind string
+	if err := tx.QueryRow(`SELECT kind FROM channels WHERE channel_id=?`, channelID).Scan(&kind); err != nil {
+		return fmt.Errorf("projection: read hard-delete channel: %w", err)
+	}
+	if kind != KindPersonal {
+		return fmt.Errorf("%w: hard delete is restricted to personal drives", ErrBadOp)
+	}
+	return nil
+}
+
+func loadHardDeleteScope(tx *sql.Tx, channelID int64, op Op) (hardDeleteScope, error) {
+	kind, err := objectKind(op.Obj)
+	if err != nil {
+		return hardDeleteScope{}, err
+	}
+	var revision int64
+	err = tx.QueryRow(`
+		SELECT revision FROM dirents
+		WHERE channel_id=? AND object_id=? AND tombstoned=0
+	`, channelID, op.Obj).Scan(&revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return hardDeleteScope{}, ErrObjectNotFound
+	}
+	if err != nil {
+		return hardDeleteScope{}, fmt.Errorf("projection: read hard-delete root: %w", err)
+	}
+	if revision != op.ExpectedRevision {
+		return hardDeleteScope{}, ErrRevisionConflict
+	}
+
+	scope := hardDeleteScope{
+		channelID:  channelID,
+		objectID:   op.Obj,
+		objectKind: kind,
+		revision:   revision,
+	}
+	if kind == ObjectKindFile {
+		scope.fileMsgID, err = parseFileMsgID(op.Obj)
+		if err != nil {
+			return hardDeleteScope{}, err
+		}
+	}
+	return scope, nil
+}
+
+// withAffectedFiles returns a statement prefix defining affected_files and
+// the arguments consumed by that prefix. Folder traversal and file selection
+// stay set-based, so deleting a large tree does not issue one query per file.
+func (s hardDeleteScope) withAffectedFiles(body string) (string, []any) {
+	if s.objectKind == ObjectKindFile {
+		return `WITH affected_files(file_msg_id) AS (SELECT ?)
+		` + body, []any{s.fileMsgID}
+	}
+	return `WITH RECURSIVE subtree(id) AS (
+			SELECT id FROM folders
+			WHERE channel_id=? AND id=?
+			UNION
+			SELECT child.id FROM folders child
+			JOIN subtree parent ON child.parent_id=parent.id
+			WHERE child.channel_id=?
+		),
+		affected_files(file_msg_id) AS (
+			SELECT msg_id FROM files
+			WHERE channel_id=?
+			  AND parent_id IN (SELECT id FROM subtree)
+		)
+		` + body, []any{s.channelID, s.objectID, s.channelID, s.channelID}
+}
+
+func validateHardDeleteContent(tx *sql.Tx, scope hardDeleteScope) error {
+	query, args := scope.withAffectedFiles(`
+		, revision_stats AS (
+			SELECT affected_files.file_msg_id,
+			       COUNT(file_revisions.revision) AS revision_count,
+			       COALESCE(SUM(CASE
+					WHEN file_revisions.revision IS NULL THEN 0
+					WHEN file_revisions.content_msg_id > 0
+					 AND file_revisions.upload_uuid = ''
+					 AND file_revisions.part_count = 0 THEN 0
+					WHEN file_revisions.content_msg_id = 0
+					 AND file_revisions.upload_uuid != ''
+					 AND file_revisions.part_count > 0 THEN 0
+					ELSE 1
+				END), 0) AS invalid_references
+			FROM affected_files
+			LEFT JOIN file_revisions
+			  ON file_revisions.channel_id=?
+			 AND file_revisions.file_msg_id=affected_files.file_msg_id
+			GROUP BY affected_files.file_msg_id
+		)
+		SELECT COUNT(*) FROM revision_stats
+		WHERE revision_count=0 OR invalid_references>0
+	`)
+	args = append(args, scope.channelID)
+	var invalid int
+	if err := tx.QueryRow(query, args...).Scan(&invalid); err != nil {
+		return fmt.Errorf("projection: validate hard-delete content references: %w", err)
+	}
+	if invalid != 0 {
+		return ErrContentIncomplete
+	}
+
+	query, args = scope.withAffectedFiles(`
+		, multipart_stats AS (
+			SELECT revisions.file_msg_id, revisions.revision,
+			       revisions.part_count, revisions.size,
+			       COUNT(parts.msg_id) AS stored_count,
+			       COALESCE(MIN(parts.part_index), -1) AS first_index,
+			       COALESCE(MAX(parts.part_index), -1) AS last_index,
+			       COALESCE(SUM(parts.size), 0) AS stored_size
+			FROM file_revisions revisions
+			JOIN affected_files
+			  ON affected_files.file_msg_id=revisions.file_msg_id
+			LEFT JOIN file_parts parts
+			  ON parts.channel_id=revisions.channel_id
+			 AND parts.upload_uuid=revisions.upload_uuid
+			WHERE revisions.channel_id=? AND revisions.upload_uuid!=''
+			GROUP BY revisions.file_msg_id, revisions.revision,
+			         revisions.part_count, revisions.size
+		)
+		SELECT COUNT(*) FROM multipart_stats
+		WHERE stored_count!=part_count
+		   OR first_index!=0
+		   OR last_index!=part_count-1
+		   OR (size>0 AND stored_size!=size)
+	`)
+	args = append(args, scope.channelID)
+	if err := tx.QueryRow(query, args...).Scan(&invalid); err != nil {
+		return fmt.Errorf("projection: validate hard-delete multipart content: %w", err)
+	}
+	if invalid != 0 {
+		return ErrContentIncomplete
+	}
+	if err := validateHardDeleteBodyTargets(tx, scope); err != nil {
+		return err
+	}
+	return validateHardDeleteBodyOwnership(tx, scope)
+}
+
+func validateHardDeleteBodyTargets(tx *sql.Tx, scope hardDeleteScope) error {
+	query, args := scope.withAffectedFiles(`
+		, body_messages(msg_id) AS (
+			SELECT revisions.content_msg_id
+			FROM file_revisions revisions
+			JOIN affected_files
+			  ON affected_files.file_msg_id=revisions.file_msg_id
+			WHERE revisions.channel_id=? AND revisions.content_msg_id>0
+			UNION
+			SELECT parts.msg_id
+			FROM file_revisions revisions
+			JOIN affected_files
+			  ON affected_files.file_msg_id=revisions.file_msg_id
+			JOIN file_parts parts
+			  ON parts.channel_id=revisions.channel_id
+			 AND parts.upload_uuid=revisions.upload_uuid
+			WHERE revisions.channel_id=? AND revisions.upload_uuid!=''
+		)
+		SELECT COUNT(*)
+		FROM body_messages bodies
+		LEFT JOIN replay_log replay
+		  ON replay.channel_id=? AND replay.msg_id=bodies.msg_id
+		WHERE bodies.msg_id>? OR (
+			replay.msg_id IS NOT NULL AND replay.op_type NOT IN (?, ?)
+		)
+	`)
+	args = append(args, scope.channelID, scope.channelID, scope.channelID, int64(math.MaxInt32), string(OpFileUpload), string(OpFilePart))
+	var invalid int
+	if err := tx.QueryRow(query, args...).Scan(&invalid); err != nil {
+		return fmt.Errorf("projection: validate hard-delete body targets: %w", err)
+	}
+	if invalid != 0 {
+		return fmt.Errorf("%w: hard-delete plan contains a non-body or out-of-range message", ErrBadOp)
+	}
+	return nil
+}
+
+func validateHardDeleteBodyOwnership(tx *sql.Tx, scope hardDeleteScope) error {
+	query, args := scope.withAffectedFiles(`
+		, affected_body_messages(msg_id) AS (
+			SELECT revisions.content_msg_id
+			FROM file_revisions revisions
+			JOIN affected_files
+			  ON affected_files.file_msg_id=revisions.file_msg_id
+			WHERE revisions.channel_id=? AND revisions.content_msg_id>0
+			UNION
+			SELECT parts.msg_id
+			FROM file_revisions revisions
+			JOIN affected_files
+			  ON affected_files.file_msg_id=revisions.file_msg_id
+			JOIN file_parts parts
+			  ON parts.channel_id=revisions.channel_id
+			 AND parts.upload_uuid=revisions.upload_uuid
+			WHERE revisions.channel_id=? AND revisions.upload_uuid!=''
+		),
+		outside_body_messages(msg_id) AS (
+			SELECT revisions.content_msg_id
+			FROM file_revisions revisions
+			WHERE revisions.channel_id=?
+			  AND revisions.content_msg_id>0
+			  AND revisions.file_msg_id NOT IN (
+				SELECT file_msg_id FROM affected_files
+			  )
+			UNION
+			SELECT parts.msg_id
+			FROM file_revisions revisions
+			JOIN file_parts parts
+			  ON parts.channel_id=revisions.channel_id
+			 AND parts.upload_uuid=revisions.upload_uuid
+			WHERE revisions.channel_id=?
+			  AND revisions.upload_uuid!=''
+			  AND revisions.file_msg_id NOT IN (
+				SELECT file_msg_id FROM affected_files
+			  )
+		)
+		SELECT 1
+		FROM affected_body_messages affected
+		JOIN outside_body_messages outside ON outside.msg_id=affected.msg_id
+		LIMIT 1
+	`)
+	args = append(args, scope.channelID, scope.channelID, scope.channelID, scope.channelID)
+	var shared int
+	err := tx.QueryRow(query, args...).Scan(&shared)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("projection: validate hard-delete body ownership: %w", err)
+	}
+	return ErrContentAlreadyCommitted
+}
+
+func hardDeleteJobStateTx(tx *sql.Tx, channelID int64, opID, objectID string) (completed, exists bool, err error) {
+	var (
+		storedObjectID string
+		completedFlag  int
+	)
+	err = tx.QueryRow(`
+		SELECT root_object_id, completed FROM hard_delete_jobs
+		WHERE channel_id=? AND op_id=?
+	`, channelID, opID).Scan(&storedObjectID, &completedFlag)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, fmt.Errorf("projection: inspect hard-delete job: %w", err)
+	}
+	if storedObjectID != objectID {
+		return false, false, fmt.Errorf("%w: hard-delete operation id targets another object", ErrBadOp)
+	}
+	return completedFlag != 0, true, nil
+}
+
+func createHardDeletePlanTx(tx *sql.Tx, scope hardDeleteScope, markerMsgID int64, opID string) error {
+	if _, err := tx.Exec(`
+		INSERT INTO hard_delete_jobs
+		  (channel_id, op_id, root_object_id, marker_msg_id, total_messages, completed)
+		VALUES (?, ?, ?, ?, 0, 0)
+	`, scope.channelID, opID, scope.objectID, markerMsgID); err != nil {
+		return fmt.Errorf("projection: create hard-delete job: %w", err)
+	}
+
+	query, args := scope.withAffectedFiles(`
+		, body_messages(msg_id) AS (
+			SELECT revisions.content_msg_id
+			FROM file_revisions revisions
+			JOIN affected_files
+			  ON affected_files.file_msg_id=revisions.file_msg_id
+			WHERE revisions.channel_id=? AND revisions.content_msg_id>0
+			UNION
+			SELECT parts.msg_id
+			FROM file_revisions revisions
+			JOIN affected_files
+			  ON affected_files.file_msg_id=revisions.file_msg_id
+			JOIN file_parts parts
+			  ON parts.channel_id=revisions.channel_id
+			 AND parts.upload_uuid=revisions.upload_uuid
+			WHERE revisions.channel_id=? AND revisions.upload_uuid!=''
+		)
+		INSERT INTO hard_delete_plan_items (channel_id, op_id, msg_id)
+		SELECT ?, ?, msg_id FROM body_messages
+		WHERE msg_id>0 AND msg_id!=?
+	`)
+	args = append(args, scope.channelID, scope.channelID, scope.channelID, opID, markerMsgID)
+	if _, err := tx.Exec(query, args...); err != nil {
+		return fmt.Errorf("projection: capture hard-delete body plan: %w", err)
+	}
+	if _, err := tx.Exec(`
+		UPDATE hard_delete_jobs
+		SET total_messages=(
+			SELECT COUNT(*) FROM hard_delete_plan_items
+			WHERE channel_id=? AND op_id=?
+		)
+		WHERE channel_id=? AND op_id=?
+	`, scope.channelID, opID, scope.channelID, opID); err != nil {
+		return fmt.Errorf("projection: count hard-delete body plan: %w", err)
+	}
+	return nil
+}
+
+func clearHardDeleteRetentionTx(tx *sql.Tx, scope hardDeleteScope) error {
+	query, args := scope.withAffectedFiles(`
+		UPDATE file_revisions SET retained_until=0
+		WHERE channel_id=?
+		  AND file_msg_id IN (SELECT file_msg_id FROM affected_files)
+	`)
+	args = append(args, scope.channelID)
+	if _, err := tx.Exec(query, args...); err != nil {
+		return fmt.Errorf("projection: clear hard-delete retention: %w", err)
+	}
+	return nil
+}
+
+func removeHardDeletedPartPointersTx(tx *sql.Tx, scope hardDeleteScope) error {
+	query, args := scope.withAffectedFiles(`
+		DELETE FROM file_parts
+		WHERE channel_id=? AND upload_uuid IN (
+			SELECT revisions.upload_uuid
+			FROM file_revisions revisions
+			JOIN affected_files
+			  ON affected_files.file_msg_id=revisions.file_msg_id
+			WHERE revisions.channel_id=? AND revisions.upload_uuid!=''
+		)
+	`)
+	args = append(args, scope.channelID, scope.channelID)
+	if _, err := tx.Exec(query, args...); err != nil {
+		return fmt.Errorf("projection: clear completed hard-delete part pointers: %w", err)
+	}
+	return nil
+}
+
+func removeHardDeleteTrashEntriesTx(tx *sql.Tx, scope hardDeleteScope) error {
+	if scope.objectKind == ObjectKindFile {
+		if _, err := tx.Exec(`
+			DELETE FROM trash_entries WHERE channel_id=? AND object_id=?
+		`, scope.channelID, scope.objectID); err != nil {
+			return fmt.Errorf("projection: clear hard-delete trash entry: %w", err)
+		}
+		return nil
+	}
+	if _, err := tx.Exec(`
+		WITH RECURSIVE subtree(id) AS (
+			SELECT id FROM folders
+			WHERE channel_id=? AND id=?
+			UNION
+			SELECT child.id FROM folders child
+			JOIN subtree parent ON child.parent_id=parent.id
+			WHERE child.channel_id=?
+		), affected_objects(object_id) AS (
+			SELECT id FROM subtree
+			UNION
+			SELECT 'f:' || CAST(msg_id AS TEXT) FROM files
+			WHERE channel_id=?
+			  AND parent_id IN (SELECT id FROM subtree)
+		)
+		DELETE FROM trash_entries
+		WHERE channel_id=? AND object_id IN (SELECT object_id FROM affected_objects)
+	`, scope.channelID, scope.objectID, scope.channelID, scope.channelID, scope.channelID); err != nil {
+		return fmt.Errorf("projection: clear hard-delete trash entries: %w", err)
+	}
+	return nil
+}
+
+// ValidateHardDeletePlanItems rechecks a journal-supplied batch against the
+// projection-owned immutable allowlist immediately before physical deletion.
+func ValidateHardDeletePlanItems(
+	ctx context.Context,
+	db *sql.DB,
+	channelID int64,
+	opID string,
+	messageIDs []int64,
+) error {
+	if err := validateHardDeletePlanRequest(ctx, db, channelID, opID); err != nil {
+		return err
+	}
+	if len(messageIDs) == 0 || len(messageIDs) > maxHardDeletePlanPageSize {
+		return ErrHardDeletePlanMismatch
+	}
+	seen := make(map[int64]struct{}, len(messageIDs))
+	for _, messageID := range messageIDs {
+		if messageID <= 0 || messageID > math.MaxInt32 {
+			return ErrHardDeletePlanMismatch
+		}
+		if _, exists := seen[messageID]; exists {
+			return ErrHardDeletePlanMismatch
+		}
+		seen[messageID] = struct{}{}
+	}
+
+	var completed int
+	if err := db.QueryRowContext(ctx, `
+		SELECT completed FROM hard_delete_jobs
+		WHERE channel_id=? AND op_id=?
+	`, channelID, opID).Scan(&completed); errors.Is(err, sql.ErrNoRows) {
+		return ErrHardDeletePlanNotFound
+	} else if err != nil {
+		return fmt.Errorf("projection: inspect hard-delete allowlist: %w", err)
+	}
+	if completed != 0 {
+		return ErrHardDeletePlanMismatch
+	}
+	for _, messageID := range messageIDs {
+		var present int
+		err := db.QueryRowContext(ctx, `
+			SELECT 1 FROM hard_delete_plan_items
+			WHERE channel_id=? AND op_id=? AND msg_id=?
+		`, channelID, opID, messageID).Scan(&present)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrHardDeletePlanMismatch
+		}
+		if err != nil {
+			return fmt.Errorf("projection: validate hard-delete allowlist: %w", err)
+		}
+	}
+	return nil
+}
+
+// HardDeletePlanPage returns a stable ascending page of Telegram body message
+// IDs. total is the original deduplicated plan size; done reports that the
+// returned page reached the immutable end of the plan.
+func HardDeletePlanPage(ctx context.Context, db *sql.DB, channelID int64, opID string, afterMsgID int64, limit int) (ids []int64, total int64, done bool, err error) {
+	if err := validateHardDeletePlanRequest(ctx, db, channelID, opID); err != nil {
+		return nil, 0, false, err
+	}
+	if afterMsgID < 0 {
+		return nil, 0, false, fmt.Errorf("projection: hard-delete plan cursor cannot be negative")
+	}
+	if limit <= 0 || limit > maxHardDeletePlanPageSize {
+		return nil, 0, false, fmt.Errorf("projection: hard-delete plan limit must be between 1 and %d", maxHardDeletePlanPageSize)
+	}
+	err = db.QueryRowContext(ctx, `
+		SELECT total_messages FROM hard_delete_jobs
+		WHERE channel_id=? AND op_id=?
+	`, channelID, opID).Scan(&total)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, 0, false, ErrHardDeletePlanNotFound
+	}
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("projection: read hard-delete plan: %w", err)
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT msg_id FROM hard_delete_plan_items
+		WHERE channel_id=? AND op_id=? AND msg_id>?
+		ORDER BY msg_id ASC
+		LIMIT ?
+	`, channelID, opID, afterMsgID, limit+1)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("projection: page hard-delete plan: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, 0, false, fmt.Errorf("projection: scan hard-delete plan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, false, fmt.Errorf("projection: iterate hard-delete plan: %w", err)
+	}
+	if len(ids) <= limit {
+		return ids, total, true, nil
+	}
+	return ids[:limit], total, false, nil
+}
+
+// CompleteHardDeletePlan atomically removes local multipart pointers, compacts
+// the normalized plan, and retains a small completed job marker for rebuilds.
+func CompleteHardDeletePlan(ctx context.Context, db *sql.DB, channelID int64, opID string) (err error) {
+	if err := validateHardDeletePlanRequest(ctx, db, channelID, opID); err != nil {
+		return err
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("projection: begin hard-delete completion: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var completed int
+	err = tx.QueryRowContext(ctx, `
+		SELECT completed FROM hard_delete_jobs
+		WHERE channel_id=? AND op_id=?
+	`, channelID, opID).Scan(&completed)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrHardDeletePlanNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("projection: inspect hard-delete completion: %w", err)
+	}
+	if completed == 0 {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM file_parts
+			WHERE channel_id=? AND msg_id IN (
+				SELECT msg_id FROM hard_delete_plan_items
+				WHERE channel_id=? AND op_id=?
+			)
+		`, channelID, channelID, opID); err != nil {
+			return fmt.Errorf("projection: clear hard-delete part pointers: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM hard_delete_plan_items WHERE channel_id=? AND op_id=?
+		`, channelID, opID); err != nil {
+			return fmt.Errorf("projection: compact hard-delete plan: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE hard_delete_jobs SET completed=1
+			WHERE channel_id=? AND op_id=? AND completed=0
+		`, channelID, opID); err != nil {
+			return fmt.Errorf("projection: complete hard-delete plan: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("projection: commit hard-delete completion: %w", err)
+	}
+	return nil
+}
+
+func validateHardDeletePlanRequest(ctx context.Context, db *sql.DB, channelID int64, opID string) error {
+	if err := validateContext(ctx, "access hard-delete plan"); err != nil {
+		return err
+	}
+	if db == nil {
+		return fmt.Errorf("projection: hard-delete plan db is nil")
+	}
+	if channelID <= 0 {
+		return fmt.Errorf("projection: hard-delete plan channel id must be positive")
+	}
+	if strings.TrimSpace(opID) == "" {
+		return fmt.Errorf("projection: hard-delete plan operation id is empty")
+	}
+	return nil
+}

--- a/backend/projection/hard_delete.go
+++ b/backend/projection/hard_delete.go
@@ -22,9 +22,10 @@ type hardDeleteScope struct {
 	revision   int64
 }
 
-// applyHardDeleteTree captures the complete Telegram body deletion plan and
-// hides the namespace subtree in the same SQLite transaction. The Telegram
-// control message itself stays in replay_log and is never selected as a body.
+// applyHardDeleteTree validates the complete Telegram body set and hides the
+// namespace subtree in one SQLite transaction. Locally originated mutations
+// also capture an immutable cleanup plan; remote replay only compacts local
+// pointers. The hard-delete control message stays in replay_log.
 func applyHardDeleteTree(tx *sql.Tx, channelID, markerMsgID int64, op Op) error {
 	if markerMsgID <= 0 || op.ExpectedRevision <= 0 {
 		return fmt.Errorf("%w: hard delete requires marker message and expected revision", ErrBadOp)
@@ -36,26 +37,32 @@ func applyHardDeleteTree(tx *sql.Tx, channelID, markerMsgID int64, op Op) error 
 	if err != nil {
 		return err
 	}
-	if err := validateHardDeleteContent(tx, scope); err != nil {
-		return err
-	}
 
-	completed, exists, err := hardDeleteJobStateTx(tx, channelID, op.OpID, op.Obj)
+	_, exists, err := hardDeleteJobStateTx(tx, channelID, op.OpID, op.Obj)
 	if err != nil {
 		return err
 	}
-	if !exists {
+	localIntent, err := hardDeleteIntentMatchesTx(tx, channelID, op)
+	if err != nil {
+		return err
+	}
+	if !exists && localIntent {
+		// Only the originating installation will physically delete Telegram
+		// bodies, so only it needs a complete and exclusively owned allowlist.
+		// A secondary installation may legitimately have an incomplete local
+		// multipart index; it must still apply the namespace tombstone.
+		if err := validateHardDeleteContent(tx, scope); err != nil {
+			return err
+		}
 		if err := createHardDeletePlanTx(tx, scope, markerMsgID, op.OpID); err != nil {
 			return err
 		}
 	}
-	if completed {
-		// A rebuild replays body-part ops from the retained local replay log.
-		// Cleanup has already succeeded remotely, so remove those reconstructed
-		// local pointers without recreating a deletion plan.
-		if err := removeHardDeletedPartPointersTx(tx, scope); err != nil {
-			return err
-		}
+	// The normalized plan is self-contained once captured. Remove multipart
+	// pointers on every client so remote replay cannot retain stale local body
+	// state. An origin with pending cleanup still reads IDs from its plan.
+	if err := removeHardDeletedPartPointersTx(tx, scope); err != nil {
+		return err
 	}
 	if err := clearHardDeleteRetentionTx(tx, scope); err != nil {
 		return err
@@ -395,7 +402,7 @@ func removeHardDeletedPartPointersTx(tx *sql.Tx, scope hardDeleteScope) error {
 	`)
 	args = append(args, scope.channelID, scope.channelID)
 	if _, err := tx.Exec(query, args...); err != nil {
-		return fmt.Errorf("projection: clear completed hard-delete part pointers: %w", err)
+		return fmt.Errorf("projection: clear hard-delete part pointers: %w", err)
 	}
 	return nil
 }
@@ -535,8 +542,8 @@ func HardDeletePlanPage(ctx context.Context, db *sql.DB, channelID int64, opID s
 	return ids[:limit], total, false, nil
 }
 
-// CompleteHardDeletePlan atomically removes local multipart pointers, compacts
-// the normalized plan, and retains a small completed job marker for rebuilds.
+// CompleteHardDeletePlan atomically removes any remaining multipart pointers,
+// compacts the plan and local intent, and retains a small completion receipt.
 func CompleteHardDeletePlan(ctx context.Context, db *sql.DB, channelID int64, opID string) (err error) {
 	if err := validateHardDeletePlanRequest(ctx, db, channelID, opID); err != nil {
 		return err
@@ -579,6 +586,11 @@ func CompleteHardDeletePlan(ctx context.Context, db *sql.DB, channelID int64, op
 		`, channelID, opID); err != nil {
 			return fmt.Errorf("projection: complete hard-delete plan: %w", err)
 		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM hard_delete_intents WHERE channel_id=? AND op_id=?
+	`, channelID, opID); err != nil {
+		return fmt.Errorf("projection: compact hard-delete intent: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("projection: commit hard-delete completion: %w", err)

--- a/backend/projection/hard_delete_intent.go
+++ b/backend/projection/hard_delete_intent.go
@@ -1,0 +1,168 @@
+package projection
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+var ErrHardDeleteIntentApplied = errors.New("projection: hard-delete intent already has a projected marker")
+
+// RegisterHardDeleteIntent records that this installation owns cleanup for a
+// hard-delete marker it is about to send. Telegram replay is global, while the
+// write journal is local; this explicit boundary prevents other installations
+// from accumulating actionable deletion plans for the same marker.
+func RegisterHardDeleteIntent(
+	ctx context.Context,
+	db *sql.DB,
+	channelID int64,
+	opID string,
+	objectID string,
+	expectedRevision int64,
+) (err error) {
+	if err := validateHardDeleteIntentRequest(ctx, db, channelID, opID, objectID, expectedRevision); err != nil {
+		return err
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("projection: begin hard-delete intent: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := validateHardDeleteChannel(tx, channelID); err != nil {
+		return err
+	}
+	storedObjectID, storedRevision, exists, err := loadHardDeleteIntentTx(tx, channelID, opID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if storedObjectID != objectID || storedRevision != expectedRevision {
+			return fmt.Errorf("%w: hard-delete intent operation id targets another object", ErrBadOp)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("projection: commit existing hard-delete intent: %w", err)
+		}
+		return nil
+	}
+	if _, jobExists, err := hardDeleteJobStateTx(tx, channelID, opID, objectID); err != nil {
+		return err
+	} else if jobExists {
+		return ErrHardDeleteIntentApplied
+	}
+
+	var currentRevision int64
+	err = tx.QueryRowContext(ctx, `
+		SELECT revision FROM dirents
+		WHERE channel_id=? AND object_id=? AND tombstoned=0
+	`, channelID, objectID).Scan(&currentRevision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrObjectNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("projection: inspect hard-delete intent target: %w", err)
+	}
+	if currentRevision != expectedRevision {
+		return ErrRevisionConflict
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO hard_delete_intents
+		  (channel_id, op_id, root_object_id, expected_revision)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(channel_id, op_id) DO NOTHING
+	`, channelID, opID, objectID, expectedRevision); err != nil {
+		return fmt.Errorf("projection: register hard-delete intent: %w", err)
+	}
+	storedObjectID, storedRevision, exists, err = loadHardDeleteIntentTx(tx, channelID, opID)
+	if err != nil {
+		return fmt.Errorf("projection: verify hard-delete intent: %w", err)
+	}
+	if !exists || storedObjectID != objectID || storedRevision != expectedRevision {
+		return fmt.Errorf("%w: hard-delete intent operation id targets another object", ErrBadOp)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("projection: commit hard-delete intent: %w", err)
+	}
+	return nil
+}
+
+// AbandonHardDeleteIntent removes a registered intent only while no marker has
+// projected a cleanup job. Callers use it after a definitive pre-send failure;
+// uncertain sends retain the intent for receipt reconciliation and restart.
+func AbandonHardDeleteIntent(ctx context.Context, db *sql.DB, channelID int64, opID string) (err error) {
+	if err := validateHardDeletePlanRequest(ctx, db, channelID, opID); err != nil {
+		return err
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("projection: begin abandon hard-delete intent: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var one int
+	err = tx.QueryRowContext(ctx, `
+		SELECT 1 FROM hard_delete_jobs WHERE channel_id=? AND op_id=?
+	`, channelID, opID).Scan(&one)
+	if err == nil {
+		return ErrHardDeleteIntentApplied
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("projection: inspect hard-delete intent job: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM hard_delete_intents WHERE channel_id=? AND op_id=?
+	`, channelID, opID); err != nil {
+		return fmt.Errorf("projection: abandon hard-delete intent: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("projection: commit abandoned hard-delete intent: %w", err)
+	}
+	return nil
+}
+
+func hardDeleteIntentMatchesTx(tx *sql.Tx, channelID int64, op Op) (bool, error) {
+	objectID, expectedRevision, exists, err := loadHardDeleteIntentTx(tx, channelID, op.OpID)
+	if err != nil || !exists {
+		return false, err
+	}
+	if objectID != op.Obj || expectedRevision != op.ExpectedRevision {
+		return false, fmt.Errorf("%w: hard-delete marker does not match local intent", ErrBadOp)
+	}
+	return true, nil
+}
+
+func loadHardDeleteIntentTx(tx *sql.Tx, channelID int64, opID string) (objectID string, expectedRevision int64, exists bool, err error) {
+	err = tx.QueryRow(`
+		SELECT root_object_id, expected_revision FROM hard_delete_intents
+		WHERE channel_id=? AND op_id=?
+	`, channelID, opID).Scan(&objectID, &expectedRevision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", 0, false, nil
+	}
+	if err != nil {
+		return "", 0, false, fmt.Errorf("projection: inspect hard-delete intent: %w", err)
+	}
+	return objectID, expectedRevision, true, nil
+}
+
+func validateHardDeleteIntentRequest(
+	ctx context.Context,
+	db *sql.DB,
+	channelID int64,
+	opID string,
+	objectID string,
+	expectedRevision int64,
+) error {
+	if err := validateHardDeletePlanRequest(ctx, db, channelID, opID); err != nil {
+		return err
+	}
+	if _, err := objectKind(objectID); err != nil {
+		return err
+	}
+	if expectedRevision <= 0 {
+		return fmt.Errorf("%w: hard-delete intent requires expected revision", ErrBadOp)
+	}
+	return validateVersionedWritableOp(Op{ProtocolVersion: 1, OpID: opID})
+}

--- a/backend/projection/hard_delete_test.go
+++ b/backend/projection/hard_delete_test.go
@@ -1,0 +1,432 @@
+package projection
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestHardDeleteWireRoundTripHasNoRetentionFields(t *testing.T) {
+	op := Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "hard-delete-1",
+		Obj: "d:docs", ExpectedRevision: 4,
+	}
+	wire := Format(op)
+	got, err := Parse(wire)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", wire, err)
+	}
+	if !reflect.DeepEqual(got, op) {
+		t.Fatalf("round trip\n got: %#v\nwant: %#v\nwire: %s", got, op, wire)
+	}
+	if got.DeletedAt != 0 || got.PurgeAfter != 0 || got.RetainedUntil != 0 {
+		t.Fatalf("hard delete retained trash metadata: %+v", got)
+	}
+}
+
+func TestHardDeleteFilePlansBodyAndExcludesControlMessages(t *testing.T) {
+	db := newTestDB(t)
+	mustOp(t, db, 101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "create-modern",
+		Name: "report.txt", ContentMsgID: 9001,
+	})
+	if _, err := db.Exec(`UPDATE file_revisions SET retained_until=123 WHERE channel_id=? AND file_msg_id=101`, testChan); err != nil {
+		t.Fatal(err)
+	}
+	mustOp(t, db, 102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "delete-modern",
+		Obj: "f:101", ExpectedRevision: 1,
+	})
+
+	assertHardDeletePlan(t, db, "delete-modern", []int64{9001}, 1, true)
+	if _, ok, err := FileByID(db, testChan, 101); err != nil || ok {
+		t.Fatalf("FileByID after hard delete: ok=%v err=%v", ok, err)
+	}
+	var retainedUntil int64
+	if err := db.QueryRow(`
+		SELECT retained_until FROM file_revisions
+		WHERE channel_id=? AND file_msg_id=101
+	`, testChan).Scan(&retainedUntil); err != nil {
+		t.Fatal(err)
+	}
+	if retainedUntil != 0 {
+		t.Fatalf("retained_until=%d, want 0", retainedUntil)
+	}
+	var trashCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM trash_entries WHERE channel_id=?`, testChan).Scan(&trashCount); err != nil {
+		t.Fatal(err)
+	}
+	if trashCount != 0 {
+		t.Fatalf("hard delete created %d trash entries", trashCount)
+	}
+}
+
+func TestHardDeleteLegacySingleMessagePlansBodyControl(t *testing.T) {
+	db := newTestDB(t)
+	mustOp(t, db, 31, Op{Type: OpFileUpload, Name: "legacy.txt", FileSize: 8})
+	mustOp(t, db, 40, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "delete-legacy",
+		Obj: "f:31", ExpectedRevision: 1,
+	})
+
+	// Legacy uploads store bytes in the original file message itself, so that
+	// message is both the historical control and the body that must be removed.
+	assertHardDeletePlan(t, db, "delete-legacy", []int64{31}, 1, true)
+}
+
+func TestHardDeleteFolderPlansEveryHistoricalBodyAndMultipartPart(t *testing.T) {
+	db := newTestDB(t)
+	mustOp(t, db, 1, Op{
+		Type: OpFolderCommit, ProtocolVersion: 1, OpID: "folder-root",
+		Obj: "d:root", Name: "Root",
+	})
+	mustOp(t, db, 2, Op{
+		Type: OpFolderCommit, ProtocolVersion: 1, OpID: "folder-child",
+		Obj: "d:child", Parent: "d:root", Name: "Child",
+	})
+	mustOp(t, db, 101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "historical-base",
+		Parent: "d:child", Name: "history.bin", ContentMsgID: 9001,
+	})
+	mustOp(t, db, 110, Op{Type: OpFilePart, UploadUUID: "history-parts", PartIndex: 0, FileSize: 4})
+	mustOp(t, db, 111, Op{Type: OpFilePart, UploadUUID: "history-parts", PartIndex: 1, FileSize: 6})
+	mustOp(t, db, 112, Op{
+		Type: OpFileReplace, ProtocolVersion: 1, OpID: "historical-replace",
+		Obj: "f:101", ExpectedRevision: 1, UploadUUID: "history-parts",
+		PartCount: 2, FileSize: 10, RetainedUntil: 500,
+	})
+	mustOp(t, db, 201, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "outside",
+		Name: "outside.txt", ContentMsgID: 9900,
+	})
+	mustOp(t, db, 120, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "delete-folder",
+		Obj: "d:root", ExpectedRevision: 1,
+	})
+
+	assertHardDeletePlan(t, db, "delete-folder", []int64{110, 111, 9001}, 3, true)
+	for _, objectID := range []string{"d:root", "d:child", "f:101"} {
+		entry, ok, err := DirentByID(db, testChan, objectID)
+		if err != nil || !ok || !entry.Tombstoned {
+			t.Fatalf("dirent %s = %+v, ok=%v err=%v", objectID, entry, ok, err)
+		}
+	}
+	if _, ok, err := FileByID(db, testChan, 201); err != nil || !ok {
+		t.Fatalf("outside file was hidden: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestHardDeleteFolderPlansPreviouslySoftDeletedDescendants(t *testing.T) {
+	db := newTestDB(t)
+	mustOp(t, db, 1, Op{
+		Type: OpFolderCommit, ProtocolVersion: 1, OpID: "folder-with-trash",
+		Obj: "d:root", Name: "Root",
+	})
+	mustOp(t, db, 101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "file-before-trash",
+		Parent: "d:root", Name: "old.txt", ContentMsgID: 9001,
+	})
+	mustOp(t, db, 102, Op{
+		Type: OpTrashTree, ProtocolVersion: 1, OpID: "soft-delete-child",
+		Obj: "f:101", ExpectedRevision: 1, DeletedAt: 100, PurgeAfter: 200,
+	})
+	mustOp(t, db, 103, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "hard-delete-parent",
+		Obj: "d:root", ExpectedRevision: 1,
+	})
+
+	assertHardDeletePlan(t, db, "hard-delete-parent", []int64{9001}, 1, true)
+	var trashCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM trash_entries WHERE channel_id=?`, testChan).Scan(&trashCount); err != nil {
+		t.Fatal(err)
+	}
+	if trashCount != 0 {
+		t.Fatalf("hard-deleted subtree retained %d trash entries", trashCount)
+	}
+}
+
+func TestHardDeleteRejectsKnownControlAndOversizedBodyReferences(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		bodyMsgID int64
+		seed      func(*testing.T, *sql.DB)
+	}{
+		{
+			name:      "known non-body control",
+			bodyMsgID: 50,
+			seed: func(t *testing.T, db *sql.DB) {
+				t.Helper()
+				op := Op{Type: OpFolderCommit, ProtocolVersion: 1, OpID: "unrelated-control", Obj: "d:control", Name: "Control"}
+				if _, err := ProjectFromOp(db, testChan, 50, op, 0, Format(op)); err != nil {
+					t.Fatalf("seed control: %v", err)
+				}
+			},
+		},
+		{name: "outside Telegram integer range", bodyMsgID: math.MaxInt32 + 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db := newTestDB(t)
+			if test.seed != nil {
+				test.seed(t, db)
+			}
+			mustOp(t, db, 101, Op{
+				Type: OpFileCommit, ProtocolVersion: 1, OpID: "file-with-unsafe-reference",
+				Name: "unsafe.bin", ContentMsgID: test.bodyMsgID,
+			})
+			err := runOp(t, db, testChan, 102, Op{
+				Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "reject-unsafe-reference",
+				Obj: "f:101", ExpectedRevision: 1,
+			})
+			if !errors.Is(err, ErrBadOp) {
+				t.Fatalf("unsafe hard delete error=%v, want ErrBadOp", err)
+			}
+			if _, ok, lookupErr := FileByID(db, testChan, 101); lookupErr != nil || !ok {
+				t.Fatalf("rejected hard delete mutated file: ok=%v err=%v", ok, lookupErr)
+			}
+		})
+	}
+}
+
+func TestHardDeleteRejectsSharedChannelControl(t *testing.T) {
+	db := newTestDB(t)
+	mustOp(t, db, 101, Op{Type: OpFileUpload, Name: "shared.txt", FileSize: 1})
+	if _, err := db.Exec(`UPDATE channels SET kind=? WHERE channel_id=?`, KindShared, testChan); err != nil {
+		t.Fatal(err)
+	}
+	err := runOp(t, db, testChan, 102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "shared-hard-delete",
+		Obj: "f:101", ExpectedRevision: 1,
+	})
+	if !errors.Is(err, ErrBadOp) {
+		t.Fatalf("shared hard delete error=%v, want ErrBadOp", err)
+	}
+	if _, ok, lookupErr := FileByID(db, testChan, 101); lookupErr != nil || !ok {
+		t.Fatalf("shared hard delete mutated file: ok=%v err=%v", ok, lookupErr)
+	}
+}
+
+func TestHardDeleteRejectsIncompleteHistoricalMultipart(t *testing.T) {
+	db := newTestDB(t)
+	mustOp(t, db, 10, Op{Type: OpFilePart, UploadUUID: "damaged", PartIndex: 0, FileSize: 4})
+	mustOp(t, db, 11, Op{Type: OpFilePart, UploadUUID: "damaged", PartIndex: 1, FileSize: 6})
+	mustOp(t, db, 101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "damaged-file",
+		Name: "damaged.bin", UploadUUID: "damaged", PartCount: 2, FileSize: 10,
+	})
+	if _, err := db.Exec(`DELETE FROM file_parts WHERE channel_id=? AND msg_id=11`, testChan); err != nil {
+		t.Fatal(err)
+	}
+	err := runOp(t, db, testChan, 102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "delete-damaged",
+		Obj: "f:101", ExpectedRevision: 1,
+	})
+	if !errors.Is(err, ErrContentIncomplete) {
+		t.Fatalf("hard delete incomplete multipart error=%v, want ErrContentIncomplete", err)
+	}
+	if _, ok, lookupErr := FileByID(db, testChan, 101); lookupErr != nil || !ok {
+		t.Fatalf("failed hard delete mutated file: ok=%v err=%v", ok, lookupErr)
+	}
+}
+
+func TestHardDeleteRejectsBodiesReferencedOutsideSubtree(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		prepare func(t *testing.T, db *sql.DB)
+	}{
+		{
+			name: "single message body",
+			prepare: func(t *testing.T, db *sql.DB) {
+				t.Helper()
+				mustOp(t, db, 101, Op{
+					Type: OpFileCommit, ProtocolVersion: 1, OpID: "owned-direct",
+					Parent: "d:inside", Name: "inside.bin", ContentMsgID: 9001,
+				})
+				mustOp(t, db, 102, Op{
+					Type: OpFileCommit, ProtocolVersion: 1, OpID: "outside-direct",
+					Name: "outside.bin", ContentMsgID: 9002,
+				})
+				if _, err := db.Exec(`
+					UPDATE file_revisions SET content_msg_id=9001
+					WHERE channel_id=? AND file_msg_id=102
+				`, testChan); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "multipart body",
+			prepare: func(t *testing.T, db *sql.DB) {
+				t.Helper()
+				mustOp(t, db, 10, Op{Type: OpFilePart, UploadUUID: "owned-parts", PartIndex: 0, FileSize: 4})
+				mustOp(t, db, 11, Op{Type: OpFilePart, UploadUUID: "owned-parts", PartIndex: 1, FileSize: 6})
+				mustOp(t, db, 101, Op{
+					Type: OpFileCommit, ProtocolVersion: 1, OpID: "owned-multipart",
+					Parent: "d:inside", Name: "inside.bin", UploadUUID: "owned-parts",
+					PartCount: 2, FileSize: 10,
+				})
+				mustOp(t, db, 102, Op{
+					Type: OpFileCommit, ProtocolVersion: 1, OpID: "outside-multipart",
+					Name: "outside.bin", ContentMsgID: 9002,
+				})
+				if _, err := db.Exec(`
+					UPDATE file_revisions
+					SET content_msg_id=0, upload_uuid='owned-parts', part_count=2, size=10
+					WHERE channel_id=? AND file_msg_id=102
+				`, testChan); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db := newTestDB(t)
+			mustOp(t, db, 1, Op{
+				Type: OpFolderCommit, ProtocolVersion: 1, OpID: "inside-folder",
+				Obj: "d:inside", Name: "Inside",
+			})
+			test.prepare(t, db)
+
+			err := runOp(t, db, testChan, 200, Op{
+				Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "delete-shared-body",
+				Obj: "d:inside", ExpectedRevision: 1,
+			})
+			if !errors.Is(err, ErrContentAlreadyCommitted) {
+				t.Fatalf("hard delete shared body error=%v, want ErrContentAlreadyCommitted", err)
+			}
+			entry, ok, lookupErr := DirentByID(db, testChan, "d:inside")
+			if lookupErr != nil || !ok || entry.Tombstoned {
+				t.Fatalf("failed hard delete mutated subtree root: %+v ok=%v err=%v", entry, ok, lookupErr)
+			}
+			if _, _, _, planErr := HardDeletePlanPage(context.Background(), db, testChan, "delete-shared-body", 0, 10); !errors.Is(planErr, ErrHardDeletePlanNotFound) {
+				t.Fatalf("failed hard delete persisted plan: %v", planErr)
+			}
+		})
+	}
+}
+
+func TestHardDeletePlanPagesAndCompletionCompactsState(t *testing.T) {
+	db := newTestDB(t)
+	for index, msgID := range []int64{10, 20, 30} {
+		mustOp(t, db, msgID, Op{Type: OpFilePart, UploadUUID: "paged", PartIndex: index, FileSize: 1})
+	}
+	mustOp(t, db, 101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "paged-file",
+		Name: "paged.bin", UploadUUID: "paged", PartCount: 3, FileSize: 3,
+	})
+	mustOp(t, db, 102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "delete-paged",
+		Obj: "f:101", ExpectedRevision: 1,
+	})
+
+	ids, total, done, err := HardDeletePlanPage(context.Background(), db, testChan, "delete-paged", 0, 2)
+	if err != nil || !reflect.DeepEqual(ids, []int64{10, 20}) || total != 3 || done {
+		t.Fatalf("first page=(%v,%d,%t,%v)", ids, total, done, err)
+	}
+	ids, total, done, err = HardDeletePlanPage(context.Background(), db, testChan, "delete-paged", 20, 2)
+	if err != nil || !reflect.DeepEqual(ids, []int64{30}) || total != 3 || !done {
+		t.Fatalf("second page=(%v,%d,%t,%v)", ids, total, done, err)
+	}
+	if err := CompleteHardDeletePlan(context.Background(), db, testChan, "delete-paged"); err != nil {
+		t.Fatalf("complete plan: %v", err)
+	}
+	ids, total, done, err = HardDeletePlanPage(context.Background(), db, testChan, "delete-paged", 0, 2)
+	if err != nil || len(ids) != 0 || total != 3 || !done {
+		t.Fatalf("completed page=(%v,%d,%t,%v)", ids, total, done, err)
+	}
+	var parts int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM file_parts WHERE channel_id=? AND upload_uuid='paged'`, testChan).Scan(&parts); err != nil {
+		t.Fatal(err)
+	}
+	if parts != 0 {
+		t.Fatalf("completed cleanup retained %d part pointers", parts)
+	}
+	// Completion is idempotent for recovery retries.
+	if err := CompleteHardDeletePlan(context.Background(), db, testChan, "delete-paged"); err != nil {
+		t.Fatalf("repeat complete: %v", err)
+	}
+}
+
+func TestHardDeleteCompletedJobSurvivesRebuildWithoutRequeue(t *testing.T) {
+	db := newTestDB(t)
+	project := func(msgID int64, op Op) {
+		t.Helper()
+		if _, err := ProjectFromOp(db, testChan, msgID, op, 0, Format(op)); err != nil {
+			t.Fatalf("project msg %d: %v", msgID, err)
+		}
+	}
+	project(10, Op{Type: OpFilePart, UploadUUID: "rebuild-parts", PartIndex: 0, FileSize: 4})
+	project(11, Op{Type: OpFilePart, UploadUUID: "rebuild-parts", PartIndex: 1, FileSize: 6})
+	project(101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "rebuild-file",
+		Name: "rebuild.bin", UploadUUID: "rebuild-parts", PartCount: 2, FileSize: 10,
+	})
+	project(102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "rebuild-delete",
+		Obj: "f:101", ExpectedRevision: 1,
+	})
+	if err := CompleteHardDeletePlan(context.Background(), db, testChan, "rebuild-delete"); err != nil {
+		t.Fatal(err)
+	}
+	if err := RebuildProjection(db, testChan); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	assertHardDeletePlan(t, db, "rebuild-delete", nil, 2, true)
+	if _, ok, err := FileByID(db, testChan, 101); err != nil || ok {
+		t.Fatalf("rebuilt hard-deleted file visible: ok=%v err=%v", ok, err)
+	}
+	var parts int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM file_parts WHERE channel_id=? AND upload_uuid='rebuild-parts'`, testChan).Scan(&parts); err != nil {
+		t.Fatal(err)
+	}
+	if parts != 0 {
+		t.Fatalf("rebuild restored %d completed body pointers", parts)
+	}
+}
+
+func TestHardDeletePlanAPIBoundaries(t *testing.T) {
+	db := newTestDB(t)
+	for _, test := range []struct {
+		name      string
+		ctx       context.Context
+		db        *sql.DB
+		channelID int64
+		opID      string
+		after     int64
+		limit     int
+	}{
+		{"nil context", nil, db, testChan, "op", 0, 1},
+		{"nil db", context.Background(), nil, testChan, "op", 0, 1},
+		{"bad channel", context.Background(), db, 0, "op", 0, 1},
+		{"empty op", context.Background(), db, testChan, "", 0, 1},
+		{"negative cursor", context.Background(), db, testChan, "op", -1, 1},
+		{"zero limit", context.Background(), db, testChan, "op", 0, 0},
+		{"large limit", context.Background(), db, testChan, "op", 0, 1001},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, _, _, err := HardDeletePlanPage(test.ctx, test.db, test.channelID, test.opID, test.after, test.limit); err == nil {
+				t.Fatal("HardDeletePlanPage succeeded")
+			}
+		})
+	}
+	if _, _, _, err := HardDeletePlanPage(context.Background(), db, testChan, "missing", 0, 1); !errors.Is(err, ErrHardDeletePlanNotFound) {
+		t.Fatalf("missing plan error=%v", err)
+	}
+	if err := CompleteHardDeletePlan(context.Background(), db, testChan, "missing"); !errors.Is(err, ErrHardDeletePlanNotFound) {
+		t.Fatalf("complete missing error=%v", err)
+	}
+}
+
+func assertHardDeletePlan(t *testing.T, db *sql.DB, opID string, wantIDs []int64, wantTotal int64, wantDone bool) {
+	t.Helper()
+	ids, total, done, err := HardDeletePlanPage(context.Background(), db, testChan, opID, 0, 1000)
+	if err != nil {
+		t.Fatalf("HardDeletePlanPage(%q): %v", opID, err)
+	}
+	if !reflect.DeepEqual(ids, wantIDs) || total != wantTotal || done != wantDone {
+		t.Fatalf("plan %q=(%v,%d,%t), want (%v,%d,%t)", opID, ids, total, done, wantIDs, wantTotal, wantDone)
+	}
+}

--- a/backend/projection/hard_delete_test.go
+++ b/backend/projection/hard_delete_test.go
@@ -176,10 +176,14 @@ func TestHardDeleteRejectsKnownControlAndOversizedBodyReferences(t *testing.T) {
 				Type: OpFileCommit, ProtocolVersion: 1, OpID: "file-with-unsafe-reference",
 				Name: "unsafe.bin", ContentMsgID: test.bodyMsgID,
 			})
-			err := runOp(t, db, testChan, 102, Op{
+			op := Op{
 				Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "reject-unsafe-reference",
 				Obj: "f:101", ExpectedRevision: 1,
-			})
+			}
+			if err := RegisterHardDeleteIntent(context.Background(), db, testChan, op.OpID, op.Obj, op.ExpectedRevision); err != nil {
+				t.Fatalf("register hard-delete intent: %v", err)
+			}
+			err := runOp(t, db, testChan, 102, op)
 			if !errors.Is(err, ErrBadOp) {
 				t.Fatalf("unsafe hard delete error=%v, want ErrBadOp", err)
 			}
@@ -219,10 +223,14 @@ func TestHardDeleteRejectsIncompleteHistoricalMultipart(t *testing.T) {
 	if _, err := db.Exec(`DELETE FROM file_parts WHERE channel_id=? AND msg_id=11`, testChan); err != nil {
 		t.Fatal(err)
 	}
-	err := runOp(t, db, testChan, 102, Op{
+	op := Op{
 		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "delete-damaged",
 		Obj: "f:101", ExpectedRevision: 1,
-	})
+	}
+	if err := RegisterHardDeleteIntent(context.Background(), db, testChan, op.OpID, op.Obj, op.ExpectedRevision); err != nil {
+		t.Fatalf("register hard-delete intent: %v", err)
+	}
+	err := runOp(t, db, testChan, 102, op)
 	if !errors.Is(err, ErrContentIncomplete) {
 		t.Fatalf("hard delete incomplete multipart error=%v, want ErrContentIncomplete", err)
 	}
@@ -289,10 +297,14 @@ func TestHardDeleteRejectsBodiesReferencedOutsideSubtree(t *testing.T) {
 			})
 			test.prepare(t, db)
 
-			err := runOp(t, db, testChan, 200, Op{
+			op := Op{
 				Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "delete-shared-body",
 				Obj: "d:inside", ExpectedRevision: 1,
-			})
+			}
+			if err := RegisterHardDeleteIntent(context.Background(), db, testChan, op.OpID, op.Obj, op.ExpectedRevision); err != nil {
+				t.Fatalf("register hard-delete intent: %v", err)
+			}
+			err := runOp(t, db, testChan, 200, op)
 			if !errors.Is(err, ErrContentAlreadyCommitted) {
 				t.Fatalf("hard delete shared body error=%v, want ErrContentAlreadyCommitted", err)
 			}
@@ -363,6 +375,9 @@ func TestHardDeleteCompletedJobSurvivesRebuildWithoutRequeue(t *testing.T) {
 		Type: OpFileCommit, ProtocolVersion: 1, OpID: "rebuild-file",
 		Name: "rebuild.bin", UploadUUID: "rebuild-parts", PartCount: 2, FileSize: 10,
 	})
+	if err := RegisterHardDeleteIntent(context.Background(), db, testChan, "rebuild-delete", "f:101", 1); err != nil {
+		t.Fatalf("register intent: %v", err)
+	}
 	project(102, Op{
 		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "rebuild-delete",
 		Obj: "f:101", ExpectedRevision: 1,
@@ -385,6 +400,163 @@ func TestHardDeleteCompletedJobSurvivesRebuildWithoutRequeue(t *testing.T) {
 	if parts != 0 {
 		t.Fatalf("rebuild restored %d completed body pointers", parts)
 	}
+}
+
+func TestRemoteHardDeleteReplayDoesNotCreateLocalCleanupWork(t *testing.T) {
+	db := newTestDB(t)
+	project := func(msgID int64, op Op) {
+		t.Helper()
+		if _, err := ProjectFromOp(db, testChan, msgID, op, 0, Format(op)); err != nil {
+			t.Fatalf("project msg %d: %v", msgID, err)
+		}
+	}
+	project(10, Op{Type: OpFilePart, UploadUUID: "remote-parts", PartIndex: 0, FileSize: 4})
+	project(101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "remote-file",
+		Name: "remote.bin", UploadUUID: "remote-parts", PartCount: 1, FileSize: 4,
+	})
+	project(102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "remote-delete",
+		Obj: "f:101", ExpectedRevision: 1,
+	})
+
+	assertNoFileParts(t, db, "remote-parts")
+	assertNoHardDeleteCleanupWork(t, db, "remote-delete")
+	if _, ok, err := FileByID(db, testChan, 101); err != nil || ok {
+		t.Fatalf("remote marker did not hide file: ok=%v err=%v", ok, err)
+	}
+	if err := RebuildProjection(db, testChan); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	assertNoFileParts(t, db, "remote-parts")
+	assertNoHardDeleteCleanupWork(t, db, "remote-delete")
+	if _, ok, err := FileByID(db, testChan, 101); err != nil || ok {
+		t.Fatalf("rebuilt remote marker did not hide file: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestRemoteHardDeleteReplayTombstonesWithIncompleteMultipartIndex(t *testing.T) {
+	db := newTestDB(t)
+	project := func(msgID int64, op Op) {
+		t.Helper()
+		if _, err := ProjectFromOp(db, testChan, msgID, op, 0, Format(op)); err != nil {
+			t.Fatalf("project msg %d: %v", msgID, err)
+		}
+	}
+	project(10, Op{Type: OpFilePart, UploadUUID: "partial-remote", PartIndex: 0, FileSize: 4})
+	project(11, Op{Type: OpFilePart, UploadUUID: "partial-remote", PartIndex: 1, FileSize: 6})
+	project(101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "partial-remote-file",
+		Name: "partial.bin", UploadUUID: "partial-remote", PartCount: 2, FileSize: 10,
+	})
+	if _, err := db.Exec(`DELETE FROM file_parts WHERE channel_id=? AND msg_id=?`, testChan, 11); err != nil {
+		t.Fatal(err)
+	}
+
+	project(102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "partial-remote-delete",
+		Obj: "f:101", ExpectedRevision: 1,
+	})
+
+	assertNoFileParts(t, db, "partial-remote")
+	assertNoHardDeleteCleanupWork(t, db, "partial-remote-delete")
+	if _, ok, err := FileByID(db, testChan, 101); err != nil || ok {
+		t.Fatalf("remote marker did not hide file: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestHardDeleteIntentSurvivesReconciliationAndRebuildUntilCompletion(t *testing.T) {
+	db := newTestDB(t)
+	project := func(msgID int64, op Op) {
+		t.Helper()
+		if _, err := ProjectFromOp(db, testChan, msgID, op, 0, Format(op)); err != nil {
+			t.Fatalf("project msg %d: %v", msgID, err)
+		}
+	}
+	project(10, Op{Type: OpFilePart, UploadUUID: "owned-parts", PartIndex: 0, FileSize: 4})
+	project(101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "owned-file",
+		Name: "owned.bin", UploadUUID: "owned-parts", PartCount: 1, FileSize: 4,
+	})
+	ctx := context.Background()
+	if err := RegisterHardDeleteIntent(ctx, db, testChan, "owned-delete", "f:101", 1); err != nil {
+		t.Fatalf("register intent: %v", err)
+	}
+	project(102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "owned-delete",
+		Obj: "f:101", ExpectedRevision: 1,
+	})
+
+	// Receipt reconciliation may call registration again after projection has
+	// already hidden the target. Exact retry must remain idempotent.
+	if err := RegisterHardDeleteIntent(ctx, db, testChan, "owned-delete", "f:101", 1); err != nil {
+		t.Fatalf("re-register projected intent: %v", err)
+	}
+	assertHardDeletePlan(t, db, "owned-delete", []int64{10}, 1, true)
+	assertNoFileParts(t, db, "owned-parts")
+
+	if err := RebuildProjection(db, testChan); err != nil {
+		t.Fatalf("rebuild pending delete: %v", err)
+	}
+	assertHardDeletePlan(t, db, "owned-delete", []int64{10}, 1, true)
+	assertNoFileParts(t, db, "owned-parts")
+
+	if err := CompleteHardDeletePlan(ctx, db, testChan, "owned-delete"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	assertHardDeleteIntentCount(t, db, "owned-delete", 0)
+	assertHardDeletePlan(t, db, "owned-delete", nil, 1, true)
+}
+
+func TestAbandonHardDeleteIntentPreventsOrphanCleanupWork(t *testing.T) {
+	db := newTestDB(t)
+	mustOp(t, db, 101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "abandoned-file",
+		Name: "abandoned.bin", ContentMsgID: 9001,
+	})
+	ctx := context.Background()
+	if err := RegisterHardDeleteIntent(ctx, db, testChan, "abandoned-delete", "f:101", 1); err != nil {
+		t.Fatalf("register intent: %v", err)
+	}
+	if err := AbandonHardDeleteIntent(ctx, db, testChan, "abandoned-delete"); err != nil {
+		t.Fatalf("abandon intent: %v", err)
+	}
+	if err := AbandonHardDeleteIntent(ctx, db, testChan, "abandoned-delete"); err != nil {
+		t.Fatalf("repeat abandon: %v", err)
+	}
+	assertHardDeleteIntentCount(t, db, "abandoned-delete", 0)
+
+	// If a marker unexpectedly arrives after a caller definitively abandoned
+	// its send, replay still hides the object but cannot enqueue local cleanup.
+	if _, err := ProjectFromOp(db, testChan, 102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "abandoned-delete",
+		Obj: "f:101", ExpectedRevision: 1,
+	}, 0, ""); err != nil {
+		t.Fatalf("project late marker: %v", err)
+	}
+	assertNoHardDeleteCleanupWork(t, db, "abandoned-delete")
+}
+
+func TestCannotAbandonAppliedHardDeleteIntent(t *testing.T) {
+	db := newTestDB(t)
+	mustOp(t, db, 101, Op{
+		Type: OpFileCommit, ProtocolVersion: 1, OpID: "applied-file",
+		Name: "applied.bin", ContentMsgID: 9001,
+	})
+	ctx := context.Background()
+	if err := RegisterHardDeleteIntent(ctx, db, testChan, "applied-delete", "f:101", 1); err != nil {
+		t.Fatalf("register intent: %v", err)
+	}
+	if _, err := ProjectFromOp(db, testChan, 102, Op{
+		Type: OpHardDeleteTree, ProtocolVersion: 1, OpID: "applied-delete",
+		Obj: "f:101", ExpectedRevision: 1,
+	}, 0, ""); err != nil {
+		t.Fatalf("project marker: %v", err)
+	}
+	if err := AbandonHardDeleteIntent(ctx, db, testChan, "applied-delete"); !errors.Is(err, ErrHardDeleteIntentApplied) {
+		t.Fatalf("abandon applied intent error=%v, want ErrHardDeleteIntentApplied", err)
+	}
+	assertHardDeleteIntentCount(t, db, "applied-delete", 1)
 }
 
 func TestHardDeletePlanAPIBoundaries(t *testing.T) {
@@ -428,5 +600,47 @@ func assertHardDeletePlan(t *testing.T, db *sql.DB, opID string, wantIDs []int64
 	}
 	if !reflect.DeepEqual(ids, wantIDs) || total != wantTotal || done != wantDone {
 		t.Fatalf("plan %q=(%v,%d,%t), want (%v,%d,%t)", opID, ids, total, done, wantIDs, wantTotal, wantDone)
+	}
+}
+
+func assertNoHardDeleteCleanupWork(t *testing.T, db *sql.DB, opID string) {
+	t.Helper()
+	if _, _, _, err := HardDeletePlanPage(context.Background(), db, testChan, opID, 0, 1000); !errors.Is(err, ErrHardDeletePlanNotFound) {
+		t.Fatalf("HardDeletePlanPage(%q) error=%v, want ErrHardDeletePlanNotFound", opID, err)
+	}
+	for _, table := range []string{"hard_delete_jobs", "hard_delete_plan_items"} {
+		var count int
+		if err := db.QueryRow(`SELECT COUNT(*) FROM `+table+` WHERE channel_id=? AND op_id=?`, testChan, opID).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Fatalf("remote marker retained %d rows in %s", count, table)
+		}
+	}
+}
+
+func assertNoFileParts(t *testing.T, db *sql.DB, uploadUUID string) {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM file_parts WHERE channel_id=? AND upload_uuid=?
+	`, testChan, uploadUUID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("hard delete retained %d local part pointers for %q", count, uploadUUID)
+	}
+}
+
+func assertHardDeleteIntentCount(t *testing.T, db *sql.DB, opID string, want int) {
+	t.Helper()
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM hard_delete_intents WHERE channel_id=? AND op_id=?
+	`, testChan, opID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != want {
+		t.Fatalf("hard-delete intent count=%d, want %d", count, want)
 	}
 }

--- a/backend/projection/rebuild.go
+++ b/backend/projection/rebuild.go
@@ -43,8 +43,9 @@ func RebuildProjection(db *sql.DB, channelID int64) error {
 func rebuildProjectionTx(tx *sql.Tx, channelID int64) (applied, rejected int, err error) {
 	// An incomplete hard-delete plan may have been captured during an
 	// out-of-order incremental pass. Recreate it from ordered replay below.
-	// Completed jobs are retained as compact resurrection barriers and never
-	// requeue already-deleted bodies.
+	// Completed jobs are retained as compact local cleanup receipts and never
+	// requeue already-deleted bodies. The replayed harddel marker remains the
+	// durable namespace resurrection barrier.
 	if _, err := tx.Exec(`DELETE FROM hard_delete_plan_items WHERE channel_id = ?`, channelID); err != nil {
 		return 0, 0, fmt.Errorf("projection: rebuild clear incomplete hard-delete plans: %w", err)
 	}

--- a/backend/projection/rebuild.go
+++ b/backend/projection/rebuild.go
@@ -28,7 +28,7 @@ func RebuildProjection(db *sql.DB, channelID int64) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	applied, rejected, err := rebuildProjectionTx(tx, channelID)
+	applied, rejected, err := RebuildProjectionTx(tx, channelID)
 	if err != nil {
 		slog.Error("projection: rebuild failed", "channel_id", channelID, "elapsed", time.Since(start), "error", err)
 		return err
@@ -41,6 +41,18 @@ func RebuildProjection(db *sql.DB, channelID int64) error {
 }
 
 func rebuildProjectionTx(tx *sql.Tx, channelID int64) (applied, rejected int, err error) {
+	// An incomplete hard-delete plan may have been captured during an
+	// out-of-order incremental pass. Recreate it from ordered replay below.
+	// Completed jobs are retained as compact resurrection barriers and never
+	// requeue already-deleted bodies.
+	if _, err := tx.Exec(`DELETE FROM hard_delete_plan_items WHERE channel_id = ?`, channelID); err != nil {
+		return 0, 0, fmt.Errorf("projection: rebuild clear incomplete hard-delete plans: %w", err)
+	}
+	if _, err := tx.Exec(`
+		DELETE FROM hard_delete_jobs WHERE channel_id = ? AND completed = 0
+	`, channelID); err != nil {
+		return 0, 0, fmt.Errorf("projection: rebuild clear incomplete hard-delete jobs: %w", err)
+	}
 	if _, err := tx.Exec(`DELETE FROM files WHERE channel_id = ?`, channelID); err != nil {
 		return 0, 0, fmt.Errorf("projection: rebuild clear files: %w", err)
 	}

--- a/backend/projection/schema.go
+++ b/backend/projection/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const currentSchemaVersion = 10
+const currentSchemaVersion = 11
 
 func EnsureSchema(db *sql.DB) error {
 	if db == nil {
@@ -163,6 +163,21 @@ func EnsureSchema(db *sql.DB) error {
 			purge_after       INTEGER NOT NULL,
 			op_id             TEXT NOT NULL,
 			PRIMARY KEY (channel_id, object_id)
+		);`,
+		`CREATE TABLE IF NOT EXISTS hard_delete_jobs (
+			channel_id      INTEGER NOT NULL,
+			op_id           TEXT NOT NULL,
+			root_object_id  TEXT NOT NULL,
+			marker_msg_id   INTEGER NOT NULL,
+			total_messages  INTEGER NOT NULL DEFAULT 0,
+			completed       INTEGER NOT NULL DEFAULT 0 CHECK (completed IN (0, 1)),
+			PRIMARY KEY (channel_id, op_id)
+		);`,
+		`CREATE TABLE IF NOT EXISTS hard_delete_plan_items (
+			channel_id INTEGER NOT NULL,
+			op_id      TEXT NOT NULL,
+			msg_id     INTEGER NOT NULL,
+			PRIMARY KEY (channel_id, op_id, msg_id)
 		);`,
 	}
 
@@ -350,7 +365,6 @@ func MigratePersonalChannel(db *sql.DB, personalChannelID int64) error {
 			return err
 		}
 	}
-
 	if _, err := tx.Exec(`DELETE FROM schema_version`); err != nil {
 		return fmt.Errorf("projection: clear schema version: %w", err)
 	}

--- a/backend/projection/schema.go
+++ b/backend/projection/schema.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-const currentSchemaVersion = 11
+const currentSchemaVersion = 12
 
 func EnsureSchema(db *sql.DB) error {
 	if db == nil {
@@ -171,6 +171,13 @@ func EnsureSchema(db *sql.DB) error {
 			marker_msg_id   INTEGER NOT NULL,
 			total_messages  INTEGER NOT NULL DEFAULT 0,
 			completed       INTEGER NOT NULL DEFAULT 0 CHECK (completed IN (0, 1)),
+			PRIMARY KEY (channel_id, op_id)
+		);`,
+		`CREATE TABLE IF NOT EXISTS hard_delete_intents (
+			channel_id        INTEGER NOT NULL,
+			op_id             TEXT NOT NULL,
+			root_object_id    TEXT NOT NULL,
+			expected_revision INTEGER NOT NULL CHECK (expected_revision > 0),
 			PRIMARY KEY (channel_id, op_id)
 		);`,
 		`CREATE TABLE IF NOT EXISTS hard_delete_plan_items (

--- a/backend/projection/types.go
+++ b/backend/projection/types.go
@@ -37,11 +37,12 @@ const (
 	// Writable-mount operations are versioned, carry a durable operation id,
 	// and project as one SQLite transaction. Telegram body messages stay
 	// hidden; OpFileCommit is the visibility boundary for a new logical file.
-	OpFileCommit   OpType = "fcommit"
-	OpFileReplace  OpType = "freplace"
-	OpFolderCommit OpType = "dcommit"
-	OpRelocate     OpType = "relocate"
-	OpTrashTree    OpType = "trash"
+	OpFileCommit     OpType = "fcommit"
+	OpFileReplace    OpType = "freplace"
+	OpFolderCommit   OpType = "dcommit"
+	OpRelocate       OpType = "relocate"
+	OpTrashTree      OpType = "trash"
+	OpHardDeleteTree OpType = "harddel"
 )
 
 type Op struct {

--- a/backend/projection/wire.go
+++ b/backend/projection/wire.go
@@ -250,6 +250,16 @@ func Parse(raw string) (Op, error) {
 		if err := setPositiveInt64(&op.PurgeAfter, kv["purge"]); err != nil {
 			return Op{}, err
 		}
+	case OpHardDeleteTree:
+		if err := setWritableEnvelope(&op, kv); err != nil {
+			return Op{}, err
+		}
+		if err := setObjAny(&op, kv["obj"]); err != nil {
+			return Op{}, err
+		}
+		if err := setPositiveInt64(&op.ExpectedRevision, kv["rev"]); err != nil {
+			return Op{}, err
+		}
 	default:
 		return Op{}, ErrWireBadOpType
 	}
@@ -434,6 +444,12 @@ func Format(op Op) string {
 		b.WriteString(strconv.FormatInt(op.DeletedAt, 10))
 		b.WriteString("|purge=")
 		b.WriteString(strconv.FormatInt(op.PurgeAfter, 10))
+	case OpHardDeleteTree:
+		appendWritableEnvelope(&b, op)
+		b.WriteString("|obj=")
+		b.WriteString(op.Obj)
+		b.WriteString("|rev=")
+		b.WriteString(strconv.FormatInt(op.ExpectedRevision, 10))
 	}
 
 	return b.String()

--- a/backend/projection/writable_apply.go
+++ b/backend/projection/writable_apply.go
@@ -22,7 +22,7 @@ var (
 
 func isVersionedWritableOp(opType OpType) bool {
 	switch opType {
-	case OpFileCommit, OpFileReplace, OpFolderCommit, OpRelocate, OpTrashTree:
+	case OpFileCommit, OpFileReplace, OpFolderCommit, OpRelocate, OpTrashTree, OpHardDeleteTree:
 		return true
 	default:
 		return false

--- a/backend/services/lifecycle/service.go
+++ b/backend/services/lifecycle/service.go
@@ -55,23 +55,25 @@ type RebuildFunc func(db *sql.DB, channelID int64) error
 type WarnFunc func(format string, args ...any)
 
 type Config struct {
-	DB       *sql.DB
-	Sync     Syncer
-	Backfill Backfiller
-	Active   *ActiveDrive
-	Events   EventSink
-	Rebuild  RebuildFunc
-	Warnf    WarnFunc
+	DB                  *sql.DB
+	Sync                Syncer
+	Backfill            Backfiller
+	Active              *ActiveDrive
+	Events              EventSink
+	Rebuild             RebuildFunc
+	Warnf               WarnFunc
+	OnProjectionChanged func(channelID int64)
 }
 
 type Service struct {
-	DB       *sql.DB
-	Sync     Syncer
-	Backfill Backfiller
-	Active   *ActiveDrive
-	Events   EventSink
-	Rebuild  RebuildFunc
-	Warnf    WarnFunc
+	DB                  *sql.DB
+	Sync                Syncer
+	Backfill            Backfiller
+	Active              *ActiveDrive
+	Events              EventSink
+	Rebuild             RebuildFunc
+	Warnf               WarnFunc
+	OnProjectionChanged func(channelID int64)
 
 	backfillMu  sync.Mutex
 	backfilling map[int64]bool
@@ -85,14 +87,15 @@ func NewService(c Config) *Service {
 		c.Rebuild = projection.RebuildProjection
 	}
 	return &Service{
-		DB:          c.DB,
-		Sync:        c.Sync,
-		Backfill:    c.Backfill,
-		Active:      c.Active,
-		Events:      c.Events,
-		Rebuild:     c.Rebuild,
-		Warnf:       c.Warnf,
-		backfilling: make(map[int64]bool),
+		DB:                  c.DB,
+		Sync:                c.Sync,
+		Backfill:            c.Backfill,
+		Active:              c.Active,
+		Events:              c.Events,
+		Rebuild:             c.Rebuild,
+		Warnf:               c.Warnf,
+		OnProjectionChanged: c.OnProjectionChanged,
+		backfilling:         make(map[int64]bool),
 	}
 }
 
@@ -119,6 +122,12 @@ func (s *Service) SyncChannel(ctx context.Context, channelID int64) error {
 	}
 	if channelID == 0 {
 		return fmt.Errorf("no active channel")
+	}
+	// Incremental sync commits one page at a time. Even if a later page fails,
+	// earlier projection changes are durable, so mounted snapshots must be
+	// invalidated before this call returns on either outcome.
+	if s.OnProjectionChanged != nil {
+		defer s.OnProjectionChanged(channelID)
 	}
 	slog.Debug("lifecycle: incremental sync starting", "channel_id", channelID)
 	err := s.Sync.Incremental(ctx, channelID)
@@ -154,6 +163,9 @@ func (s *Service) RebuildProjection(channelID int64) error {
 		return err
 	}
 	slog.Info("lifecycle: full projection rebuild complete", "channel_id", channelID)
+	if s.OnProjectionChanged != nil {
+		s.OnProjectionChanged(channelID)
+	}
 	return nil
 }
 

--- a/backend/services/lifecycle/service_test.go
+++ b/backend/services/lifecycle/service_test.go
@@ -221,9 +221,16 @@ func TestSyncChannelSucceedsWhenReconcileFails(t *testing.T) {
 	active := NewActiveDrive()
 	active.Set(99)
 	syncer := &fakeSyncer{reconcileErr: fmt.Errorf("boom")}
+	notified := 0
 	svc := NewService(Config{
 		Active: active,
 		Sync:   syncer,
+		OnProjectionChanged: func(channelID int64) {
+			if channelID != 99 {
+				t.Errorf("completion channel = %d, want 99", channelID)
+			}
+			notified++
+		},
 	})
 
 	// Reconcile failing is best-effort: it must not fail the overall sync.
@@ -233,6 +240,65 @@ func TestSyncChannelSucceedsWhenReconcileFails(t *testing.T) {
 	if syncer.reconcileCalled != 1 {
 		t.Fatalf("reconcile called=%d, want 1", syncer.reconcileCalled)
 	}
+	if notified != 1 {
+		t.Fatalf("completion notifications = %d, want 1", notified)
+	}
+}
+
+func TestSyncChannelNotifiesAfterProjectionWorkCompletes(t *testing.T) {
+	t.Parallel()
+
+	order := make([]string, 0, 3)
+	syncer := &orderedSyncer{order: &order}
+	svc := NewService(Config{
+		Active: NewActiveDrive(),
+		Sync:   syncer,
+		OnProjectionChanged: func(channelID int64) {
+			order = append(order, fmt.Sprintf("notify:%d", channelID))
+		},
+	})
+
+	if err := svc.SyncChannel(context.Background(), 123); err != nil {
+		t.Fatalf("SyncChannel() error = %v", err)
+	}
+	want := []string{"incremental", "reconcile", "notify:123"}
+	if fmt.Sprint(order) != fmt.Sprint(want) {
+		t.Fatalf("completion order = %v, want %v", order, want)
+	}
+}
+
+func TestSyncChannelInvalidatesProjectionWhenIncrementalFails(t *testing.T) {
+	t.Parallel()
+
+	notified := false
+	svc := NewService(Config{
+		Active: NewActiveDrive(),
+		Sync:   &fakeSyncer{err: fmt.Errorf("boom")},
+		OnProjectionChanged: func(int64) {
+			notified = true
+		},
+	})
+
+	if err := svc.SyncChannel(context.Background(), 123); err == nil {
+		t.Fatal("SyncChannel() error = nil, want incremental failure")
+	}
+	if !notified {
+		t.Fatal("projection callback did not run after a possibly partial incremental sync")
+	}
+}
+
+type orderedSyncer struct {
+	order *[]string
+}
+
+func (syncer *orderedSyncer) Incremental(context.Context, int64) error {
+	*syncer.order = append(*syncer.order, "incremental")
+	return nil
+}
+
+func (syncer *orderedSyncer) ReconcileDeletions(context.Context, int64) (int, error) {
+	*syncer.order = append(*syncer.order, "reconcile")
+	return 0, nil
 }
 
 func TestRebuildProjectionDelegates(t *testing.T) {
@@ -240,6 +306,7 @@ func TestRebuildProjectionDelegates(t *testing.T) {
 	active := NewActiveDrive()
 	active.Set(55)
 	var rebuilt int64
+	var notified int64
 	svc := NewService(Config{
 		DB:     db,
 		Active: active,
@@ -250,6 +317,9 @@ func TestRebuildProjectionDelegates(t *testing.T) {
 			rebuilt = channelID
 			return nil
 		},
+		OnProjectionChanged: func(channelID int64) {
+			notified = channelID
+		},
 	})
 
 	if err := svc.RebuildProjection(0); err != nil {
@@ -257,5 +327,8 @@ func TestRebuildProjectionDelegates(t *testing.T) {
 	}
 	if rebuilt != 55 {
 		t.Fatalf("rebuilt channel = %d, want 55", rebuilt)
+	}
+	if notified != 55 {
+		t.Fatalf("projection notification channel = %d, want 55", notified)
 	}
 }

--- a/backend/sync/sync.go
+++ b/backend/sync/sync.go
@@ -163,42 +163,35 @@ func (e *Engine) Incremental(ctx context.Context, channelID int64) error {
 
 // PrepareHardDeleteProjection synchronizes the channel while holding its
 // per-channel lock. Writable hard deletes use this stronger boundary because
-// local commits can be projected ahead of the contiguous sync watermark. A
-// full replay is performed only when that overlap is detected, keeping the
-// normal path incremental while preserving Telegram message ordering.
+// local commits can be projected ahead of the contiguous sync watermark. The
+// incremental pass fills the missing range first, then rebuilds from the now
+// complete local replay log only when it encounters overlap. This avoids an
+// unnecessary full Telegram history scan for ordinary local writes.
 func (e *Engine) PrepareHardDeleteProjection(ctx context.Context, channelID int64) error {
 	lk := e.lockFor(channelID)
 	lk.Lock()
 	defer lk.Unlock()
-	if _, err := flagReplayAheadOfWatermark(e.db, channelID); err != nil {
-		return err
-	}
+	return e.incrementalLocked(ctx, channelID)
+}
+
+func (e *Engine) incrementalLocked(ctx context.Context, channelID int64) error {
 	replayOverlap, err := e.incrementalLockedWithReplayStatus(ctx, channelID)
-	if err != nil {
+	if err != nil || !replayOverlap {
 		return err
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	replayAhead, err := flagReplayAheadOfWatermark(e.db, channelID)
-	if err != nil {
-		return err
-	}
-	if !replayOverlap && !replayAhead {
-		return nil
-	}
+	// applyHistoryPlan durably marks an overlap before returning. Rebuild while
+	// the caller still owns the channel lock so no successful Incremental call
+	// exposes an out-of-order derived projection or leaves repair to a later run.
 	return projection.RebuildProjection(e.db, channelID)
-}
-
-func (e *Engine) incrementalLocked(ctx context.Context, channelID int64) error {
-	_, err := e.incrementalLockedWithReplayStatus(ctx, channelID)
-	return err
 }
 
 // incrementalLockedWithReplayStatus reports whether a message fetched above
 // the contiguous watermark was already present in replay_log. That can happen
-// when a local writable commit was projected ahead of sync, in which case a
-// replay is required before hard-delete subtree ownership can be trusted.
+// when a local writable commit was projected ahead of sync, in which case the
+// caller must replay the completed log before reporting successful sync.
 func (e *Engine) incrementalLockedWithReplayStatus(ctx context.Context, channelID int64) (bool, error) {
 	// A drive flagged for rebuild cannot be moved forward from its watermark:
 	// the ops below it were never read, and the ones above were applied against
@@ -669,26 +662,6 @@ func readWatermark(db *sql.DB, channelID int64) (int64, error) {
 		return 0, err
 	}
 	return v, nil
-}
-
-func flagReplayAheadOfWatermark(db *sql.DB, channelID int64) (bool, error) {
-	result, err := db.Exec(`
-		UPDATE channels
-		SET needs_projection_rebuild = 1
-		WHERE channel_id = ? AND EXISTS (
-			SELECT 1 FROM replay_log replay
-			WHERE replay.channel_id = channels.channel_id
-			  AND replay.msg_id > channels.last_synced_msg
-		)
-	`, channelID)
-	if err != nil {
-		return false, fmt.Errorf("sync: flag replay ahead of watermark: %w", err)
-	}
-	updated, err := result.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("sync: inspect replay-ahead update: %w", err)
-	}
-	return updated > 0, nil
 }
 
 func markProjectionRebuildRequiredTx(tx *sql.Tx, channelID int64) error {

--- a/backend/sync/sync.go
+++ b/backend/sync/sync.go
@@ -161,39 +161,77 @@ func (e *Engine) Incremental(ctx context.Context, channelID int64) error {
 	return nil
 }
 
+// PrepareHardDeleteProjection synchronizes the channel while holding its
+// per-channel lock. Writable hard deletes use this stronger boundary because
+// local commits can be projected ahead of the contiguous sync watermark. A
+// full replay is performed only when that overlap is detected, keeping the
+// normal path incremental while preserving Telegram message ordering.
+func (e *Engine) PrepareHardDeleteProjection(ctx context.Context, channelID int64) error {
+	lk := e.lockFor(channelID)
+	lk.Lock()
+	defer lk.Unlock()
+	if _, err := flagReplayAheadOfWatermark(e.db, channelID); err != nil {
+		return err
+	}
+	replayOverlap, err := e.incrementalLockedWithReplayStatus(ctx, channelID)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	replayAhead, err := flagReplayAheadOfWatermark(e.db, channelID)
+	if err != nil {
+		return err
+	}
+	if !replayOverlap && !replayAhead {
+		return nil
+	}
+	return projection.RebuildProjection(e.db, channelID)
+}
+
 func (e *Engine) incrementalLocked(ctx context.Context, channelID int64) error {
+	_, err := e.incrementalLockedWithReplayStatus(ctx, channelID)
+	return err
+}
+
+// incrementalLockedWithReplayStatus reports whether a message fetched above
+// the contiguous watermark was already present in replay_log. That can happen
+// when a local writable commit was projected ahead of sync, in which case a
+// replay is required before hard-delete subtree ownership can be trusted.
+func (e *Engine) incrementalLockedWithReplayStatus(ctx context.Context, channelID int64) (bool, error) {
 	// A drive flagged for rebuild cannot be moved forward from its watermark:
 	// the ops below it were never read, and the ones above were applied against
 	// objects that did not exist. It needs the full scan, which owns the repair.
 	channel, err := projection.GetChannel(e.db, channelID)
 	if err != nil {
-		return fmt.Errorf("sync: read channel authority: %w", err)
+		return false, fmt.Errorf("sync: read channel authority: %w", err)
 	}
 	if channel.NeedsProjectionRebuild {
 		slog.Info("sync: rebuild pending, escalating to a full history scan", "channel_id", channelID)
-		return e.authoritativeLocked(ctx, channelID)
+		return false, e.authoritativeLocked(ctx, channelID)
 	}
 
 	peer, err := e.peers.ResolvePeer(ctx, channelID)
 	if err != nil {
-		return fmt.Errorf("sync: resolve peer: %w", err)
+		return false, fmt.Errorf("sync: resolve peer: %w", err)
 	}
 
 	watermark, err := readWatermark(e.db, channelID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	parseOpts, err := parseOptionsForChannel(e.db, channelID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	plan, err := e.planHistory(ctx, channelID, peer, watermark)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(plan.upperBounds) == 0 {
-		return e.adoptRecentCaptionlessMedia(ctx, channelID, peer, parseOpts)
+		return false, e.adoptRecentCaptionlessMedia(ctx, channelID, peer, parseOpts)
 	}
 	return e.applyHistoryPlan(ctx, channelID, peer, watermark, plan, parseOpts)
 }
@@ -455,15 +493,16 @@ func (e *Engine) applyProgress(channelID int64, plan historyPlan, index, message
 	})
 }
 
-func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan, parseOpts ParseOptions) error {
+func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan, parseOpts ParseOptions) (bool, error) {
 	messagesDone := 0
+	replayOverlap := false
 	for i := len(plan.upperBounds) - 1; i >= 0; i-- {
 		if err := ctx.Err(); err != nil {
-			return err
+			return false, err
 		}
 		page, err := e.getHistory(ctx, channelID, peer, minID, plan.upperBounds[i], defaultPageSize)
 		if err != nil {
-			return fmt.Errorf("sync: get history: %w", err)
+			return false, fmt.Errorf("sync: get history: %w", err)
 		}
 		pageWatermark := minID
 		filtered := page[:0]
@@ -482,29 +521,39 @@ func (e *Engine) applyHistoryPlan(ctx context.Context, channelID int64, peer tgc
 
 		tx, err := e.db.Begin()
 		if err != nil {
-			return fmt.Errorf("sync: begin projection: %w", err)
+			return false, fmt.Errorf("sync: begin projection: %w", err)
 		}
+		pageReplayOverlap := false
 		for _, p := range parsed {
-			if _, err := projection.ProjectFromOpTx(tx, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader); err != nil {
+			alreadySeen, err := projection.ProjectFromOpTx(tx, channelID, p.MsgID, p.Op, p.FromID, p.RawHeader)
+			if err != nil {
 				_ = tx.Rollback()
 				slog.Error("sync: applying op failed, page rolled back", "channel_id", channelID, "msg_id", p.MsgID, "op_type", p.Op.Type, "error", err)
-				return fmt.Errorf("sync: project msg=%d: %w", p.MsgID, err)
+				return false, fmt.Errorf("sync: project msg=%d: %w", p.MsgID, err)
 			}
+			pageReplayOverlap = pageReplayOverlap || alreadySeen
+		}
+		if pageReplayOverlap {
+			if err := markProjectionRebuildRequiredTx(tx, channelID); err != nil {
+				_ = tx.Rollback()
+				return false, err
+			}
+			replayOverlap = true
 		}
 		if pageWatermark > minID {
 			if err := writeWatermarkTx(tx, channelID, pageWatermark); err != nil {
 				_ = tx.Rollback()
-				return err
+				return false, err
 			}
 			minID = pageWatermark
 		}
 		if err := tx.Commit(); err != nil {
-			return fmt.Errorf("sync: commit projection: %w", err)
+			return false, fmt.Errorf("sync: commit projection: %w", err)
 		}
 		messagesDone += len(page)
 		e.applyProgress(channelID, plan, i, messagesDone)
 	}
-	return nil
+	return replayOverlap, nil
 }
 
 func (e *Engine) applyInitialHistoryPlan(ctx context.Context, channelID int64, peer tgclient.InputPeer, minID int64, plan historyPlan, parseOpts ParseOptions, rebuild bool) error {
@@ -620,6 +669,43 @@ func readWatermark(db *sql.DB, channelID int64) (int64, error) {
 		return 0, err
 	}
 	return v, nil
+}
+
+func flagReplayAheadOfWatermark(db *sql.DB, channelID int64) (bool, error) {
+	result, err := db.Exec(`
+		UPDATE channels
+		SET needs_projection_rebuild = 1
+		WHERE channel_id = ? AND EXISTS (
+			SELECT 1 FROM replay_log replay
+			WHERE replay.channel_id = channels.channel_id
+			  AND replay.msg_id > channels.last_synced_msg
+		)
+	`, channelID)
+	if err != nil {
+		return false, fmt.Errorf("sync: flag replay ahead of watermark: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("sync: inspect replay-ahead update: %w", err)
+	}
+	return updated > 0, nil
+}
+
+func markProjectionRebuildRequiredTx(tx *sql.Tx, channelID int64) error {
+	result, err := tx.Exec(`
+		UPDATE channels SET needs_projection_rebuild = 1 WHERE channel_id = ?
+	`, channelID)
+	if err != nil {
+		return fmt.Errorf("sync: mark projection rebuild required: %w", err)
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("sync: inspect projection rebuild marker: %w", err)
+	}
+	if updated != 1 {
+		return fmt.Errorf("sync: channel %d not registered", channelID)
+	}
+	return nil
 }
 
 func writeWatermark(db *sql.DB, channelID int64, msgID int64) error {

--- a/backend/sync/sync_test.go
+++ b/backend/sync/sync_test.go
@@ -84,6 +84,109 @@ func TestIncrementalAppliesOpsAscending(t *testing.T) {
 	}
 }
 
+func TestPrepareHardDeleteProjectionRebuildsLocallyAheadStateInMessageOrder(t *testing.T) {
+	db, telegram, engine := newSyncEnv(t)
+	mkdir := projection.Op{Type: projection.OpMkdir, Obj: "d:ordered", Name: "Before"}
+	rename := projection.Op{Type: projection.OpRename, Obj: "d:ordered", Name: "After"}
+
+	// Simulate a local commit projected ahead of the contiguous sync watermark.
+	// The rename is initially a no-op because its earlier mkdir is still unseen.
+	if _, err := projection.ProjectFromOp(db, testChan, 101, rename, 7, projection.Format(rename)); err != nil {
+		t.Fatalf("project ahead rename: %v", err)
+	}
+	telegram.SeedHistory(
+		tgclient.HistoryMessage{MsgID: 100, FromID: 7, Text: projection.Format(mkdir)},
+		tgclient.HistoryMessage{MsgID: 101, FromID: 7, Text: projection.Format(rename)},
+	)
+
+	if err := engine.PrepareHardDeleteProjection(context.Background(), testChan); err != nil {
+		t.Fatalf("PrepareHardDeleteProjection: %v", err)
+	}
+	folder, found, err := projection.FolderByID(db, testChan, "d:ordered")
+	if err != nil || !found || folder.Name != "After" {
+		t.Fatalf("ordered folder = %+v found=%v err=%v", folder, found, err)
+	}
+}
+
+func TestPrepareHardDeleteProjectionReplacesStalePlanAfterOrderedRebuild(t *testing.T) {
+	db, telegram, engine := newSyncEnv(t)
+	root := projection.Op{Type: projection.OpFolderCommit, ProtocolVersion: 1, OpID: "ordered-root", Obj: "d:root", Name: "Root"}
+	outside := projection.Op{Type: projection.OpFolderCommit, ProtocolVersion: 1, OpID: "ordered-outside", Obj: "d:outside", Name: "Outside"}
+	part := projection.Op{Type: projection.OpFilePart, UploadUUID: "ordered-body", PartIndex: 0, FileSize: 1}
+	file := projection.Op{
+		Type: projection.OpFileCommit, ProtocolVersion: 1, OpID: "ordered-file",
+		Parent: "d:root", Name: "move-me.txt", UploadUUID: "ordered-body", PartCount: 1, FileSize: 1,
+	}
+	moveOut := projection.Op{
+		Type: projection.OpRelocate, ProtocolVersion: 1, OpID: "ordered-move-out",
+		Obj: "f:103", Parent: "d:outside", Name: "move-me.txt", ExpectedRevision: 1,
+	}
+	hardDelete := projection.Op{
+		Type: projection.OpHardDeleteTree, ProtocolVersion: 1, OpID: "ordered-hard-delete",
+		Obj: "d:root", ExpectedRevision: 1,
+	}
+
+	// The locally projected relocate is initially rejected because its target
+	// has not been synchronized. The first incremental pass would otherwise
+	// capture a stale hard-delete plan before repairing message order.
+	if _, err := projection.ProjectFromOp(db, testChan, 104, moveOut, 7, projection.Format(moveOut)); err != nil {
+		t.Fatalf("project ahead relocate: %v", err)
+	}
+	telegram.SeedHistory(
+		tgclient.HistoryMessage{MsgID: 100, FromID: 7, Text: projection.Format(root)},
+		tgclient.HistoryMessage{MsgID: 101, FromID: 7, Text: projection.Format(outside)},
+		tgclient.HistoryMessage{MsgID: 102, FromID: 7, Text: projection.Format(part)},
+		tgclient.HistoryMessage{MsgID: 103, FromID: 7, Text: projection.Format(file)},
+		tgclient.HistoryMessage{MsgID: 104, FromID: 7, Text: projection.Format(moveOut)},
+		tgclient.HistoryMessage{MsgID: 105, FromID: 7, Text: projection.Format(hardDelete)},
+	)
+
+	if err := engine.PrepareHardDeleteProjection(context.Background(), testChan); err != nil {
+		t.Fatalf("PrepareHardDeleteProjection: %v", err)
+	}
+	fileRow, found, err := projection.FileByID(db, testChan, 103)
+	if err != nil || !found || fileRow.ParentID != "d:outside" {
+		t.Fatalf("moved file = %+v found=%v err=%v", fileRow, found, err)
+	}
+	ids, total, done, err := projection.HardDeletePlanPage(
+		context.Background(), db, testChan, "ordered-hard-delete", 0, 10,
+	)
+	if err != nil || len(ids) != 0 || total != 0 || !done {
+		t.Fatalf("ordered hard-delete plan=(%v,%d,%t,%v), want empty", ids, total, done, err)
+	}
+}
+
+func TestPrepareHardDeleteProjectionSkipsFullRebuildForContiguousReplay(t *testing.T) {
+	db, telegram, engine := newSyncEnv(t)
+	mkdir := projection.Op{Type: projection.OpMkdir, Obj: "d:ordered", Name: "Before"}
+	rename := projection.Op{Type: projection.OpRename, Obj: "d:ordered", Name: "After"}
+	sendOp(t, telegram, mkdir)
+	if err := engine.Incremental(context.Background(), testChan); err != nil {
+		t.Fatalf("initial incremental: %v", err)
+	}
+
+	// This row is intentionally outside replay_log. It makes an unnecessary
+	// full rebuild observable without coupling production code to a test hook.
+	if _, err := db.Exec(`
+		INSERT INTO folders (channel_id, id, name, parent_id, tombstoned, revision)
+		VALUES (?, 'd:sentinel', 'Sentinel', '', 0, 1)
+	`, testChan); err != nil {
+		t.Fatalf("insert sentinel projection row: %v", err)
+	}
+
+	sendOp(t, telegram, rename)
+	if err := engine.PrepareHardDeleteProjection(context.Background(), testChan); err != nil {
+		t.Fatalf("PrepareHardDeleteProjection: %v", err)
+	}
+	if !projection.FolderExists(db, testChan, "d:sentinel") {
+		t.Fatal("contiguous hard-delete preparation performed an unnecessary full rebuild")
+	}
+	folder, found, err := projection.FolderByID(db, testChan, "d:ordered")
+	if err != nil || !found || folder.Name != "After" {
+		t.Fatalf("ordered folder = %+v found=%v err=%v", folder, found, err)
+	}
+}
+
 func TestIncrementalRetriesReadFloodWait(t *testing.T) {
 	db, tg, eng := newSyncEnv(t)
 	idA := sendOp(t, tg, projection.Op{Type: projection.OpMkdir, Obj: "d:a", Parent: projection.RootParent, Name: "A"})

--- a/backend/sync/sync_test.go
+++ b/backend/sync/sync_test.go
@@ -84,6 +84,38 @@ func TestIncrementalAppliesOpsAscending(t *testing.T) {
 	}
 }
 
+func TestIncrementalRepairsLocallyAheadReplayBeforeReturning(t *testing.T) {
+	db, telegram, engine := newSyncEnv(t)
+	mkdir := projection.Op{Type: projection.OpMkdir, Obj: "d:incremental-ordered", Name: "Before"}
+	rename := projection.Op{Type: projection.OpRename, Obj: "d:incremental-ordered", Name: "After"}
+
+	// Simulate a writable local commit projected before the contiguous history
+	// preceding it. Its first application cannot find the target, so replaying
+	// the completed log in message order is required before Incremental succeeds.
+	if _, err := projection.ProjectFromOp(db, testChan, 101, rename, 7, projection.Format(rename)); err != nil {
+		t.Fatalf("project ahead rename: %v", err)
+	}
+	telegram.SeedHistory(
+		tgclient.HistoryMessage{MsgID: 100, FromID: 7, Text: projection.Format(mkdir)},
+		tgclient.HistoryMessage{MsgID: 101, FromID: 7, Text: projection.Format(rename)},
+	)
+
+	if err := engine.Incremental(context.Background(), testChan); err != nil {
+		t.Fatalf("Incremental: %v", err)
+	}
+	folder, found, err := projection.FolderByID(db, testChan, "d:incremental-ordered")
+	if err != nil || !found || folder.Name != "After" {
+		t.Fatalf("ordered folder after one Incremental = %+v found=%v err=%v", folder, found, err)
+	}
+	channel, err := projection.GetChannel(db, testChan)
+	if err != nil {
+		t.Fatalf("GetChannel: %v", err)
+	}
+	if channel.NeedsProjectionRebuild {
+		t.Fatal("Incremental returned with projection rebuild still pending")
+	}
+}
+
 func TestPrepareHardDeleteProjectionRebuildsLocallyAheadStateInMessageOrder(t *testing.T) {
 	db, telegram, engine := newSyncEnv(t)
 	mkdir := projection.Op{Type: projection.OpMkdir, Obj: "d:ordered", Name: "Before"}
@@ -108,7 +140,39 @@ func TestPrepareHardDeleteProjectionRebuildsLocallyAheadStateInMessageOrder(t *t
 	}
 }
 
-func TestPrepareHardDeleteProjectionReplacesStalePlanAfterOrderedRebuild(t *testing.T) {
+func TestPrepareHardDeleteProjectionRepairsAheadReplayWithoutFullHistoryScan(t *testing.T) {
+	db, telegram, _ := newSyncEnv(t)
+	recorder := &recordingHistoryPager{Fake: telegram}
+	engine := NewEngine(db, recorder, fakePeers{})
+	mkdir := projection.Op{Type: projection.OpMkdir, Obj: "d:recent", Name: "Before"}
+	rename := projection.Op{Type: projection.OpRename, Obj: "d:recent", Name: "After"}
+
+	if _, err := db.Exec(`UPDATE channels SET last_synced_msg=? WHERE channel_id=?`, 99, testChan); err != nil {
+		t.Fatalf("seed watermark: %v", err)
+	}
+	if _, err := projection.ProjectFromOp(db, testChan, 101, rename, 7, projection.Format(rename)); err != nil {
+		t.Fatalf("project ahead rename: %v", err)
+	}
+	telegram.SeedHistory(
+		tgclient.HistoryMessage{MsgID: 100, FromID: 7, Text: projection.Format(mkdir)},
+		tgclient.HistoryMessage{MsgID: 101, FromID: 7, Text: projection.Format(rename)},
+	)
+
+	if err := engine.PrepareHardDeleteProjection(context.Background(), testChan); err != nil {
+		t.Fatalf("PrepareHardDeleteProjection: %v", err)
+	}
+	for _, minID := range recorder.minIDs {
+		if minID == 0 {
+			t.Fatalf("hard-delete preparation performed a full history scan: min_ids=%v", recorder.minIDs)
+		}
+	}
+	folder, found, err := projection.FolderByID(db, testChan, "d:recent")
+	if err != nil || !found || folder.Name != "After" {
+		t.Fatalf("ordered folder = %+v found=%v err=%v", folder, found, err)
+	}
+}
+
+func TestPrepareHardDeleteProjectionRepairsOrderingWithoutForeignPlan(t *testing.T) {
 	db, telegram, engine := newSyncEnv(t)
 	root := projection.Op{Type: projection.OpFolderCommit, ProtocolVersion: 1, OpID: "ordered-root", Obj: "d:root", Name: "Root"}
 	outside := projection.Op{Type: projection.OpFolderCommit, ProtocolVersion: 1, OpID: "ordered-outside", Obj: "d:outside", Name: "Outside"}
@@ -127,8 +191,9 @@ func TestPrepareHardDeleteProjectionReplacesStalePlanAfterOrderedRebuild(t *test
 	}
 
 	// The locally projected relocate is initially rejected because its target
-	// has not been synchronized. The first incremental pass would otherwise
-	// capture a stale hard-delete plan before repairing message order.
+	// has not been synchronized. The ordered repair must still move the file
+	// before applying the hard-delete marker. This installation did not register
+	// the marker intent, so it must not retain an actionable cleanup plan.
 	if _, err := projection.ProjectFromOp(db, testChan, 104, moveOut, 7, projection.Format(moveOut)); err != nil {
 		t.Fatalf("project ahead relocate: %v", err)
 	}
@@ -148,11 +213,18 @@ func TestPrepareHardDeleteProjectionReplacesStalePlanAfterOrderedRebuild(t *test
 	if err != nil || !found || fileRow.ParentID != "d:outside" {
 		t.Fatalf("moved file = %+v found=%v err=%v", fileRow, found, err)
 	}
+	channel, err := projection.GetChannel(db, testChan)
+	if err != nil {
+		t.Fatalf("GetChannel: %v", err)
+	}
+	if channel.NeedsProjectionRebuild {
+		t.Fatal("ordered repair left projection rebuild pending")
+	}
 	ids, total, done, err := projection.HardDeletePlanPage(
 		context.Background(), db, testChan, "ordered-hard-delete", 0, 10,
 	)
-	if err != nil || len(ids) != 0 || total != 0 || !done {
-		t.Fatalf("ordered hard-delete plan=(%v,%d,%t,%v), want empty", ids, total, done, err)
+	if !errors.Is(err, projection.ErrHardDeletePlanNotFound) || len(ids) != 0 || total != 0 || done {
+		t.Fatalf("foreign hard-delete plan=(%v,%d,%t,%v), want no local plan", ids, total, done, err)
 	}
 }
 
@@ -220,6 +292,22 @@ func TestIncrementalRetriesReadFloodWait(t *testing.T) {
 	if wm != idA {
 		t.Fatalf("watermark = %d, want %d", wm, idA)
 	}
+}
+
+type recordingHistoryPager struct {
+	*tgclient.Fake
+	minIDs []int64
+}
+
+func (pager *recordingHistoryPager) GetHistory(
+	ctx context.Context,
+	peer tgclient.InputPeer,
+	minID int64,
+	offsetID int64,
+	limit int,
+) ([]tgclient.HistoryMessage, error) {
+	pager.minIDs = append(pager.minIDs, minID)
+	return pager.Fake.GetHistory(ctx, peer, minID, offsetID, limit)
 }
 
 func TestIncrementalFailsAfterMaxFloodRetries(t *testing.T) {

--- a/backend/tgclient/fake_test.go
+++ b/backend/tgclient/fake_test.go
@@ -145,6 +145,12 @@ func TestFakeDeleteMessagesRemovesFromHistory(t *testing.T) {
 	if len(batches) != 1 || len(batches[0]) != 1 || batches[0][0] != id {
 		t.Fatalf("delete batches = %v", batches)
 	}
+	if err := f.DeleteMessages(ctx, testPeer, []int64{id, id + 999}); err != nil {
+		t.Fatalf("idempotent delete of missing messages: %v", err)
+	}
+	if batches = f.DeletedBatches(); len(batches) != 2 {
+		t.Fatalf("delete batches after idempotent retry = %v", batches)
+	}
 }
 
 func TestFakeSendFileDrainsReader(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a distinct durable hard-delete protocol for mounted WebDAV deletes while preserving existing soft-delete behavior elsewhere
- retain the Telegram hard-delete control marker, but physically delete every referenced file body, historical revision, and multipart part
- make cleanup crash-safe with a normalized journal, bounded pagination/batches, per-batch checkpoints, idempotent recovery, and fail-closed HTTP behavior

## Design and safety

- captures the exact subtree and immutable body allowlist in the same projection transaction that applies the marker
- rejects incomplete multipart data, shared body references, known non-body control references, out-of-range Telegram IDs, stale revisions, and non-personal-drive hard-delete controls
- revalidates every journal batch against the operation-scoped projection allowlist immediately before calling Telegram
- preserves completed deletion markers across replay while rebuilding incomplete plans from Telegram message order
- durably records replay overlap before advancing the sync watermark, preventing an out-of-order move from producing a stale destructive plan
- returns success only after the marker, cache invalidation, all body deletions, projection finalization, and journal compaction complete
- keeps work bounded: 500-ID plan pages, 100-ID Telegram batches, compact completed metadata, and full projection replay only when local commits are detected ahead of sync

## Cross-platform behavior

- keeps the single WebDAV `DELETE` entry point used by Finder/WebDAVFS, Windows MiniRedir, and Linux GVfs
- verifies Windows file `Depth: 0`, macOS `Depth: infinity`, Linux default depth, delayed `204`, and retryable `503` behavior
- extends native GitHub Actions test/vet coverage for mountadapter, mountwrite, and tgclient across Linux, Windows, and macOS

## Verification

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race -count=1 ./backend/projection ./backend/mountwrite ./backend/mountadapter ./backend/sync ./backend/tgclient ./backend/mountdav ./backend/mountcontroller`
- focused package coverage: mountwrite 84.4%, mountadapter 81.0%, sync 82.3%, mountdav 85.7%; projection remains at its existing package-wide baseline and has direct hard-delete/replay regression coverage
- independent correctness and security re-reviews: no remaining CRITICAL or HIGH findings

## Risk

Hard delete is irreversible and Telegram control-message publication cannot be atomic with body deletion. The retained marker plus journaled two-phase cleanup ensures a crash cannot resurrect a deleted item or silently convert the operation back to soft delete.
